### PR TITLE
Add support of cross-compilation for linux-based targets.

### DIFF
--- a/build/configs/toolchain_linux_i686.cmake
+++ b/build/configs/toolchain_linux_i686.cmake
@@ -15,5 +15,7 @@
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR x86)
 
-set(CMAKE_C_COMPILER i686-linux-gnu-gcc)
-set(CMAKE_CXX_COMPILER i686-linux-gnu-g++)
+find_program(CMAKE_C_COMPILER NAMES i686-linux-gnu-gcc i686-unknown-linux-gnu-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES i686-linux-gnu-g++ i686-unknown-linux-gnu-g++)
+# FIXME: This could break cross compilation, when the strip is not for the target architecture
+find_program(CMAKE_STRIP NAMES i686-linux-gnu-strip i686-unknown-linux-gnu-strip strip)

--- a/jerry-core/parser/js/opcodes-dumper.cpp
+++ b/jerry-core/parser/js/opcodes-dumper.cpp
@@ -1171,7 +1171,10 @@ dump_call_additional_info (opcode_call_flags_t flags, /**< call flags */
 
   const opcode_t opcode = getop_meta (OPCODE_META_TYPE_CALL_SITE_INFO,
                                       flags,
-                                      (flags & OPCODE_CALL_FLAGS_HAVE_THIS_ARG) ? this_arg.data.uid : INVALID_VALUE);
+                                      (idx_t) (flags & OPCODE_CALL_FLAGS_HAVE_THIS_ARG
+                                               ? this_arg.data.uid
+                                               : INVALID_VALUE));
+
   serializer_dump_op_meta (create_op_meta_000 (opcode));
 } /* dump_call_additional_info */
 

--- a/tools/precommit-full-testing.sh
+++ b/tools/precommit-full-testing.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2015 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OUT_DIR="$1"
+shift
+
+TARGETS="$1"
+shift
+
+RUN_IDS=""
+
+for TARGET in ${TARGETS}
+do
+ ENGINE=${OUT_DIR}/${TARGET}/jerry
+ LOGS_PATH_FULL=${OUT_DIR}/${TARGET}/check
+
+ # Full testing
+ INDEX=0
+ for TESTS_PATH in "./tests/jerry" "./tests/jerry-test-suite/precommit_test_list"
+ do
+   ./tools/runners/run-precommit-check-for-target.sh "${ENGINE}" "${LOGS_PATH_FULL}"/"${INDEX}" "${TESTS_PATH}" &
+   RUN_IDS="${RUN_IDS} $!";
+   INDEX=$((INDEX + 1))
+ done
+done
+
+RESULT_OK=1
+for RUN_ID in ${RUN_IDS}
+do
+  wait "${RUN_ID}" || RESULT_OK=0
+done;
+[ ${RESULT_OK} -eq 1 ] || exit 1
+
+echo -e "Full testing completed successfully\n\n================\n\n"

--- a/tools/precommit.sh
+++ b/tools/precommit.sh
@@ -57,38 +57,4 @@ echo -e "All targets were built successfully. Starting unit tests' run.\n"
 $MAKE unittests_run || exit 1
 echo -e "\nUnit tests completed successfully. Starting full testing.\n"
 
-RUN_IDS=""
-
-for TARGET in $TARGETS
-do
- ENGINE=$OUT_DIR/$TARGET/jerry
- LOGS_PATH_PARSE_ONLY=$OUT_DIR/$TARGET/check_parse_only
- LOGS_PATH_FULL=$OUT_DIR/$TARGET/check
-
- # Parse-only testing
- INDEX=0
- for TESTS_PATH in "./tests/benchmarks/jerry"
- do
-   ./tools/runners/run-precommit-check-for-target.sh $ENGINE $LOGS_PATH_PARSE_ONLY/$INDEX $TESTS_PATH --parse-only &
-   RUN_IDS="$RUN_IDS $!";
-   INDEX=$((INDEX + 1))
- done
-
- # Full testing
- INDEX=0
- for TESTS_PATH in "./tests/jerry" "./tests/jerry-test-suite/precommit_test_list"
- do
-   ./tools/runners/run-precommit-check-for-target.sh $ENGINE $LOGS_PATH_FULL/$INDEX $TESTS_PATH &
-   RUN_IDS="$RUN_IDS $!";
-   INDEX=$((INDEX + 1))
- done
-done
-
-RESULT_OK=1
-for RUN_ID in $RUN_IDS
-do
-  wait $RUN_ID || RESULT_OK=0
-done;
-[ $RESULT_OK -eq 1 ] || exit 1
-
-echo -e "Full testing completed successfully\n\n================\n\n"
+./tools/precommit-full-testing.sh "${OUT_DIR}" "${TARGETS}" || exit 1

--- a/tools/runners/run-tests-remote.sh
+++ b/tools/runners/run-tests-remote.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Copyright 2015 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TARGET="$1" #debug.linux release.linux
+TARGET_IP="$2" # ip address of target board
+TARGET_USER="$3" # login
+TARGET_PASS="$4" # password
+
+if [ $# -lt 4 ]
+then
+  echo "This script runs ./jerry/* and ./jerry-test-suite/* tests on the remote board."
+  echo ""
+  echo "Usage:"
+  echo "  1st parameter: target to be tested: {debug.linux, release.linux}"
+  echo "  2nd parameter: ip address of target board: {110.110.110.110}"
+  echo "  3rd parameter: ssh login to target board: {login}"
+  echo "  4th parameter: ssh password to target board: {password}"
+  echo ""
+  echo "Example:"
+  echo "  ./tools/runners/run-tests-remote.sh debug.linux 110.110.110.110 login password"
+  exit 1
+fi
+
+BASE_DIR=$(dirname "$(readlink -f "$0")" )
+
+OUT_DIR="${BASE_DIR}"/../.././build/bin
+LOGS_PATH_FULL="${OUT_DIR}"/"${TARGET}"/check
+
+export SSHPASS="${TARGET_PASS}"
+
+rm -rf "${LOGS_PATH_FULL}"
+
+mkdir -p "${LOGS_PATH_FULL}"
+
+REMOTE_TMP_DIR=$(sshpass -e ssh "${TARGET_USER}"@"${TARGET_IP}" 'mktemp -d')
+REMOTE_TMP_TAR=$(sshpass -e ssh "${TARGET_USER}"@"${TARGET_IP}" 'mktemp')
+LOCAL_TMP_TAR=$(mktemp)
+
+tar -zcf "${LOCAL_TMP_TAR}" \
+  "${BASE_DIR}"/../.././build/bin/"${TARGET}" \
+  "${BASE_DIR}"/../.././tests/benchmarks \
+  "${BASE_DIR}"/../.././tests/jerry \
+  "${BASE_DIR}"/../.././tests/jerry-test-suite \
+  "${BASE_DIR}"/../.././tools/runners \
+  "${BASE_DIR}"/../.././tools/precommit-full-testing.sh > /dev/null 2>&1
+
+sshpass -e scp "${LOCAL_TMP_TAR}" "${TARGET_USER}"@"${TARGET_IP}":"${REMOTE_TMP_TAR}"
+
+sshpass -e ssh "${TARGET_USER}"@"${TARGET_IP}" \
+  "tar -zxf \"${REMOTE_TMP_TAR}\" -C \"${REMOTE_TMP_DIR}\"; rm \"${REMOTE_TMP_TAR}\";\
+  cd \"${REMOTE_TMP_DIR}\"; \
+  ./tools/precommit-full-testing.sh ./build/bin \"$TARGET\" > ./build/bin/\"${TARGET}\"/check/run.log 2>&1; \
+  echo \$? > ./build/bin/\"${TARGET}\"/check/IS_TEST_OK"
+
+sshpass -e scp -r "${TARGET_USER}"@"${TARGET_IP}":"${REMOTE_TMP_DIR}"/build/bin/"${TARGET}"/check/* "${LOGS_PATH_FULL}"
+sshpass -e ssh "${TARGET_USER}"@"${TARGET_IP}" "rm -rf \"${REMOTE_TMP_DIR}\""
+
+STATUS=$(cat "${LOGS_PATH_FULL}"/IS_TEST_OK)
+
+if [ "${STATUS}" == 0 ] ; then
+  echo "${TARGET} testing passed."
+  exit 0
+else
+  echo "${TARGET} testing failed."
+  echo "See logs in ${LOGS_PATH_FULL} directory for details."
+  exit 1
+fi

--- a/tools/runners/run-unittests-remote.sh
+++ b/tools/runners/run-unittests-remote.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright 2015 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TARGET_IP="$1"
+TARGET_USER="$2"
+TARGET_PASS="$3"
+
+if [ $# -lt 3 ]
+then
+  echo "This script runs unittests on the remote board."
+  echo ""
+  echo "Usage:"
+  echo "  1st parameter: ip address of target board: {110.110.110.110}"
+  echo "  2nd parameter: ssh login to target board: {login}"
+  echo "  3rd parameter: ssh password to target board: {password}"
+  echo ""
+  echo "Example:"
+  echo "  ./tools/runners/run-unittests-remote.sh 110.110.110.110 login password"
+  exit 1
+fi
+
+BASE_DIR=$(dirname "$(readlink -f "$0")" )
+
+OUT_DIR="${BASE_DIR}"/../.././build/bin
+
+rm -rf "${OUT_DIR}"/unittests/check
+
+mkdir -p "${OUT_DIR}"/unittests/check
+
+export SSHPASS="${TARGET_PASS}"
+REMOTE_TMP_DIR=$(sshpass -e ssh "${TARGET_USER}"@"${TARGET_IP}" 'mktemp -d')
+
+sshpass -e scp "${BASE_DIR}"/../../tools/runners/run-unittests.sh "${TARGET_USER}"@"${TARGET_IP}":"${REMOTE_TMP_DIR}"
+sshpass -e scp -r "${OUT_DIR}"/unittests/* "${TARGET_USER}"@"${TARGET_IP}":"${REMOTE_TMP_DIR}"
+
+sshpass -e ssh "${TARGET_USER}"@"${TARGET_IP}" "mkdir -p \"${REMOTE_TMP_DIR}\"/check; \
+                                                \"${REMOTE_TMP_DIR}\"/run-unittests.sh \"${REMOTE_TMP_DIR}\"; \
+                                                echo \$? > \"${REMOTE_TMP_DIR}\"/check/IS_REMOTE_TEST_OK"
+
+sshpass -e scp -r "${TARGET_USER}"@$"{TARGET_IP}":"${REMOTE_TMP_DIR}"/check "${OUT_DIR}"/unittests
+
+sshpass -e ssh "${TARGET_USER}"@"${TARGET_IP}" "rm -rf \"${REMOTE_TMP_DIR}\""
+
+STATUS=$(cat "${OUT_DIR}"/unittests/check/IS_REMOTE_TEST_OK)
+
+if [ "${STATUS}" == 0 ] ; then
+    echo "Unit tests run passed."
+    exit 0
+else
+    echo "Unit tests run failed. See ${OUT_DIR}/unittests/unit_tests_run.log for details."
+    exit 1
+fi


### PR DESCRIPTION
Usage:
- Cross compile:
  make debug.linux TOOLCHAIN=./build/configs/toolchain_linux_armv7l-el.cmake
- Build unittests
  make unittests TOOLCHAIN=./build/configs/toolchain_linux_armv7l-el.cmake
- Run unittests on target board
  ./tools/runners/run-unittests-remote.sh <ip> <login> <pass>
- Run JavaScript test on target board
  ./tools/runners/run-tests-remote.sh debug.linux <ip> <login> <pass>

JerryScript-DCO-1.0-Signed-off-by: Evgeny Gavrin e.gavrin@samsung.com