### PR TITLE
Fix failing prerequisites script.

### DIFF
--- a/tools/prerequisites.sh
+++ b/tools/prerequisites.sh
@@ -246,7 +246,7 @@ setup_from_zip "stm32f4" \
 
 setup_nuttx_headers "nuttx" \
                      "./third-party/nuttx" \
-                     "http://git.code.sf.net/p/nuttx/git" \
+                     "https://bitbucket.org/patacongo/nuttx.git" \
                      "36a655eddec29754cc93631b6083fe6409817861"
 
 setup_cppcheck "cppcheck-1.66" \


### PR DESCRIPTION
Prerequisites script fails due to unavailability of http://git.code.sf.net/p/nuttx/git

JerryScript-DCO-1.0-Signed-off-by: Evgeny Gavrin e.gavrin@samsung.com