### PR TITLE
Add syntax check for return from global scope/eval.

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -2730,6 +2730,11 @@ parse_statement (jsp_label_t *outermost_stmt_label_p) /**< outermost (first) lab
   }
   if (is_keyword (KW_RETURN))
   {
+    if (!inside_function)
+    {
+      EMIT_ERROR ("Return is illegal");
+    }
+
     skip_token ();
     if (!token_is (TOK_SEMICOLON) && !token_is (TOK_NEWLINE))
     {

--- a/tests/jerry/regression-test-issue-129.js
+++ b/tests/jerry/regression-test-issue-129.js
@@ -1,0 +1,23 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+    eval("do { \
+        return null; \
+        } while (false);");
+    assert (false);
+} catch (e) {
+    assert (e instanceof SyntaxError);
+}


### PR DESCRIPTION
Related issue: #129

JerryScript-DCO-1.0-Signed-off-by: Evgeny Gavrin e.gavrin@samsung.com