### PR TITLE
Fix element indexing for Object.keys/Object.getOwnPropertyNames

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.cpp
@@ -203,7 +203,7 @@ ecma_builtin_helper_object_get_properties (ecma_object_t *obj_p, /** < object */
 
   for (ecma_property_t *property_p = ecma_get_property_list (obj_p);
        property_p != NULL;
-       property_p = ECMA_GET_POINTER (ecma_property_t, property_p->next_property_p), index++)
+       property_p = ECMA_GET_POINTER (ecma_property_t, property_p->next_property_p))
   {
     ecma_string_t *property_name_p;
 
@@ -255,6 +255,8 @@ ecma_builtin_helper_object_get_properties (ecma_object_t *obj_p, /** < object */
 
     ecma_free_completion_value (completion);
     ecma_deref_ecma_string (index_string_p);
+
+    index++;
   }
 
   return new_array;

--- a/tests/jerry/object-keys.js
+++ b/tests/jerry/object-keys.js
@@ -69,3 +69,31 @@ try {
 } catch (e) {
   assert (e instanceof TypeError);
 }
+
+var o = {};
+
+Object.defineProperty(o, 'a', {
+  value: "OK",
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(o, 'b', {
+  value: "NOT_OK",
+  writable: true,
+  enumerable: false,
+  configurable: true
+});
+
+Object.defineProperty(o, 'c', {
+  value: "OK",
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
+
+props = Object.keys(o);
+assert(props.length === 2);
+assert(o[props[0]] === "OK");
+assert(o[props[1]] === "OK");


### PR DESCRIPTION
Previously the index was incremented even if an internal property
or a non enumerable property was found.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com