### PR TITLE
Set global object's prototype

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtins.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.inc.h
@@ -301,7 +301,7 @@ BUILTIN (ECMA_BUILTIN_ID_COMPACT_PROFILE_ERROR,
 /* The Global object (15.1) */
 BUILTIN (ECMA_BUILTIN_ID_GLOBAL,
          ECMA_OBJECT_TYPE_GENERAL,
-         ECMA_BUILTIN_ID__COUNT /* no prototype */,
+         ECMA_BUILTIN_ID_OBJECT_PROTOTYPE, /* Implementation-dependent */
          true,
          true,
          global)

--- a/tests/jerry/global.js
+++ b/tests/jerry/global.js
@@ -13,13 +13,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-try
-{
-  print({toString: function() { throw new TypeError("foo"); }}, []);
-  assert (false);
-}
-catch (e)
-{
-  assert (e instanceof TypeError);
-  assert (e.message === "foo");
-}
+
+assert (this.hasOwnProperty !== undefined);


### PR DESCRIPTION
The global object should have the same prototype
as a simple object.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com