### PR TITLE
Assertion fix for missing class names.

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.cpp
+++ b/jerry-core/ecma/operations/ecma-objects.cpp
@@ -607,6 +607,20 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
             break;
           }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_ERROR_BUILTINS */
+#ifndef CONFIG_ECMA_COMPACT_PROFILE_DISABLE_DATE_BUILTIN
+          case ECMA_BUILTIN_ID_DATE:
+          {
+            class_name = LIT_MAGIC_STRING_DATE_UL;
+            break;
+          }
+#endif /* CONFIG_ECMA_COMPACT_PROFILE_DISABLE_DATE_BUILTIN */
+#ifndef CONFIG_ECMA_COMPACT_PROFILE_DISABLE_REGEXP_BUILTIN
+          case ECMA_BUILTIN_ID_REGEXP:
+          {
+            class_name = LIT_MAGIC_STRING_REGEXP_UL;
+            break;
+          }
+#endif /* CONFIG_ECMA_COMPACT_PROFILE_DISABLE_REGEXP_BUILTIN */
           default:
           {
             JERRY_ASSERT (builtin_id == ECMA_BUILTIN_ID_TYPE_ERROR_THROWER);
@@ -681,6 +695,12 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
             return LIT_MAGIC_STRING_ERROR_UL;
           }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_ERROR_BUILTINS */
+#ifndef CONFIG_ECMA_COMPACT_PROFILE_DISABLE_DATE_BUILTIN
+          case ECMA_BUILTIN_ID_DATE_PROTOTYPE:
+          {
+            return LIT_MAGIC_STRING_DATE_UL;
+          }
+#endif /* CONFIG_ECMA_COMPACT_PROFILE_DISABLE_DATE_BUILTIN */
 #ifndef CONFIG_ECMA_COMPACT_PROFILE_DISABLE_REGEXP_BUILTIN
           case ECMA_BUILTIN_ID_REGEXP_PROTOTYPE:
           {

--- a/tests/jerry/regression-test-issue-285.js
+++ b/tests/jerry/regression-test-issue-285.js
@@ -1,0 +1,17 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+NaN == RegExp;
+NaN == Date;


### PR DESCRIPTION
Assertion 'builtin_id == ECMA_BUILTIN_ID_TYPE_ERROR_THROWER' failed in ecma_object_get_class_name.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com