### PR TITLE
Add length property to Array constructor

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array.inc.h
@@ -46,6 +46,16 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_PROPERTY_NOT_ENUMERABLE,
               ECMA_PROPERTY_NOT_CONFIGURABLE)
 
+/* Number properties:
+ *  (property name, object pointer getter) */
+
+// 15.4.3
+NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
+              1,
+              ECMA_PROPERTY_NOT_WRITABLE,
+              ECMA_PROPERTY_NOT_ENUMERABLE,
+              ECMA_PROPERTY_NOT_CONFIGURABLE)
+
 /* Routine properties:
  *  (property name, C routine name, arguments number or NON_FIXED, value of the routine's length property) */
 ROUTINE (LIT_MAGIC_STRING_IS_ARRAY_UL, ecma_builtin_array_object_is_array, 1, 1)


### PR DESCRIPTION
The Array constructor should have a length property with value `1`.
See: http://www.ecma-international.org/ecma-262/5.1/index.html#sec-15.4.3
JerryScript-DCO-1.0-Signed-off-by: Dániel Bátyai dbatyai.u-szeged@partner.samsung.com