### PR TITLE
Array.prototype.sort() should sort in place.

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-string.cpp
+++ b/jerry-core/ecma/base/ecma-helpers-string.cpp
@@ -993,6 +993,39 @@ ecma_string_to_number (const ecma_string_t *str_p) /**< ecma-string */
 } /* ecma_string_to_number */
 
 /**
+ * Check if string is array index.
+ *
+ * @return true - if string is valid array index
+ *         false - otherwise
+ */
+bool
+ecma_string_get_array_index (const ecma_string_t *str_p, /**< ecma-string */
+                             uint32_t *out_index_p) /**< out: index */
+{
+  bool is_array_index = true;
+  if (str_p->container == ECMA_STRING_CONTAINER_UINT32_IN_DESC)
+  {
+    *out_index_p = str_p->u.uint32_number;
+  }
+  else
+  {
+    ecma_number_t num = ecma_string_to_number (str_p);
+    *out_index_p = ecma_number_to_uint32 (num);
+
+    ecma_string_t *to_uint32_to_string_p = ecma_new_ecma_string_from_uint32 (*out_index_p);
+
+    is_array_index = ecma_compare_ecma_strings (str_p,
+                                                to_uint32_to_string_p);
+
+    ecma_deref_ecma_string (to_uint32_to_string_p);
+  }
+
+  is_array_index = is_array_index && (*out_index_p != ECMA_MAX_VALUE_OF_VALID_ARRAY_INDEX);
+
+  return is_array_index;
+} /* ecma_string_is_array_index */
+
+/**
  * Convert ecma-string's contents to a utf-8 string and put it to the buffer.
  *
  * @return number of bytes, actually copied to the buffer - if string's content was copied successfully;

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -125,6 +125,7 @@ extern ecma_string_t* ecma_copy_or_ref_ecma_string (ecma_string_t *string_desc_p
 extern void ecma_deref_ecma_string (ecma_string_t *string_p);
 extern void ecma_check_that_ecma_string_need_not_be_freed (const ecma_string_t *string_p);
 extern ecma_number_t ecma_string_to_number (const ecma_string_t *str_p);
+extern bool ecma_string_get_array_index (const ecma_string_t *str_p, uint32_t *index);
 extern ssize_t ecma_string_to_utf8_string (const ecma_string_t *string_desc_p,
                                            lit_utf8_byte_t *buffer_p,
                                            ssize_t buffer_size);

--- a/jerry-core/ecma/operations/ecma-array-object.cpp
+++ b/jerry-core/ecma/operations/ecma-array-object.cpp
@@ -386,29 +386,8 @@ ecma_op_array_object_define_own_property (ecma_object_t *obj_p, /**< the array o
   {
     // 4.a.
     uint32_t index;
-    bool is_index;
 
-    if (property_name_p->container == ECMA_STRING_CONTAINER_UINT32_IN_DESC)
-    {
-      index = property_name_p->u.uint32_number;
-      is_index = true;
-    }
-    else
-    {
-      ecma_number_t number = ecma_string_to_number (property_name_p);
-      index = ecma_number_to_uint32 (number);
-
-      ecma_string_t *to_uint32_to_string_p = ecma_new_ecma_string_from_uint32 (index);
-
-      is_index = ecma_compare_ecma_strings (property_name_p,
-                                            to_uint32_to_string_p);
-
-      ecma_deref_ecma_string (to_uint32_to_string_p);
-    }
-
-    is_index = is_index && (index != ECMA_MAX_VALUE_OF_VALID_ARRAY_INDEX);
-
-    if (!is_index)
+    if (!ecma_string_get_array_index (property_name_p, &index))
     {
       // 5.
       return ecma_op_general_object_define_own_property (obj_p,

--- a/tests/jerry/array-prototype-sort.js
+++ b/tests/jerry/array-prototype-sort.js
@@ -14,22 +14,22 @@
 // limitations under the License.
 
 var array = ["Peach", "Apple", "Orange", "Grape", "Cherry", "Apricot", "Grapefruit"];
-var sorted = array.sort();
+array.sort();
 
-assert(sorted[0] === "Apple");
-assert(sorted[1] === "Apricot");
-assert(sorted[2] === "Cherry");
-assert(sorted[3] === "Grape");
-assert(sorted[4] === "Grapefruit");
-assert(sorted[5] === "Orange");
-assert(sorted[6] === "Peach");
+assert(array[0] === "Apple");
+assert(array[1] === "Apricot");
+assert(array[2] === "Cherry");
+assert(array[3] === "Grape");
+assert(array[4] === "Grapefruit");
+assert(array[5] === "Orange");
+assert(array[6] === "Peach");
 
 var array = [6, 4, 5, 1, 2, 9, 7, 3, 0, 8];
 
 // Default comparison
-var sorted = array.sort();
+array.sort();
 for (i = 0; i < array.length; i++) {
-	assert(sorted[i] === i);
+	assert(array[i] === i);
 }
 
 // Using custom comparison function
@@ -43,9 +43,21 @@ function f(arg1, arg2) {
 	}
 }
 
-var sorted = array.sort(f);
+array.sort(f);
 for (i = 0; i < array.length; i++) {
-	assert(sorted[sorted.length - i - 1] === i);
+	assert(array[array.length - i - 1] === i);
+}
+
+// Sorting sparse array
+var array = [1,,2,,3,,4,undefined,5];
+var expected = [1,2,3,4,5,undefined,,,,];
+
+array.sort();
+
+assert(array.length === expected.length);
+for (i = 0; i < array.length; i++) {
+	assert(expected.hasOwnProperty (i) === array.hasOwnProperty (i));
+	assert(array[i] === expected[i]);
 }
 
 // Checking behavior when provided comparefn is not callable


### PR DESCRIPTION
Array.prototype.sort() should sort in place instead of creating a new Array with the sorted elements.
JerryScript-DCO-1.0-Signed-off-by: Dániel Bátyai dbatyai.u-szeged@partner.samsung.com