### PR TITLE
Fix use strict detection

### DIFF
--- a/jerry-core/parser/js/lexer.cpp
+++ b/jerry-core/parser/js/lexer.cpp
@@ -1762,6 +1762,42 @@ lexer_are_tokens_with_same_identifier (token id1, /**< identifier token (TOK_NAM
 } /* lexer_are_tokens_with_same_identifier */
 
 /**
+ * Checks that TOK_STRING doesn't contain EscapeSequence or LineContinuation
+ *
+ * @return true, if token's string in source buffer doesn't contain backslash
+ *         false, otherwise
+ */
+bool
+lexer_is_no_escape_sequences_in_token_string (token tok) /**< token of type TOK_STRING */
+{
+  JERRY_ASSERT (tok.type == TOK_STRING);
+
+  lit_utf8_iterator_t iter = src_iter;
+  lit_utf8_iterator_seek (&iter, tok.loc);
+
+  JERRY_ASSERT (!lit_utf8_iterator_is_eos (&iter));
+  ecma_char_t c = lit_utf8_iterator_read_next (&iter);
+  JERRY_ASSERT (c == LIT_CHAR_SINGLE_QUOTE
+                || c == LIT_CHAR_DOUBLE_QUOTE);
+
+  const ecma_char_t end_char = c;
+
+  do
+  {
+    JERRY_ASSERT (!lit_utf8_iterator_is_eos (&iter));
+    c = lit_utf8_iterator_read_next (&iter);
+
+    if (c == LIT_CHAR_BACKSLASH)
+    {
+      return false;
+    }
+  }
+  while (c != end_char);
+
+  return true;
+} /* lexer_is_no_escape_sequences_in_token_string */
+
+/**
  * Initialize lexer to start parsing of a new source
  */
 void

--- a/jerry-core/parser/js/lexer.h
+++ b/jerry-core/parser/js/lexer.h
@@ -187,4 +187,6 @@ void lexer_set_strict_mode (bool);
 
 extern bool lexer_are_tokens_with_same_identifier (token id1, token id2);
 
+extern bool lexer_is_no_escape_sequences_in_token_string (token);
+
 #endif

--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -2886,7 +2886,8 @@ preparse_scope (bool is_global)
    */
   while (token_is (TOK_STRING))
   {
-    if (lit_literal_equal_type_cstr (lit_get_literal_by_cp (token_data_as_lit_cp ()), "use strict"))
+    if (lit_literal_equal_type_cstr (lit_get_literal_by_cp (token_data_as_lit_cp ()), "use strict")
+        && lexer_is_no_escape_sequences_in_token_string (tok))
     {
       scopes_tree_set_strict_mode (STACK_TOP (scopes), true);
       is_use_strict = true;

--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -2881,11 +2881,24 @@ preparse_scope (bool is_global)
   bool is_ref_eval_identifier = false;
   bool is_use_strict = false;
 
-  if (token_is (TOK_STRING) && lit_literal_equal_type_cstr (lit_get_literal_by_cp (token_data_as_lit_cp ()),
-                                                            "use strict"))
+  /*
+   * Check Directive Prologue for Use Strict directive (see ECMA-262 5.1 section 14.1)
+   */
+  while (token_is (TOK_STRING))
   {
-    scopes_tree_set_strict_mode (STACK_TOP (scopes), true);
-    is_use_strict = true;
+    if (lit_literal_equal_type_cstr (lit_get_literal_by_cp (token_data_as_lit_cp ()), "use strict"))
+    {
+      scopes_tree_set_strict_mode (STACK_TOP (scopes), true);
+      is_use_strict = true;
+      break;
+    }
+
+    skip_newlines ();
+
+    if (token_is (TOK_SEMICOLON))
+    {
+      skip_newlines ();
+    }
   }
 
   lexer_set_strict_mode (scopes_tree_strict_mode (STACK_TOP (scopes)));


### PR DESCRIPTION
The patch adds the following features:
- Recognize Use Strict directive in the middle of directive prologue.
- Do not recognize Use Strict if it contains escape sequences
(see 14.1 Directive Prologues and the Use Strict Directive)

Fixes the following tests form Test262:
  ch14/14.1/14.1-14-s.js
  ch14/14.1/14.1-4-s.js
  ch14/14.1/14.1-5-s.js
  ch14/14.1/14.1-8-s.js
