### PR TITLE
Fix assertion in RegExp bytecode realloc.

### DIFF
--- a/jerry-core/parser/regexp/re-compiler.cpp
+++ b/jerry-core/parser/regexp/re-compiler.cpp
@@ -48,7 +48,11 @@ realloc_regexp_bytecode_block (re_bytecode_ctx_t *bc_ctx_p) /**< RegExp bytecode
 {
   JERRY_ASSERT (bc_ctx_p->block_end_p - bc_ctx_p->block_start_p >= 0);
   size_t old_size = static_cast<size_t> (bc_ctx_p->block_end_p - bc_ctx_p->block_start_p);
-  JERRY_ASSERT (!bc_ctx_p->current_p && !bc_ctx_p->block_end_p && !bc_ctx_p->block_start_p);
+
+  /* If one of the members of RegExp bytecode context is NULL, then all member should be NULL
+   * (it means first allocation), otherwise all of the members should be a non NULL pointer. */
+  JERRY_ASSERT ((!bc_ctx_p->current_p && !bc_ctx_p->block_end_p && !bc_ctx_p->block_start_p)
+                || (bc_ctx_p->current_p && bc_ctx_p->block_end_p && bc_ctx_p->block_start_p));
 
   size_t new_block_size = old_size + REGEXP_BYTECODE_BLOCK_SIZE;
   JERRY_ASSERT (bc_ctx_p->current_p - bc_ctx_p->block_start_p >= 0);

--- a/tests/jerry/regression-test-issue-245.js
+++ b/tests/jerry/regression-test-issue-245.js
@@ -1,0 +1,25 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try
+{
+  v_0 = /N(?![^6](?:.)|(?!C[^k-o]*|p){0,}|H)|\\xDF\\db{0,}|i\\0?)/;
+  assert (false);
+}
+catch (e)
+{
+  assert (e instanceof SyntaxError);
+  assert (e.message === "Unexpected end of paren.");
+}


### PR DESCRIPTION
Assertion '!bc_ctx_p->current_p && !bc_ctx_p->block_end_p && !bc_ctx_p->block_start_p' failed in realloc_regexp_bytecode_block

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com