### PR TITLE
Fix parser issues for ch07 dev

### DIFF
--- a/jerry-core/parser/js/lexer.cpp
+++ b/jerry-core/parser/js/lexer.cpp
@@ -1566,6 +1566,8 @@ lexer_dump_line (size_t line) /**< line number */
   size_t l = 0;
   lit_utf8_iterator_t iter = src_iter;
 
+  lit_utf8_iterator_seek_bos (&iter);
+
   while (!lit_utf8_iterator_is_eos (&iter))
   {
     ecma_char_t code_unit;

--- a/jerry-core/parser/js/lexer.cpp
+++ b/jerry-core/parser/js/lexer.cpp
@@ -384,7 +384,10 @@ lexer_transform_escape_sequences (const jerry_api_char_t *source_str_p, /**< str
               && (lit_utf8_iterator_is_eos (&source_str_iter)
                   || !lit_char_is_octal_digit (lit_utf8_iterator_peek_next (&source_str_iter))))
           {
-            lit_utf8_iterator_incr (&source_str_iter);
+            if (!lit_utf8_iterator_is_eos (&source_str_iter))
+            {
+              lit_utf8_iterator_incr (&source_str_iter);
+            }
 
             converted_char = LIT_CHAR_NULL;
           }
@@ -638,7 +641,10 @@ new_token (void)
 static void
 consume_char (void)
 {
-  lit_utf8_iterator_incr (&src_iter);
+  if (!lit_utf8_iterator_is_eos (&src_iter))
+  {
+    lit_utf8_iterator_incr (&src_iter);
+  }
 }
 
 #define RETURN_PUNC_EX(TOK, NUM) \

--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -2855,31 +2855,47 @@ parse_source_element (void)
   }
 }
 
-static void
+/**
+ * Skip function's optional name and parentheses
+ *
+ * @return: true, if skipped successfully
+ *          false, if open parentheses wasn't found (this means that keyword 'function' is used as
+ *                                                   a property name)
+ */
+static bool
 skip_optional_name_and_parens (void)
 {
   if (token_is (TOK_NAME))
   {
     token_after_newlines_must_be (TOK_OPEN_PAREN);
   }
+
+  if (token_is (TOK_OPEN_PAREN))
+  {
+    skip_newlines ();
+  }
   else
   {
-    current_token_must_be (TOK_OPEN_PAREN);
+    return false;
   }
 
   while (!token_is (TOK_CLOSE_PAREN))
   {
     skip_newlines ();
   }
-}
+
+  return true;
+} /* skip_optional_name_and_parens */
 
 static void
 skip_function (void)
 {
   skip_newlines ();
-  skip_optional_name_and_parens ();
-  skip_newlines ();
-  jsp_skip_braces (TOK_OPEN_BRACE);
+  if (skip_optional_name_and_parens ())
+  {
+    skip_newlines ();
+    jsp_skip_braces (TOK_OPEN_BRACE);
+  }
 }
 
 static bool

--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -313,6 +313,16 @@ parse_property_name (void)
                                                                    (lit_utf8_size_t)strlen (s));
       return literal_operand (lit_cpointer_t::compress (lit));
     }
+    case TOK_NULL:
+    case TOK_BOOL:
+    {
+      lit_magic_string_id_t id = (token_is (TOK_NULL)
+                                  ? LIT_MAGIC_STRING_NULL
+                                  : (tok.uid ? LIT_MAGIC_STRING_TRUE : LIT_MAGIC_STRING_FALSE));
+      literal_t lit = lit_find_or_create_literal_from_utf8_string (lit_get_magic_string_utf8 (id),
+                                                                   lit_get_magic_string_size (id));
+      return literal_operand (lit_cpointer_t::compress (lit));
+    }
     default:
     {
       EMIT_ERROR_VARG ("Wrong property name type: %s", lexer_token_type_to_string (tok.type));
@@ -898,6 +908,15 @@ parse_member_expression (operand *this_arg, operand *prop_gl)
         {
           EMIT_ERROR ("Expected identifier");
         }
+        prop = dump_string_assignment_res (lit_cpointer_t::compress (lit));
+      }
+      else if (token_is (TOK_BOOL) || token_is (TOK_NULL))
+      {
+        lit_magic_string_id_t id = (token_is (TOK_NULL)
+                                    ? LIT_MAGIC_STRING_NULL
+                                    : (tok.uid ? LIT_MAGIC_STRING_TRUE : LIT_MAGIC_STRING_FALSE));
+        literal_t lit = lit_find_or_create_literal_from_utf8_string (lit_get_magic_string_utf8 (id),
+                                                                     lit_get_magic_string_size (id));
         prop = dump_string_assignment_res (lit_cpointer_t::compress (lit));
       }
       else


### PR DESCRIPTION
This patch fixes:
ch07/7.6/7.6.1/7.6.1-1-1 in non-strict mode 
ch07/7.6/7.6.1/7.6.1-2-1 in non-strict mode
ch07/7.6/7.6.1/7.6.1-2-7 in non-strict mode
ch07/7.6/7.6.1/7.6.1-4-1 in non-strict mode
ch07/7.6/7.6.1/7.6.1-5-1 in non-strict mode
ch07/7.6/7.6.1/7.6.1-6-1 in non-strict mode
ch07/7.6/7.6.1/7.6.1-6-7 in non-strict mode
ch07/7.6/7.6.1/7.6.1-8-1 in non-strict mode
ch07/7.8/7.8.4/7.8.4-31-s in strict mode
ch07/7.8/7.8.4/S7.8.4_A5.1_T1 in non-strict mode
ch07/7.8/7.8.4/S7.8.4_A5.1_T2 in non-strict mode
ch07/7.8/7.8.4/S7.8.4_A5.1_T3 in non-strict mode