### PR TITLE
Fix preparsing of variable declaration lists, which are not divided by a semicolon

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -3018,6 +3018,10 @@ preparse_scope (bool is_global)
           }
           else if (token_is (TOK_KEYWORD))
           {
+            if (is_keyword (KW_VAR))
+            {
+              is_in_var_declaration_list = false;
+            }
             break;
           }
           else if (token_is (TOK_CLOSE_BRACE))


### PR DESCRIPTION
This patch fixes the following tests from test262:
- ch13/13.2/13.2-1-s.js
- ch13/13.2/13.2-3-s.js
