### PR TITLE
Update RegExp.prototype.exec so that it returns 'null' instead of 'undefined' in case argument doesn't match corresponding regular expression

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.cpp
@@ -117,7 +117,7 @@ ecma_builtin_regexp_prototype_test (ecma_value_t this_arg, /**< this argument */
                   ecma_builtin_regexp_prototype_exec (this_arg, arg),
                   ret_value);
 
-  if (ecma_is_value_undefined (match_value))
+  if (ecma_is_value_null (match_value))
   {
     ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
   }

--- a/jerry-core/ecma/operations/ecma-regexp-object.cpp
+++ b/jerry-core/ecma/operations/ecma-regexp-object.cpp
@@ -1318,7 +1318,7 @@ ecma_regexp_exec_helper (ecma_object_t *obj_p, /**< RegExp object */
     }
     else
     {
-      ret_value = ecma_make_normal_completion_value (ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED));
+      ret_value = ecma_make_normal_completion_value (ecma_make_simple_value (ECMA_SIMPLE_VALUE_NULL));
     }
   }
   MEM_FINALIZE_LOCAL_ARRAY (num_of_iter_p);

--- a/tests/jerry/regexp-routines.js
+++ b/tests/jerry/regexp-routines.js
@@ -17,7 +17,7 @@ var r;
 
 r = new RegExp ("a");
 assert (r.exec ("a") == "a");
-assert (r.exec ("b") == undefined);
+assert (r.exec ("b") == null);
 try {
 	r.exec.call({}, "a");
 	assert (false)


### PR DESCRIPTION
ECMA-262 v5, 15.10.6.2 specifies that `null` is returned "if `string` didn't match".