### PR TITLE
Fix checking of semicolons in expression statements.

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -2561,7 +2561,7 @@ insert_semicolon (void)
   {
     lexer_save_token (tok);
   }
-  else if (!token_is (TOK_SEMICOLON))
+  else if (!token_is (TOK_SEMICOLON) && !token_is (TOK_EOF))
   {
     EMIT_ERROR ("Expected either ';' or newline token");
   }
@@ -2847,23 +2847,13 @@ parse_statement (jsp_label_t *outermost_stmt_label_p) /**< outermost (first) lab
       tok = temp;
       operand expr = parse_expression (true, JSP_EVAL_RET_STORE_DUMP);
       dump_assignment_of_lhs_if_literal (expr);
-      skip_newlines ();
-      if (!token_is (TOK_SEMICOLON))
-      {
-        lexer_save_token (tok);
-      }
-      return;
+      insert_semicolon ();
     }
   }
   else
   {
     parse_expression (true, JSP_EVAL_RET_STORE_DUMP);
-    skip_newlines ();
-    if (!token_is (TOK_SEMICOLON))
-    {
-      lexer_save_token (tok);
-    }
-    return;
+    insert_semicolon ();
   }
 }
 

--- a/tests/unit/test-api.cpp
+++ b/tests/unit/test-api.cpp
@@ -31,7 +31,7 @@ const char *test_source = (
                            "this.foo = f; "
                            "this.bar = function (a) { "
                            "return a + t; "
-                           "} "
+                           "}; "
                            "function A () { "
                            "this.t = 12; "
                            "} "


### PR DESCRIPTION
Fixes the following tests in test262:
- ch07/7.3/S7.3_A3.1_T3.js
- ch07/7.3/S7.3_A3.2_T3.js
- ch07/7.9/S7.9_A10_T8.js
- ch07/7.9/S7.9_A11_T4.js
- ch07/7.9/7.9.2/S7.9.2_A1_T1.js