### PR TITLE
Fix buffer size calculation in parseInt.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.cpp
@@ -110,9 +110,9 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
   ECMA_TRY_CATCH (string_var, ecma_op_to_string (string), ret_value);
 
   ecma_string_t *number_str_p = ecma_get_string_from_value (string_var);
-  ecma_length_t str_size = ecma_string_get_length (number_str_p);
+  lit_utf8_size_t str_size = ecma_string_get_size (number_str_p);
 
-  MEM_DEFINE_LOCAL_ARRAY (utf8_string_buff, str_size + 1, lit_utf8_byte_t);
+  MEM_DEFINE_LOCAL_ARRAY (utf8_string_buff, str_size, lit_utf8_byte_t);
 
   ssize_t bytes_copied = ecma_string_to_utf8_string (number_str_p,
                                                      utf8_string_buff,

--- a/tests/jerry/regression-test-issue-279.js
+++ b/tests/jerry/regression-test-issue-279.js
@@ -1,0 +1,16 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert (isNaN (parseInt (RegExp ("\u2029"))));


### PR DESCRIPTION
Fixes issue #279.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com