### PR TITLE
Fix syntax checking for hex and regexp literals

### DIFF
--- a/jerry-core/parser/js/lexer.cpp
+++ b/jerry-core/parser/js/lexer.cpp
@@ -849,15 +849,19 @@ lexer_parse_number (void)
     consume_char ();
     consume_char ();
     new_token ();
-    while (true)
+
+    c = LA (0);
+    if (!lit_char_is_hex_digit (c))
     {
-      c = LA (0);
-      if (!lit_char_is_hex_digit (c))
-      {
-        break;
-      }
-      consume_char ();
+      PARSE_ERROR ("Invalid HexIntegerLiteral", lit_utf8_iterator_get_pos (&src_iter));
     }
+
+    do
+    {
+      consume_char ();
+      c = LA (0);
+    }
+    while (lit_char_is_hex_digit (c));
 
     if (lexer_is_char_can_be_identifier_start (c))
     {

--- a/jerry-core/parser/js/lexer.cpp
+++ b/jerry-core/parser/js/lexer.cpp
@@ -1099,13 +1099,17 @@ lexer_parse_regexp (void)
     {
       PARSE_ERROR ("Unclosed string", token_start_pos);
     }
-    else if (c == LIT_CHAR_LF)
+    else if (lit_char_is_line_terminator (c))
     {
       PARSE_ERROR ("RegExp literal shall not contain newline character", token_start_pos);
     }
     else if (c == LIT_CHAR_BACKSLASH)
     {
       consume_char ();
+      if (lit_char_is_line_terminator (LA (0)))
+      {
+        PARSE_ERROR ("RegExp literal backslash sequence should not contain newline character", token_start_pos);
+      }
     }
     else if (c == LIT_CHAR_LEFT_SQUARE)
     {


### PR DESCRIPTION
This patch fixes the following tests form test262:
- ch07/7.8/7.8.3/S7.8.3_A6.1_T1.js
- ch07/7.8/7.8.3/S7.8.3_A6.1_T2.js
- ch07/7.8/7.8.5/S7.8.5_A1.5_T1.js
- ch07/7.8/7.8.5/S7.8.5_A1.5_T3.js
- ch07/7.8/7.8.5/S7.8.5_A2.5_T1.js
- ch07/7.8/7.8.5/S7.8.5_A2.5_T3.js