### PR TITLE
Fix Array.prototype.concat() argument array length.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.cpp
@@ -146,7 +146,7 @@ ecma_builtin_array_prototype_object_concat (ecma_value_t this_arg, /**< this arg
                       ecma_op_object_get (ecma_get_object_from_value (args[arg_index]),
                                           magic_string_length_p),
                       ret_value);
-      ECMA_OP_TO_NUMBER_TRY_CATCH (arg_len_number, len_value, ret_value);
+      ECMA_OP_TO_NUMBER_TRY_CATCH (arg_len_number, arg_len_value, ret_value);
 
       uint32_t arg_len = ecma_number_to_uint32 (arg_len_number);
 

--- a/tests/jerry/array-prototype-concat.js
+++ b/tests/jerry/array-prototype-concat.js
@@ -37,6 +37,19 @@ assert(new_array[5] === "Grape");
 assert(new_array[6] === obj);
 assert(new_array[7] === 1);
 
+var arr1 = [1,2];
+var arr2 = [4,5,6,7,8];
+var arr3 = [,,9,10];
+var arr4 = [];
+var expected = [1,2,4,5,6,7,8,,,9,10];
+
+var result = arr1.concat(arr2, arr3, arr4);
+
+assert(result.length === expected.length)
+for (i = 0; i < result.length; i++) {
+	assert(result[i] === expected[i]);
+}
+
 // Checking behavior when unable to get length
 var obj = { concat : Array.prototype.concat }
 Object.defineProperty(obj, 'length', { 'get' : function () {throw new ReferenceError ("foo"); } });


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Dániel Bátyai dbatyai.u-szeged@partner.samsung.com