### PR TITLE
Restore "Fix preparsing of variable declaration lists, which are not …

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -3050,6 +3050,10 @@ preparse_scope (bool is_global)
             }
             else if (token_is (TOK_KEYWORD))
             {
+              if (is_keyword (KW_VAR))
+              {
+                is_in_var_declaration_list = false;
+              }
               break;
             }
             else if (token_is (TOK_CLOSE_BRACE))


### PR DESCRIPTION
…divided by a semicolon." 06d0c1806d7ceff5192feee996c770b42bc1e1e9) that was incorrectly removed in abc2b55297eff13538fca2440d127ba79cdcc8b3.

JerryScript-DCO-1.0-Signed-off-by: Andrey Shitov a.shitov@samsung.com