### PR TITLE
Fix endian detection on 32bit

### DIFF
--- a/third-party/fdlibm/include/fdlibm.h
+++ b/third-party/fdlibm/include/fdlibm.h
@@ -13,7 +13,8 @@
 /* Sometimes it's necessary to define __LITTLE_ENDIAN explicitly
    but these catch some common cases. */
 
-#if defined(i386) || defined(i486) || \
+#if defined(i386) || defined(__i386) || defined(__i386__) || \
+	defined(i486) || defined(__i486) || defined(__i486__) || \
 	defined(intel) || defined(x86) || defined(i86pc) || \
 	defined(__alpha) || defined(__osf__) || \
 	defined(__x86_64__) || defined(__arm__)


### PR DESCRIPTION
When using the -std=c99 the gcc does not defines the `i386` macro
just the `__i386` and `__i386__`.

Fixes issue #355

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com