### PR TITLE
Fix leak in Array.prototype.indexOf() 

### DIFF
--- a/tests/jerry/array-prototype-indexof.js
+++ b/tests/jerry/array-prototype-indexof.js
@@ -45,6 +45,23 @@ assert(obj.indexOf("foo") === -1);
 var arr = [11, 22, 33, 44];
 assert(arr.indexOf(44, 4) === -1);
 
+var fromIndex = {
+	toString: function () {
+		return {};
+	},
+
+	valueOf: function () {
+		return {};
+	}
+};
+
+try {
+    [0, 1].indexOf(1, fromIndex);
+    assert(false);
+} catch (e) {
+    assert(e instanceof TypeError);
+}
+
 // Checking behavior when unable to get length
 var obj = { indexOf : Array.prototype.indexOf}
 Object.defineProperty(obj, 'length', { 'get' : function () { throw new ReferenceError ("foo"); } });


### PR DESCRIPTION
The leak occurs when `fromIndex` can't coerce to primitive value.

JerryScript-DCO-1.0-Signed-off-by: Dániel Bátyai dbatyai.u-szeged@partner.samsung.com