### PR TITLE
Returned array of Array.prototype.map() should have same length as original.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.cpp
@@ -2384,7 +2384,11 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
 
     if (ecma_is_completion_value_empty (ret_value))
     {
+      ECMA_TRY_CATCH (set_length_value,
+                      ecma_builtin_array_prototype_helper_set_length (new_array_p, ecma_uint32_to_number (len)),
+                      ret_value);
       ret_value = new_array;
+      ECMA_FINALIZE (set_length_value);
     }
     else
     {

--- a/tests/jerry/array-prototype-map.js
+++ b/tests/jerry/array-prototype-map.js
@@ -52,6 +52,10 @@ assert ([1, 4, 9].map(func).equals([1,5,11]));
 
 assert ([1, "X", 10].map(func).equals([1, "X1", 12]));
 
+var arr = [1,2,3];
+arr.length = 5;
+assert(arr.map(func).length === arr.length);
+
 var long_array = [0, 1];
 assert (long_array.map(func).equals([0,2]));
 


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Dániel Bátyai dbatyai.u-szeged@partner.samsung.com