### PR TITLE
RegExp: treat undefined argument as empty.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.cpp
@@ -78,7 +78,7 @@ ecma_builtin_regexp_dispatch_construct (const ecma_value_t *arguments_list_p, /*
     }
   }
 
-  if (arguments_list_len == 0)
+  if (arguments_list_len == 0 || ecma_is_value_undefined (arguments_list_p[0]))
   {
     ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_EMPTY_NON_CAPTURE_GROUP);
     ret_value = ecma_op_create_regexp_object (magic_str_p, NULL);

--- a/tests/jerry/regexp-construct.js
+++ b/tests/jerry/regexp-construct.js
@@ -86,3 +86,15 @@ assert (r.ignoreCase == true);
 assert (r.multiline == true);
 
 assert(Object.prototype.toString.call(RegExp.prototype) === '[object RegExp]');
+
+
+/* The 'undefined' argument for the RegExp constructor should not be converted to string,
+ * and it should behave just like when there is no argument.
+ */
+r1 = new RegExp();
+r2 = new RegExp(undefined);
+var foo;
+r3 = new RegExp(foo)
+
+assert (r1.source === r2.source);
+assert (r2.source === r3.source);


### PR DESCRIPTION
new RegExp() and new RegExp(undefined) calls now results in the
same 'source' pattern.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com