### PR TITLE
Fix preparse_scope - consider nesting level during search for identifier tokens

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -2949,9 +2949,18 @@ preparse_scope (bool is_global)
     }
   }
 
-  while (!token_is (end_tt))
+  size_t nesting_level = 0;
+  while (nesting_level > 0 || !token_is (end_tt))
   {
-    if (token_is (TOK_NAME))
+    if (token_is (TOK_OPEN_BRACE))
+    {
+      nesting_level++;
+    }
+    else if (token_is (TOK_CLOSE_BRACE))
+    {
+      nesting_level--;
+    }
+    else if (token_is (TOK_NAME))
     {
       if (lit_literal_equal_type_cstr (lit_get_literal_by_cp (token_data_as_lit_cp ()), "arguments"))
       {

--- a/tests/jerry/regression-test-issue-440.js
+++ b/tests/jerry/regression-test-issue-440.js
@@ -1,0 +1,19 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function () {
+  var d = {};
+  var a = [arguments];
+})();


### PR DESCRIPTION
Related issue: #440