### PR TITLE
Fix buffer size calculation in Number.prototype.toString()

### DIFF
--- a/tests/jerry/number-prototype-to-string.js
+++ b/tests/jerry/number-prototype-to-string.js
@@ -41,6 +41,8 @@ assert((-0.03125).toString(2) === "-0.00001");
 assert((-0.03125).toString(16) === "-0.08");
 assert((-0.0001).toString(4) === "-0.000000122031232023223013010030231")
 assert((-0).toString(16) === "0");
+assert((1e+73).toString(35) === "2nx1mg1l0w4ujlpt449c5qfrkkmtpgpsfsc2prlaqtnjbli2")
+assert((-1e+73).toString(35) === "-2nx1mg1l0w4ujlpt449c5qfrkkmtpgpsfsc2prlaqtnjbli2")
 
 assert((123400).toString(2) === "11110001000001000");
 assert((123400).toString(3) === "20021021101");


### PR DESCRIPTION
This is a fix for issue #445.

JerryScript-DCO-1.0-Signed-off-by: Dániel Bátyai dbatyai.u-szeged@partner.samsung.com