### PR TITLE
Fix Array.prototype.toLocaleString() when toLocaleString returns non-string.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.cpp
@@ -154,10 +154,15 @@ ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /** < t
     if (ecma_op_is_callable (to_locale_value))
     {
       ecma_object_t *locale_func_obj_p = ecma_get_object_from_value (to_locale_value);
-      ret_value = ecma_op_function_call (locale_func_obj_p,
-                                         ecma_make_object_value (index_obj_p),
-                                         NULL,
-                                         0);
+      ECMA_TRY_CATCH (call_value,
+                      ecma_op_function_call (locale_func_obj_p,
+                                             ecma_make_object_value (index_obj_p),
+                                             NULL,
+                                             0),
+                      ret_value);
+      ret_value = ecma_op_to_string (call_value);
+      ECMA_FINALIZE (call_value);
+
     }
     else
     {

--- a/tests/jerry/array-prototype-tolocalestring.js
+++ b/tests/jerry/array-prototype-tolocalestring.js
@@ -26,6 +26,11 @@ var test_ok = {
 assert ([3, test_ok, 4, test_ok].toLocaleString() === "3,1,4,1");
 
 
+var obj = { toLocaleString: function() {} };
+var test_non_str_locale = [undefined, obj, null, obj, obj];
+
+assert(test_non_str_locale.toLocaleString() === ",undefined,,undefined,undefined");
+
 var test_fail = {
   toLocaleString: "FAIL"
 };


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Dániel Bátyai dbatyai.u-szeged@partner.samsung.com