### PR TITLE
Improve Infinity handling in Math.min/max methods

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.cpp
@@ -362,11 +362,12 @@ ecma_builtin_math_object_max (ecma_value_t this_arg __attr_unused___, /**< 'this
           ret_num = arg_num;
         }
       }
-      else if (ecma_number_is_infinity (ret_num)) /* ret_num is negative infinity */
+      else if (ecma_number_is_infinity (ret_num))
       {
-        JERRY_ASSERT (ecma_number_is_negative (ret_num));
-
-        ret_num = arg_num;
+        if (ecma_number_is_negative (ret_num))
+        {
+          ret_num = arg_num;
+        }
       }
       else
       {
@@ -443,11 +444,12 @@ ecma_builtin_math_object_min (ecma_value_t this_arg __attr_unused___, /**< 'this
           ret_num = arg_num;
         }
       }
-      else if (ecma_number_is_infinity (ret_num)) /* ret_num is positive infinity */
+      else if (ecma_number_is_infinity (ret_num))
       {
-        JERRY_ASSERT (!ecma_number_is_negative (ret_num));
-
-        ret_num = arg_num;
+        if (!ecma_number_is_negative (ret_num))
+        {
+          ret_num = arg_num;
+        }
       }
       else
       {

--- a/tests/jerry/math-max.js
+++ b/tests/jerry/math-max.js
@@ -27,3 +27,13 @@ assert(Math['max'] () === -Infinity);
 
 assert(Math['max'] (0.0, -0.0) === 0.0);
 assert(Math['max'] (-0.0, 0.0) === 0.0);
+
+assert(Math['max'] (2, Infinity) === Infinity);
+assert(Math['max'] (Infinity, 2) === Infinity);
+assert(Math['max'] (2, -Infinity) === 2);
+assert(Math['max'] (-Infinity, 2) === 2);
+
+assert(Math['max'] (-2, Infinity) === Infinity);
+assert(Math['max'] (Infinity, -2) === Infinity);
+assert(Math['max'] (-2, -Infinity) === -2);
+assert(Math['max'] (-Infinity, -2) === -2);

--- a/tests/jerry/math-min.js
+++ b/tests/jerry/math-min.js
@@ -27,3 +27,13 @@ assert(Math['min'] () === Infinity);
 
 assert(Math['min'] (0.0, -0.0) === -0.0);
 assert(Math['min'] (-0.0, 0.0) === -0.0);
+
+assert(Math['min'] (2, -Infinity) === -Infinity);
+assert(Math['min'] (-Infinity, 2) === -Infinity);
+assert(Math['min'] (2, Infinity) === 2);
+assert(Math['min'] (Infinity, 2) === 2);
+
+assert(Math['min'] (-2, Infinity) === -2);
+assert(Math['min'] (Infinity, -2) === -2);
+assert(Math['min'] (-2, -Infinity) === -Infinity);
+assert(Math['min'] (-Infinity, -2) === -Infinity);


### PR DESCRIPTION
In Math.max case: if we already found an infinity value update the result
only when the previous value was a negative infinity.

In Math.min case: if we already found an infinity value update the result
only when the previous value was a positive infinity.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com