### PR TITLE
Build system changes to allow compiler toolchain override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project (Jerry CXX C ASM)
 
 # Require g++ of version >= 4.7.0
  if(NOT CMAKE_COMPILER_IS_GNUCXX)
-  message(FATAL_ERROR "g++ compiler is required")
+  message(WARNING "g++ compiler is required")
  else()
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
                   OUTPUT_VARIABLE GNU_CXX_VERSION
@@ -32,10 +32,14 @@ project (Jerry CXX C ASM)
  get_filename_component(PATH_TO_GCC ${CMAKE_C_COMPILER} REALPATH)
  get_filename_component(DIRECTORY_GCC ${PATH_TO_GCC} DIRECTORY)
  get_filename_component(FILE_NAME_GCC ${PATH_TO_GCC} NAME)
- string(REPLACE "gcc" "gcc-ar" CMAKE_AR ${FILE_NAME_GCC})
- string(REPLACE "gcc" "gcc-ranlib" CMAKE_RANLIB ${FILE_NAME_GCC})
- set(CMAKE_AR ${DIRECTORY_GCC}/${CMAKE_AR})
- set(CMAKE_RANLIB ${DIRECTORY_GCC}/${CMAKE_RANLIB})
+ if(NOT DEFINED CMAKE_AR)
+  string(REPLACE "gcc" "gcc-ar" CMAKE_AR ${FILE_NAME_GCC})
+  set(CMAKE_AR ${DIRECTORY_GCC}/${CMAKE_AR})
+ endif()
+ if(NOT DEFINED CMAKE_RANLIB)
+  string(REPLACE "gcc" "gcc-ranlib" CMAKE_RANLIB ${FILE_NAME_GCC})
+  set(CMAKE_RANLIB ${DIRECTORY_GCC}/${CMAKE_RANLIB})
+ endif()
 
 # Imported and third-party targets prefix
  set(PREFIX_IMPORTED_LIB imported_)
@@ -202,8 +206,12 @@ project (Jerry CXX C ASM)
 
  # LTO
   if("${ENABLE_LTO}" STREQUAL "ON")
-   set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -flto -fno-fat-lto-objects")
-   set(LINKER_FLAGS_COMMON "${LINKER_FLAGS_COMMON} -flto")
+   if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_COMPILER_IS_GNUCXX)
+    set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -flto -fno-fat-lto-objects")
+    set(LINKER_FLAGS_COMMON "${LINKER_FLAGS_COMMON} -flto")
+   else()
+    message(FATAL_ERROR "LTO is only supported for g++ (consider using LTO=OFF)")
+   endif()
   endif()
 
  # Turn off stack protector
@@ -213,11 +221,17 @@ project (Jerry CXX C ASM)
   set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -g -gdwarf-4")
 
  # Warnings
-  set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Wall -Wextra -pedantic -Wlogical-op")
+  set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Wall -Wextra -pedantic")
   set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Wformat-nonliteral -Winit-self -Wno-stack-protector")
   set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Wconversion -Wsign-conversion -Wformat-security")
   set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Wmissing-declarations -Wno-attributes")
   set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Werror -Wfatal-errors")
+  if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_COMPILER_IS_GNUCXX)
+   set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Wlogical-op")
+  endif()
+
+ # Extra flags
+  set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} ${EXTRA_COMPILE_FLAGS}")
 
  # Static build
   set(LINKER_FLAGS_STATIC "-static")
@@ -226,7 +240,9 @@ project (Jerry CXX C ASM)
   set(CXX_FLAGS_JERRY "-std=c++11 -fno-exceptions -fno-rtti")
 
   # Turn off implicit template instantiation
-   set(CXX_FLAGS_JERRY "${CXX_FLAGS_JERRY} -fno-implicit-templates -fno-implicit-inline-templates")
+   if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CXX_FLAGS_JERRY "${CXX_FLAGS_JERRY} -fno-implicit-templates -fno-implicit-inline-templates")
+   endif()
 
  # C
   set(C_FLAGS_JERRY "-std=c99")

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,24 @@
    QLOG := >/dev/null
   endif
 
+ # Toolchain overrride
+  CMAKE_TOOLCHAIN_OPTIONS :=
+  ifdef CC
+   CMAKE_TOOLCHAIN_OPTIONS += -DCMAKE_C_COMPILER=$(CC)
+  endif
+  ifdef CXX
+   CMAKE_TOOLCHAIN_OPTIONS += -DCMAKE_CXX_COMPILER=$(CXX)
+  endif
+  ifdef EXTRA_CFLAGS
+   CMAKE_TOOLCHAIN_OPTIONS += -DEXTRA_COMPILE_FLAGS="$(EXTRA_CFLAGS)"
+  endif
+  ifdef AR
+   CMAKE_TOOLCHAIN_OPTIONS += -DCMAKE_AR=$(AR)
+  endif
+  ifdef RANLIB
+   CMAKE_TOOLCHAIN_OPTIONS += -DCMAKE_RANLIB=$(RANLIB)
+  endif
+
 # External build configuration
  # Flag, indicating whether to use compiler's default libc (YES / NO)
   USE_COMPILER_DEFAULT_LIBC ?= NO
@@ -91,6 +109,7 @@
  # Compiler to use for external build
  EXTERNAL_C_COMPILER ?= arm-none-eabi-gcc
  EXTERNAL_CXX_COMPILER ?= arm-none-eabi-g++
+ CMAKE_TOOLCHAIN_OPTIONS += -DUSE_COMPILER_DEFAULT_LIBC=$(USE_COMPILER_DEFAULT_LIBC)
 
 export TARGET_DEBUG_MODES = debug
 export TARGET_RELEASE_MODES = release
@@ -176,7 +195,7 @@ $(BUILD_DIRS_NATIVE): prerequisites
           mkdir -p $@; \
           echo "$$TOOLCHAIN" > $@/toolchain.config
 	$(Q) cd $@ && \
-          (cmake -DENABLE_VALGRIND=$(VALGRIND) -DENABLE_LOG=$(LOG) -DENABLE_LTO=$(LTO) -DCMAKE_TOOLCHAIN_FILE=`cat toolchain.config` ../../.. 2>&1 | tee cmake.log $(QLOG) ; ( exit $${PIPESTATUS[0]} ) ) || \
+          (cmake $(CMAKE_TOOLCHAIN_OPTIONS) -DENABLE_VALGRIND=$(VALGRIND) -DENABLE_LOG=$(LOG) -DENABLE_LTO=$(LTO) -DCMAKE_TOOLCHAIN_FILE=`cat toolchain.config` ../../.. 2>&1 | tee cmake.log $(QLOG) ; ( exit $${PIPESTATUS[0]} ) ) || \
           (echo "CMake run failed. See "`pwd`"/cmake.log for details."; exit 1;); \
 
 .PHONY: $(BUILD_DIRS_STM32F3)

--- a/build/configs/toolchain_linux_x86_64.cmake
+++ b/build/configs/toolchain_linux_x86_64.cmake
@@ -15,9 +15,15 @@
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
-find_program(CMAKE_C_COMPILER NAMES x86_64-linux-gnu-gcc x86_64-unknown-linux-gnu-gcc)
-find_program(CMAKE_CXX_COMPILER NAMES x86_64-linux-gnu-g++ x86_64-unknown-linux-gnu-g++)
+if(NOT DEFINED CMAKE_C_COMPILER)
+  find_program(CMAKE_C_COMPILER NAMES x86_64-linux-gnu-gcc x86_64-unknown-linux-gnu-gcc)
+endif()
+if(NOT DEFINED CMAKE_CXX_COMPILER)
+  find_program(CMAKE_CXX_COMPILER NAMES x86_64-linux-gnu-g++ x86_64-unknown-linux-gnu-g++)
+endif()
 # FIXME: This could break cross compilation, when the strip is not for the target architecture
 find_program(CMAKE_STRIP NAMES x86_64-linux-gnu-strip x86_64-unknown-linux-gnu-strip strip)
 
-set(FLAGS_COMMON_ARCH -ffixed-rbp)
+if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_COMPILER_IS_GNUCXX)
+  set(FLAGS_COMMON_ARCH -ffixed-rbp)
+endif()


### PR DESCRIPTION
E.g., works with Clang as
```
make clean && make debug.linux CC=clang-3.5 CXX=clang++-3.5 AR=/usr/bin/ar RANLIB=/usr/bin/ranlib \
  EXTRA_CFLAGS="-Wno-unknown-warning-option -Wno-sign-conversion -Wno-sign-compare -Wno-nested-anon-types -Wno-c99-extensions -Wno-float-conversion -Wno-null-conversion -Wno-invalid-noreturn" \
  LTO=OFF
```

(Works on x86_64/linux at least.)