### PR TITLE
Change jerry_api_string_to_char_buffer so it doesn't add '\0' to the end of output buffer.

### DIFF
--- a/jerry-core/jerry.cpp
+++ b/jerry-core/jerry.cpp
@@ -274,10 +274,13 @@ jerry_api_convert_api_value_to_ecma_value (ecma_value_t *out_value_p, /**< out: 
  */
 
 /**
- * Copy string characters to specified buffer, append zero character at end of the buffer.
+ * Copy string characters to specified buffer.
+ *
+ * Note:
+ *   '\0' could occur in characters.
  *
  * @return number of bytes, actually copied to the buffer - if string's content was copied successfully;
- *         otherwise (in case size of buffer is insuficcient) - negative number, which is calculated
+ *         otherwise (in case size of buffer is insufficient) - negative number, which is calculated
  *         as negation of buffer size, that is required to hold the string's content.
  */
 ssize_t
@@ -287,22 +290,7 @@ jerry_api_string_to_char_buffer (const jerry_api_string_t *string_p, /**< string
 {
   jerry_assert_api_available ();
 
-  if (buffer_size > 0)
-  {
-    buffer_size--;
-  }
-  ssize_t ret_val = ecma_string_to_utf8_string (string_p, (lit_utf8_byte_t *) buffer_p, buffer_size);
-  if (ret_val >= 0)
-  {
-    buffer_p[ret_val] = 0;
-    ret_val++;
-  }
-  else
-  {
-    ret_val--;
-  }
-
-  return ret_val;
+  return ecma_string_to_utf8_string (string_p, (lit_utf8_byte_t *) buffer_p, buffer_size);
 } /* jerry_api_string_to_char_buffer */
 
 /**

--- a/tests/unit/test-api.cpp
+++ b/tests/unit/test-api.cpp
@@ -120,10 +120,10 @@ handler (const jerry_api_object_t *function_obj_p,
 
   JERRY_ASSERT (args_p[0].type == JERRY_API_DATA_TYPE_STRING);
   sz = jerry_api_string_to_char_buffer (args_p[0].v_string, NULL, 0);
-  JERRY_ASSERT (sz == -2);
+  JERRY_ASSERT (sz == -1);
   sz = jerry_api_string_to_char_buffer (args_p[0].v_string, (jerry_api_char_t *) buffer, -sz);
-  JERRY_ASSERT (sz == 2);
-  JERRY_ASSERT (!strcmp (buffer, "1"));
+  JERRY_ASSERT (sz == 1);
+  JERRY_ASSERT (!strncmp (buffer, "1", (size_t) sz));
 
   JERRY_ASSERT (args_p[1].type == JERRY_API_DATA_TYPE_BOOLEAN);
   JERRY_ASSERT (args_p[1].v_bool == true);
@@ -249,6 +249,12 @@ main (void)
 
   global_obj_p = jerry_api_get_global ();
 
+  // Test corner case for jerry_api_string_to_char_buffer
+  test_api_init_api_value_string (&args[0], "");
+  sz = jerry_api_string_to_char_buffer (args[0].v_string, NULL, 0);
+  JERRY_ASSERT (sz == 0);
+  jerry_api_release_value (&args[0]);
+
   // Get global.t
   is_ok = jerry_api_get_object_field_value (global_obj_p, (jerry_api_char_t *)"t", &val_t);
   JERRY_ASSERT (is_ok
@@ -296,11 +302,11 @@ main (void)
   JERRY_ASSERT (is_ok
                 && res.type == JERRY_API_DATA_TYPE_STRING);
   sz = jerry_api_string_to_char_buffer (res.v_string, NULL, 0);
-  JERRY_ASSERT (sz == -5);
+  JERRY_ASSERT (sz == -4);
   sz = jerry_api_string_to_char_buffer (res.v_string, (jerry_api_char_t *) buffer, -sz);
-  JERRY_ASSERT (sz == 5);
+  JERRY_ASSERT (sz == 4);
   jerry_api_release_value (&res);
-  JERRY_ASSERT (!strcmp (buffer, "abcd"));
+  JERRY_ASSERT (!strncmp (buffer, "abcd", (size_t) sz));
 
   // Get global.A
   is_ok = jerry_api_get_object_field_value (global_obj_p, (jerry_api_char_t *)"A", &val_A);
@@ -378,11 +384,11 @@ main (void)
   JERRY_ASSERT (is_ok
                 && res.type == JERRY_API_DATA_TYPE_STRING);
   sz = jerry_api_string_to_char_buffer (res.v_string, NULL, 0);
-  JERRY_ASSERT (sz == -20);
+  JERRY_ASSERT (sz == -19);
   sz = jerry_api_string_to_char_buffer (res.v_string, (jerry_api_char_t *) buffer, -sz);
-  JERRY_ASSERT (sz == 20);
+  JERRY_ASSERT (sz == 19);
   jerry_api_release_value (&res);
-  JERRY_ASSERT (!strcmp (buffer, "string from handler"));
+  JERRY_ASSERT (!strncmp (buffer, "string from handler", (size_t) sz));
 
   // Create native handler bound function object and set it to 'external_construct' variable
   external_construct_p = jerry_api_create_external_function (handler_construct);


### PR DESCRIPTION
Fixes issue #439.
