### PR TITLE
Fix assertion 'bytes_copied > 0 || !string_len' in JSON.stringify()

### DIFF
--- a/tests/jerry/json-stringify.js
+++ b/tests/jerry/json-stringify.js
@@ -28,6 +28,9 @@ assert (JSON.stringify (ctl_string) == '"asd\\u001fasd"');
 escpad_string = "\"asda\sd";
 assert (JSON.stringify (escpad_string) == '"\\"asdasd"');
 
+assert (JSON.stringify('\u2040') == '"⁀"');
+assert (JSON.stringify('abc\u2040\u2030cba') == '"abc⁀‰cba"');
+
 // Checking primitive types
 assert (JSON.stringify (1) === '1');
 assert (JSON.stringify (true) === 'true');
@@ -165,6 +168,7 @@ object = {"a": 2};
 assert (JSON.stringify (object, null, "   ") == '{\n   "a": 2\n}');
 assert (JSON.stringify (object, null, "asd") == '{\nasd"a": 2\n}');
 assert (JSON.stringify (object, null, "asd0123456789") == '{\nasd0123456"a": 2\n}');
+assert (JSON.stringify (object, null, "asd\u20400123456789") == '{\nasd⁀012345"a": 2\n}');
 assert (JSON.stringify (object, null, 100) == '{\n          "a": 2\n}');
 assert (JSON.stringify (object, null, -5) == '{"a":2}');
 
@@ -172,6 +176,7 @@ array = [2];
 assert (JSON.stringify (array, null, "   ") == '[\n   2\n]');
 assert (JSON.stringify (array, null, "asd") == '[\nasd2\n]');
 assert (JSON.stringify (array, null, "asd0123456789") == '[\nasd01234562\n]');
+assert (JSON.stringify (array, null, "asd\u20400123456789") == '[\nasd⁀0123452\n]');
 assert (JSON.stringify (array, null, 100) == '[\n          2\n]');
 assert (JSON.stringify (array, null, -5) == '[2]');
 


### PR DESCRIPTION
Modified some places to support unicode characters.
Also renamed some variables to be more clearer.