### PR TITLE
Eliminate the year calculation from an infinity value.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.cpp
@@ -141,7 +141,7 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
 
   if (ecma_is_completion_value_empty (ret_value))
   {
-    if (!ecma_number_is_nan (year))
+    if (!ecma_number_is_nan (year) && !ecma_number_is_infinity (year))
     {
       /* 8. */
       int32_t y = ecma_number_to_int32 (year);

--- a/tests/jerry/date-tostring.js
+++ b/tests/jerry/date-tostring.js
@@ -14,6 +14,12 @@
 // limitations under the License.
 
 assert (new Date (NaN) == "Invalid Date");
+assert (new Date (Infinity, 1, 1, 0, 0, 0) == "Invalid Date");
+assert (new Date (2015, Infinity, 1, 0, 0, 0) == "Invalid Date");
+assert (new Date (2015, 7, 1, 0, Infinity, 0) == "Invalid Date");
+assert (new Date (NaN, 1, 1, 0, 0, 0) == "Invalid Date");
+assert (new Date (2015, NaN, 1, 0, 0, 0) == "Invalid Date");
+assert (new Date (2015, 7, 1, 0, NaN, 0) == "Invalid Date");
 assert (new Date ("2015-02-13") == "2015-02-13T00:00:00.000");
 assert (new Date ("2015-07-08T11:29:05.023") == "2015-07-08T11:29:05.023");
 


### PR DESCRIPTION
Added a missing 'infinity prevention' condition to the year calculation of the Date object.