### PR TITLE
Implement append functionality in ecma collections

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -752,11 +752,11 @@ typedef struct
   /** Number of elements in the collection */
   ecma_length_t unit_number;
 
-  /** Compressed pointer to next chunk with collection's data */
-  mem_cpointer_t next_chunk_cp;
+  /** Compressed pointer to first chunk with collection's data */
+  mem_cpointer_t first_chunk_cp;
 
-  /** Place for the collection's data */
-  uint8_t data[ sizeof (uint64_t) - sizeof (mem_cpointer_t) - sizeof (ecma_length_t) ];
+  /** Compressed pointer to last chunk with collection's data */
+  mem_cpointer_t last_chunk_cp;
 } ecma_collection_header_t;
 
 /**

--- a/jerry-core/ecma/base/ecma-helpers-string.cpp
+++ b/jerry-core/ecma/base/ecma-helpers-string.cpp
@@ -71,15 +71,15 @@ ecma_new_chars_collection (const lit_utf8_byte_t chars_buffer[], /**< utf-8 char
 
   collection_p->unit_number = chars_size;
 
-  mem_cpointer_t* next_chunk_cp_p = &collection_p->next_chunk_cp;
-  lit_utf8_byte_t *cur_char_buf_iter_p = (lit_utf8_byte_t *) collection_p->data;
-  lit_utf8_byte_t *cur_char_buf_end_p = cur_char_buf_iter_p + sizeof (collection_p->data);
+  mem_cpointer_t* next_chunk_cp_p = &collection_p->first_chunk_cp;
+  lit_utf8_byte_t *cur_char_buf_iter_p = NULL;
+  lit_utf8_byte_t *cur_char_buf_end_p = NULL;
 
   for (lit_utf8_size_t byte_index = 0;
        byte_index < chars_size;
        byte_index++)
   {
-    if (unlikely (cur_char_buf_iter_p == cur_char_buf_end_p))
+    if (cur_char_buf_iter_p == cur_char_buf_end_p)
     {
       ecma_collection_chunk_t *chunk_p = ecma_alloc_collection_chunk ();
       ECMA_SET_NON_NULL_POINTER (*next_chunk_cp_p, chunk_p);
@@ -115,10 +115,10 @@ ecma_get_chars_collection_length (const ecma_collection_header_t *header_p) /**<
 
   const ecma_length_t chars_number = header_p->unit_number;
 
-  const lit_utf8_byte_t *cur_char_buf_iter_p = (lit_utf8_byte_t *) header_p->data;
-  const lit_utf8_byte_t *cur_char_buf_end_p = cur_char_buf_iter_p + sizeof (header_p->data);
+  const lit_utf8_byte_t *cur_char_buf_iter_p = NULL;
+  const lit_utf8_byte_t *cur_char_buf_end_p = NULL;
 
-  mem_cpointer_t next_chunk_cp = header_p->next_chunk_cp;
+  mem_cpointer_t next_chunk_cp = header_p->first_chunk_cp;
   lit_utf8_size_t skip_bytes = 0;
   ecma_length_t length = 0;
 
@@ -127,7 +127,7 @@ ecma_get_chars_collection_length (const ecma_collection_header_t *header_p) /**<
        char_index < chars_number;
        char_index++)
   {
-    if (unlikely (cur_char_buf_iter_p == cur_char_buf_end_p))
+    if (cur_char_buf_iter_p == cur_char_buf_end_p)
     {
       const ecma_collection_chunk_t *chunk_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_chunk_t, next_chunk_cp);
 
@@ -176,19 +176,19 @@ ecma_compare_chars_collection (const ecma_collection_header_t* header1_p, /**< f
 
   const ecma_length_t chars_number = header1_p->unit_number;
 
-  const lit_utf8_byte_t *cur_char_buf1_iter_p = (lit_utf8_byte_t *) header1_p->data;
-  const lit_utf8_byte_t *cur_char_buf1_end_p = cur_char_buf1_iter_p + sizeof (header1_p->data);
-  const lit_utf8_byte_t *cur_char_buf2_iter_p = (lit_utf8_byte_t *) header2_p->data;
-  const lit_utf8_byte_t *cur_char_buf2_end_p = cur_char_buf2_iter_p + sizeof (header2_p->data);
+  const lit_utf8_byte_t *cur_char_buf1_iter_p = NULL;
+  const lit_utf8_byte_t *cur_char_buf1_end_p = NULL;
+  const lit_utf8_byte_t *cur_char_buf2_iter_p = NULL;
+  const lit_utf8_byte_t *cur_char_buf2_end_p = NULL;
 
-  mem_cpointer_t next_chunk1_cp = header1_p->next_chunk_cp;
-  mem_cpointer_t next_chunk2_cp = header2_p->next_chunk_cp;
+  mem_cpointer_t next_chunk1_cp = header1_p->first_chunk_cp;
+  mem_cpointer_t next_chunk2_cp = header2_p->first_chunk_cp;
 
   for (ecma_length_t char_index = 0;
        char_index < chars_number;
        char_index++)
   {
-    if (unlikely (cur_char_buf1_iter_p == cur_char_buf1_end_p))
+    if (cur_char_buf1_iter_p == cur_char_buf1_end_p)
     {
       JERRY_ASSERT (cur_char_buf2_iter_p == cur_char_buf2_end_p);
 
@@ -229,10 +229,10 @@ ecma_copy_chars_collection (const ecma_collection_header_t* collection_p) /**< c
   ecma_collection_header_t *new_header_p = ecma_alloc_collection_header ();
   *new_header_p = *collection_p;
 
-  mem_cpointer_t* next_chunk_cp_p = &new_header_p->next_chunk_cp;
+  mem_cpointer_t* next_chunk_cp_p = &new_header_p->first_chunk_cp;
 
   ecma_collection_chunk_t *chunk_p = ECMA_GET_POINTER (ecma_collection_chunk_t,
-                                                       collection_p->next_chunk_cp);
+                                                       collection_p->first_chunk_cp);
 
   while (chunk_p != NULL)
   {
@@ -265,15 +265,15 @@ ecma_copy_chars_collection_to_buffer (const ecma_collection_header_t *collection
 
   const lit_utf8_size_t chars_number = collection_p->unit_number;
 
-  mem_cpointer_t next_chunk_cp = collection_p->next_chunk_cp;
-  const lit_utf8_byte_t *cur_char_buf_iter_p = (lit_utf8_byte_t *) collection_p->data;
-  const lit_utf8_byte_t *cur_char_buf_end_p = cur_char_buf_iter_p + sizeof (collection_p->data);
+  mem_cpointer_t next_chunk_cp = collection_p->first_chunk_cp;
+  const lit_utf8_byte_t *cur_char_buf_iter_p = NULL;
+  const lit_utf8_byte_t *cur_char_buf_end_p = NULL;
 
   for (lit_utf8_size_t char_index = 0;
        char_index < chars_number;
        char_index++)
   {
-    if (unlikely (cur_char_buf_iter_p == cur_char_buf_end_p))
+    if (cur_char_buf_iter_p == cur_char_buf_end_p)
     {
       const ecma_collection_chunk_t *chunk_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_chunk_t, next_chunk_cp);
 
@@ -300,7 +300,7 @@ ecma_free_chars_collection (ecma_collection_header_t* collection_p) /**< collect
   JERRY_ASSERT (collection_p != NULL);
 
   ecma_collection_chunk_t *chunk_p = ECMA_GET_POINTER (ecma_collection_chunk_t,
-                                                       collection_p->next_chunk_cp);
+                                                       collection_p->first_chunk_cp);
 
   while (chunk_p != NULL)
   {

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -187,12 +187,14 @@ extern void ecma_number_to_decimal (ecma_number_t num,
                                     int32_t *out_decimal_exp_p);
 
 /* ecma-helpers-values-collection.cpp */
-
 extern ecma_collection_header_t *ecma_new_values_collection (const ecma_value_t values_buffer[],
                                                              ecma_length_t values_number,
                                                              bool do_ref_if_object);
-extern void ecma_free_values_collection (ecma_collection_header_t* header_p, bool do_deref_if_object);
-extern ecma_collection_header_t *ecma_new_strings_collection (ecma_string_t* string_ptrs_buffer[],
+extern void ecma_free_values_collection (ecma_collection_header_t *header_p, bool do_deref_if_object);
+extern void ecma_append_to_values_collection (ecma_collection_header_t *header_p,
+                                              ecma_value_t v,
+                                              bool do_ref_if_object);
+extern ecma_collection_header_t *ecma_new_strings_collection (ecma_string_t *string_ptrs_buffer[],
                                                               ecma_length_t strings_number);
 
 /**

--- a/jerry-core/vm/opcodes-ecma-support.h
+++ b/jerry-core/vm/opcodes-ecma-support.h
@@ -37,10 +37,9 @@
 bool is_reg_variable (vm_frame_ctx_t *frame_ctx_p, idx_t var_idx);
 ecma_completion_value_t get_variable_value (vm_frame_ctx_t *, idx_t, bool);
 ecma_completion_value_t set_variable_value (vm_frame_ctx_t *, vm_instr_counter_t, idx_t, ecma_value_t);
-ecma_completion_value_t fill_varg_list (vm_frame_ctx_t *frame_ctx_p,
-                                        ecma_length_t args_number,
-                                        ecma_value_t args_values[],
-                                        ecma_length_t *out_arg_number_p);
+ecma_completion_value_t vm_fill_varg_list (vm_frame_ctx_t *frame_ctx_p,
+                                           ecma_length_t args_number,
+                                           ecma_collection_header_t *args_values_p);
 void fill_params_list (vm_frame_ctx_t *frame_ctx_p,
                        ecma_length_t params_number,
                        ecma_string_t* params_names[]);


### PR DESCRIPTION
Related issue: #310 

The changes leads to significant reduce of performance on access-binary-trees.js: 1.932s -> 2.972s.
Cause of the reduce is increased GC activity due to lack of free memory: additionally to argument arrays, currently there are also argument value collections. This is intended to be fixed in a subsequent patch.
