### PR TITLE
Fix regexp match on right brackets

### DIFF
--- a/jerry-core/ecma/operations/ecma-regexp-object.cpp
+++ b/jerry-core/ecma/operations/ecma-regexp-object.cpp
@@ -257,13 +257,6 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
 
   while ((op = re_get_opcode (&bc_p)))
   {
-    if (re_ctx_p->match_limit >= RE_EXECUTE_MATCH_LIMIT)
-    {
-      ret_value = ecma_raise_range_error ("RegExp executor steps limit is exceeded.");
-      return ret_value;
-    }
-    re_ctx_p->match_limit++;
-
     switch (op)
     {
       case RE_OP_MATCH:
@@ -1204,7 +1197,6 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
   re_matcher_ctx_t re_ctx;
   re_ctx.input_start_p = iterator.buf_p;
   re_ctx.input_end_p = iterator.buf_p + iterator.buf_size;
-  re_ctx.match_limit = 0;
   re_ctx.recursion_depth = 0;
 
   /* 1. Read bytecode header and init regexp matcher context. */

--- a/jerry-core/ecma/operations/ecma-regexp-object.h
+++ b/jerry-core/ecma/operations/ecma-regexp-object.h
@@ -35,11 +35,6 @@
 #define RE_EXECUTE_RECURSION_LIMIT  1000
 
 /**
- * Limit of RegExp execetur matching steps
- */
-#define RE_EXECUTE_MATCH_LIMIT      10000
-
-/**
  * RegExp executor context
  */
 typedef struct
@@ -47,7 +42,6 @@ typedef struct
   lit_utf8_iterator_t *saved_p; /**< saved result string pointers, ECMA 262 v5, 15.10.2.1, State */
   const lit_utf8_byte_t *input_start_p; /**< start of input pattern string */
   const lit_utf8_byte_t *input_end_p; /**< end of input pattern string */
-  uint32_t match_limit; /**< matching limit counter */
   uint32_t recursion_depth; /**< recursion depth counter */
   uint32_t num_of_captures; /**< number of capture groups */
   uint32_t num_of_non_captures; /**< number of non-capture groups */

--- a/jerry-core/parser/regexp/re-parser.cpp
+++ b/jerry-core/parser/regexp/re-parser.cpp
@@ -825,10 +825,9 @@ re_parse_next_token (re_parser_ctx_t *parser_ctx_p, /**< RegExp parser context *
         out_token_p->type = RE_TOK_START_INV_CHAR_CLASS;
         lit_utf8_iterator_advance (iter_p, 1);
       }
+
       break;
     }
-    case LIT_CHAR_RIGHT_SQUARE:
-    case LIT_CHAR_RIGHT_BRACE:
     case LIT_CHAR_QUESTION:
     case LIT_CHAR_ASTERISK:
     case LIT_CHAR_PLUS:

--- a/tests/jerry/regression-test-issue-257.js
+++ b/tests/jerry/regression-test-issue-257.js
@@ -1,0 +1,21 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var r;
+r = new RegExp("]");
+assert (r.exec("]") == "]");
+
+r = new RegExp("}");
+assert (r.exec("}") == "}");


### PR DESCRIPTION
Related issue: #257
Related test262 tests:
 * `ch15/15.10/15.10.2/S15.10.2_A1_T1`
 * `ch15/15.10/15.10.2/15.10.2.6/S15.10.2.6_A4_T7`