### PR TITLE
Remove dependency on prerequisites for linux build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ export SHELL=/bin/bash
 all: precommit
 
 .PHONY: $(BUILD_DIRS_NATIVE)
-$(BUILD_DIRS_NATIVE): prerequisites
+$(BUILD_DIRS_NATIVE):
 	$(Q) if [ "$$TOOLCHAIN" == "" ]; \
           then \
             arch=`uname -m`; \


### PR DESCRIPTION
Precommit still depends on prerequisites, as it depends on vera++, etc.

Related issue: #516