### PR TITLE
Object constructor prototype should be set to Function.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtins.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.inc.h
@@ -27,7 +27,7 @@ BUILTIN (ECMA_BUILTIN_ID_OBJECT_PROTOTYPE,
 /* The Object object (15.2.1) */
 BUILTIN (ECMA_BUILTIN_ID_OBJECT,
          ECMA_OBJECT_TYPE_FUNCTION,
-         ECMA_BUILTIN_ID_OBJECT_PROTOTYPE,
+         ECMA_BUILTIN_ID_FUNCTION_PROTOTYPE,
          true,
          true,
          object)

--- a/tests/jerry/function-prototype-bind.js
+++ b/tests/jerry/function-prototype-bind.js
@@ -119,15 +119,6 @@ var func = Number.prototype.toString.bind('foo');
 assert (func instanceof Function);
 
 try {
-  var this_obj = this.constructor;
-  var bound = this_obj.bind(null, "foo");
-  var foo = new bound();
-  assert (false);
-} catch (e) {
-  assert (e instanceof TypeError);
-}
-
-try {
   var math = Math.sin;
   var bound = math.bind(null, 0);
   var foo = new bound();

--- a/tests/jerry/object-prototype-isprototypeof.js
+++ b/tests/jerry/object-prototype-isprototypeof.js
@@ -31,3 +31,5 @@ assert (Function_A.prototype.isPrototypeOf (Array) === false)
 
 assert (Function_A.prototype.isPrototypeOf.call(0, 0) === false);
 assert (Function_A.prototype.isPrototypeOf.call(Function_A, 0) === false);
+
+assert (Function.prototype.isPrototypeOf (Object) === true)


### PR DESCRIPTION
Fixes ch15/15.2/15.2.3/S15.2.3_A2.js test262 test

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com