### PR TITLE
Fix ecma_get_property_descriptor_from_property for accessor properties with [[Get]] / [[Set]] set to undefined value

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.cpp
+++ b/jerry-core/ecma/base/ecma-helpers.cpp
@@ -1293,24 +1293,17 @@ ecma_get_property_descriptor_from_property (ecma_property_t *prop_p) /**< proper
   else if (prop_p->type == ECMA_PROPERTY_NAMEDACCESSOR)
   {
     prop_desc.get_p = ecma_get_named_accessor_property_getter (prop_p);
+    prop_desc.is_get_defined = true;
     if (prop_desc.get_p != NULL)
     {
-      prop_desc.is_get_defined = true;
       ecma_ref_object (prop_desc.get_p);
     }
-    else
-    {
-      prop_desc.is_get_defined = false;
-    }
+
     prop_desc.set_p = ecma_get_named_accessor_property_setter (prop_p);
+    prop_desc.is_set_defined = true;
     if (prop_desc.set_p != NULL)
     {
-      prop_desc.is_set_defined = true;
       ecma_ref_object (prop_desc.set_p);
-    }
-    else
-    {
-      prop_desc.is_set_defined = false;
     }
   }
 

--- a/tests/jerry/object-defineproperty.js
+++ b/tests/jerry/object-defineproperty.js
@@ -38,3 +38,20 @@ try {
     assert (desc.value === 2010);
     assert (typeof (desc.get) === 'undefined');
 }
+
+obj = {};
+var setter = function () {};
+
+Object.defineProperty(obj, "prop", {
+    set: setter,
+    configurable: true
+});
+
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+
+Object.defineProperty(obj, "prop", {
+    set: undefined
+});
+
+var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
+assert (desc1.set === setter && desc2.set === undefined);


### PR DESCRIPTION
The standard doesn't prohibit the overwriting of the accessor's member if it is configurable and in the test262 there are 50 tests which fail with assert because of this.