### PR TITLE
Use ecma-collections to pass function's arguments

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-values-collection.cpp
+++ b/jerry-core/ecma/base/ecma-helpers-values-collection.cpp
@@ -284,7 +284,7 @@ ecma_collection_iterator_init (ecma_collection_iterator_t *iterator_p, /**< cont
                                ecma_collection_header_t *collection_p) /**< header of collection */
 {
   iterator_p->header_p = collection_p;
-  iterator_p->next_chunk_cp = collection_p->first_chunk_cp;
+  iterator_p->next_chunk_cp = (collection_p != NULL ? collection_p->first_chunk_cp : MEM_CP_NULL);
   iterator_p->current_index = 0;
   iterator_p->current_value_p = NULL;
   iterator_p->current_chunk_end_p = NULL;
@@ -299,7 +299,8 @@ ecma_collection_iterator_init (ecma_collection_iterator_t *iterator_p, /**< cont
 bool
 ecma_collection_iterator_next (ecma_collection_iterator_t *iterator_p) /**< context of iterator */
 {
-  if (unlikely (iterator_p->header_p->unit_number == 0))
+  if (iterator_p->header_p == NULL
+      || unlikely (iterator_p->header_p->unit_number == 0))
   {
     return false;
   }

--- a/jerry-core/ecma/base/ecma-helpers-values-collection.cpp
+++ b/jerry-core/ecma/base/ecma-helpers-values-collection.cpp
@@ -258,25 +258,20 @@ ecma_collection_header_t *
 ecma_new_strings_collection (ecma_string_t *string_ptrs_buffer[], /**< pointers to ecma-strings */
                              ecma_length_t strings_number) /**< number of ecma-strings */
 {
-  JERRY_ASSERT (string_ptrs_buffer != NULL);
-  JERRY_ASSERT (strings_number > 0);
+  JERRY_ASSERT (string_ptrs_buffer != NULL || strings_number == 0);
 
   ecma_collection_header_t *new_collection_p;
 
-  MEM_DEFINE_LOCAL_ARRAY (values_buffer, strings_number, ecma_value_t);
+  new_collection_p = ecma_new_values_collection (NULL, 0, false);
 
   for (ecma_length_t string_index = 0;
        string_index < strings_number;
        string_index++)
   {
-    values_buffer[string_index] = ecma_make_string_value (string_ptrs_buffer[string_index]);
+    ecma_append_to_values_collection (new_collection_p,
+                                      ecma_make_string_value (string_ptrs_buffer[string_index]),
+                                      false);
   }
-
-  new_collection_p = ecma_new_values_collection (values_buffer,
-                                                 strings_number,
-                                                 false);
-
-  MEM_FINALIZE_LOCAL_ARRAY (values_buffer);
 
   return new_collection_p;
 } /* ecma_new_strings_collection */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.cpp
@@ -113,7 +113,7 @@ ecma_builtin_array_prototype_object_to_string (ecma_value_t this_arg) /**< this 
     /* 4. */
     ecma_object_t *join_func_obj_p = ecma_get_object_from_value (join_value);
 
-    return_value = ecma_op_function_call (join_func_obj_p, this_arg, NULL, 0);
+    return_value = ecma_op_function_call (join_func_obj_p, this_arg, NULL);
   }
 
   ECMA_FINALIZE (join_value);
@@ -1013,10 +1013,10 @@ ecma_builtin_array_prototype_object_sort_compare_helper (ecma_value_t j, /**< le
         ecma_value_t compare_args[] = {j, k};
 
         ECMA_TRY_CATCH (call_value,
-                        ecma_op_function_call (comparefn_obj_p,
-                                               ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED),
-                                               compare_args,
-                                               2),
+                        ecma_op_function_call_array_args (comparefn_obj_p,
+                                                          ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED),
+                                                          compare_args,
+                                                          2),
                         ret_value);
 
         if (!ecma_is_value_number (call_value))
@@ -2069,7 +2069,7 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
 
         ecma_value_t call_args[] = { get_value, current_index, obj_this };
         /* 7.c.ii */
-        ECMA_TRY_CATCH (call_value, ecma_op_function_call (func_object_p, arg2, call_args, 3), ret_value);
+        ECMA_TRY_CATCH (call_value, ecma_op_function_call_array_args (func_object_p, arg2, call_args, 3), ret_value);
 
         /* 7.c.iii, ecma_op_to_boolean always returns a simple value, so no need to free. */
         if (ecma_is_completion_value_normal_false (ecma_op_to_boolean (call_value)))
@@ -2170,7 +2170,7 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
 
         ecma_value_t call_args[] = { get_value, current_index, obj_this };
         /* 7.c.ii */
-        ECMA_TRY_CATCH (call_value, ecma_op_function_call (func_object_p, arg2, call_args, 3), ret_value);
+        ECMA_TRY_CATCH (call_value, ecma_op_function_call_array_args (func_object_p, arg2, call_args, 3), ret_value);
 
         /* 7.c.iii, ecma_op_to_boolean always returns a simple value, so no need to free. */
         if (ecma_is_completion_value_normal_true (ecma_op_to_boolean (call_value)))
@@ -2270,7 +2270,7 @@ ecma_builtin_array_prototype_object_for_each (ecma_value_t this_arg, /**< this a
 
         /* 7.c.ii */
         ecma_value_t call_args[] = {current_value, current_index, obj_this};
-        ECMA_TRY_CATCH (call_value, ecma_op_function_call (func_object_p, arg2, call_args, 3), ret_value);
+        ECMA_TRY_CATCH (call_value, ecma_op_function_call_array_args (func_object_p, arg2, call_args, 3), ret_value);
 
         ECMA_FINALIZE (call_value);
         ECMA_FINALIZE (current_value);
@@ -2367,7 +2367,7 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
         current_index = ecma_make_number_value (num_p);
         ecma_value_t call_args[] = {current_value, current_index, obj_this};
 
-        ECMA_TRY_CATCH (mapped_value, ecma_op_function_call (func_object_p, arg2, call_args, 3), ret_value);
+        ECMA_TRY_CATCH (mapped_value, ecma_op_function_call_array_args (func_object_p, arg2, call_args, 3), ret_value);
 
         /* 8.c.iii */
         /* This will always be a simple value since 'is_throw' is false, so no need to free. */
@@ -2485,7 +2485,7 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
 
         ecma_value_t call_args[] = { get_value, current_index, obj_this };
         /* 9.c.ii */
-        ECMA_TRY_CATCH (call_value, ecma_op_function_call (func_object_p, arg2, call_args, 3), ret_value);
+        ECMA_TRY_CATCH (call_value, ecma_op_function_call_array_args (func_object_p, arg2, call_args, 3), ret_value);
 
         /* 9.c.iii, ecma_op_to_boolean always returns a simple value, so no need to free. */
         if (ecma_is_completion_value_normal_true (ecma_op_to_boolean (call_value)))
@@ -2643,10 +2643,10 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
           ecma_value_t call_args[] = {accumulator, current_value, current_index, obj_this};
 
           ECMA_TRY_CATCH (call_value,
-                          ecma_op_function_call (func_object_p,
-                                                 ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED),
-                                                 call_args,
-                                                 4),
+                          ecma_op_function_call_array_args (func_object_p,
+                                                            ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED),
+                                                            call_args,
+                                                            4),
                           ret_value);
 
           ecma_free_value (accumulator, true);
@@ -2787,10 +2787,10 @@ ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< th
           ecma_value_t call_args[] = {accumulator, current_value, current_index, obj_this};
 
           ECMA_TRY_CATCH (call_value,
-                          ecma_op_function_call (func_object_p,
-                                                 ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED),
-                                                 call_args,
-                                                 4),
+                          ecma_op_function_call_array_args (func_object_p,
+                                                            ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED),
+                                                            call_args,
+                                                            4),
                           ret_value);
 
           ecma_free_value (accumulator, true);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.cpp
@@ -1233,7 +1233,7 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg, /**< this argument *
     else
     {
       ecma_object_t *to_iso_obj_p = ecma_get_object_from_value (to_iso);
-      ret_value = ecma_op_function_call (to_iso_obj_p, this_arg, NULL, 0);
+      ret_value = ecma_op_function_call (to_iso_obj_p, this_arg, NULL);
     }
 
     ECMA_FINALIZE (to_iso);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.cpp
@@ -97,10 +97,7 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
     /* 2. */
     if (ecma_is_value_null (arg2) || ecma_is_value_undefined (arg2))
     {
-      ret_value = ecma_op_function_call (func_obj_p,
-                                         arg1,
-                                         NULL,
-                                         0);
+      ret_value = ecma_op_function_call (func_obj_p, arg1, NULL);
     }
     else
     {
@@ -127,10 +124,9 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
         const uint32_t length = ecma_number_to_uint32 (length_number);
 
         /* 6. */
-        MEM_DEFINE_LOCAL_ARRAY (arg_list, length, ecma_value_t);
+        ecma_collection_header_t *arg_collection_p = ecma_new_values_collection (NULL, 0, true);
 
         /* 7. */
-        uint32_t appended_num = 0;
         for (uint32_t index = 0; index < length && ecma_is_completion_value_empty (ret_value); index++)
         {
           ecma_string_t *curr_idx_str_p = ecma_new_ecma_string_from_uint32 (index);
@@ -139,29 +135,22 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
                           ecma_op_object_get (obj_p, curr_idx_str_p),
                           ret_value);
 
-          arg_list[index] = ecma_copy_value (get_value, true);
-          appended_num++;
+          ecma_append_to_values_collection (arg_collection_p, get_value, true);
 
           ECMA_FINALIZE (get_value);
           ecma_deref_ecma_string (curr_idx_str_p);
         }
 
-        JERRY_ASSERT (appended_num == length || !ecma_is_completion_value_empty (ret_value));
+        JERRY_ASSERT (arg_collection_p->unit_number == length || !ecma_is_completion_value_empty (ret_value));
 
         if (ecma_is_completion_value_empty (ret_value))
         {
           ret_value = ecma_op_function_call (func_obj_p,
                                              arg1,
-                                             arg_list,
-                                             (ecma_length_t) appended_num);
+                                             arg_collection_p);
         }
 
-        for (uint32_t index = 0; index < appended_num; index++)
-        {
-          ecma_free_value (arg_list[index], true);
-        }
-
-        MEM_FINALIZE_LOCAL_ARRAY (arg_list);
+        ecma_free_values_collection (arg_collection_p, true);
 
         ECMA_OP_TO_NUMBER_FINALIZE (length_number);
         ECMA_FINALIZE (length_value);
@@ -199,15 +188,14 @@ ecma_builtin_function_prototype_object_call (ecma_value_t this_arg, /**< this ar
     {
       return ecma_op_function_call (func_obj_p,
                                     ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED),
-                                    NULL,
-                                    0);
+                                    NULL);
     }
     else
     {
-      return ecma_op_function_call (func_obj_p,
-                                    arguments_list_p[0],
-                                    (arguments_number == 1u) ? NULL : (arguments_list_p + 1),
-                                    (ecma_length_t) (arguments_number - 1u));
+      return ecma_op_function_call_array_args (func_obj_p,
+                                               arguments_list_p[0],
+                                               (arguments_number == 1u) ? NULL : (arguments_list_p + 1),
+                                               (ecma_length_t) (arguments_number - 1u));
     }
   }
 } /* ecma_builtin_function_prototype_object_call */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function.cpp
@@ -306,8 +306,11 @@ ecma_builtin_function_dispatch_construct (const ecma_value_t *arguments_list_p, 
       /* 11. */
       ecma_object_t *glob_lex_env_p = ecma_get_global_environment ();
 
-      ecma_object_t *func_obj_p = ecma_op_create_function_object (params_count > 1u ? string_params_p : NULL,
-                                                                  (ecma_length_t) (params_count - 1u),
+      ecma_collection_header_t *formal_params_collection_p;
+      formal_params_collection_p = ecma_new_strings_collection (params_count > 1u ? string_params_p : NULL,
+                                                                (ecma_length_t) (params_count - 1u));
+
+      ecma_object_t *func_obj_p = ecma_op_create_function_object (formal_params_collection_p,
                                                                   glob_lex_env_p,
                                                                   is_strict,
                                                                   do_instantiate_arguments_object,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.cpp
@@ -158,8 +158,7 @@ ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /** < t
       ECMA_TRY_CATCH (call_value,
                       ecma_op_function_call (locale_func_obj_p,
                                              ecma_make_object_value (index_obj_p),
-                                             NULL,
-                                             0),
+                                             NULL),
                       ret_value);
       ret_value = ecma_op_to_string (call_value);
       ECMA_FINALIZE (call_value);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
@@ -793,10 +793,10 @@ ecma_builtin_json_walk (ecma_object_t *reviver_p, /**< reviver function */
    /*
     * The completion value can be anything including exceptions.
     */
-    ret_value = ecma_op_function_call (reviver_p,
-                                       ecma_make_object_value (holder_p),
-                                       arguments_list,
-                                       2);
+    ret_value = ecma_op_function_call_array_args (reviver_p,
+                                                  ecma_make_object_value (holder_p),
+                                                  arguments_list,
+                                                  2);
   }
   else
   {
@@ -1353,7 +1353,7 @@ ecma_builtin_json_str (ecma_string_t *key_p, /**< property key*/
       ecma_object_t *toJSON_obj_p = ecma_get_object_from_value (toJSON);
 
       ECMA_TRY_CATCH (func_ret_val,
-                      ecma_op_function_call (toJSON_obj_p, my_val, call_args, 1),
+                      ecma_op_function_call_array_args (toJSON_obj_p, my_val, call_args, 1),
                       ret_value);
 
       ecma_free_value (my_val, true);
@@ -1375,7 +1375,7 @@ ecma_builtin_json_str (ecma_string_t *key_p, /**< property key*/
     ecma_value_t call_args[] = { key_value, my_val };
 
     ECMA_TRY_CATCH (func_ret_val,
-                    ecma_op_function_call (context_p->replacer_function_p, holder_value, call_args, 2),
+                    ecma_op_function_call_array_args (context_p->replacer_function_p, holder_value, call_args, 2),
                     ret_value);
 
     ecma_free_value (my_val, true);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.cpp
@@ -110,7 +110,7 @@ ecma_builtin_object_prototype_object_to_locale_string (ecma_value_t this_arg) /*
   {
     /* 4. */
     ecma_object_t *to_string_func_obj_p = ecma_get_object_from_value (to_string_val);
-    return_value = ecma_op_function_call (to_string_func_obj_p, this_arg, NULL, 0);
+    return_value = ecma_op_function_call (to_string_func_obj_p, this_arg, NULL);
   }
   ECMA_FINALIZE (to_string_val);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.cpp
@@ -1045,10 +1045,10 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
       arguments_list[length + 1] = ecma_copy_value (context_p->input_string, true);
 
       ECMA_TRY_CATCH (result_value,
-                      ecma_op_function_call (context_p->replace_function_p,
-                                             context_p->regexp_or_search_string,
-                                             arguments_list,
-                                             length + 2),
+                      ecma_op_function_call_array_args (context_p->replace_function_p,
+                                                        context_p->regexp_or_search_string,
+                                                        arguments_list,
+                                                        length + 2),
                       ret_value);
 
       ECMA_TRY_CATCH (to_string_value,

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -41,12 +41,10 @@ extern void ecma_finalize_builtins (void);
 extern ecma_completion_value_t
 ecma_builtin_dispatch_call (ecma_object_t *obj_p,
                             ecma_value_t this_arg,
-                            const ecma_value_t *arguments_list_p,
-                            ecma_length_t arguments_list_len);
+                            ecma_collection_header_t *arg_collection_p);
 extern ecma_completion_value_t
 ecma_builtin_dispatch_construct (ecma_object_t *obj_p,
-                                 const ecma_value_t *arguments_list_p,
-                                 ecma_length_t arguments_list_len);
+                                 ecma_collection_header_t *arg_collection_p);
 extern ecma_property_t*
 ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p,
                                           ecma_string_t *string_p);

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -42,13 +42,18 @@ ecma_op_create_external_function_object (ecma_external_pointer_t code_p);
 extern ecma_completion_value_t
 ecma_op_function_call (ecma_object_t *func_obj_p,
                        ecma_value_t this_arg_value,
-                       const ecma_value_t* arguments_list_p,
-                       ecma_length_t arguments_list_len);
+                       ecma_collection_header_t *arg_collection_p);
+
+extern ecma_completion_value_t
+ecma_op_function_call_array_args (ecma_object_t *func_obj_p,
+                                  ecma_value_t this_arg_value,
+                                  const ecma_value_t* arguments_list_p,
+                                  ecma_length_t arguments_list_len);
+
 
 extern ecma_completion_value_t
 ecma_op_function_construct (ecma_object_t *func_obj_p,
-                            const ecma_value_t* arguments_list_p,
-                            ecma_length_t arguments_list_len);
+                            ecma_collection_header_t *arg_collection_p);
 
 extern ecma_completion_value_t
 ecma_op_function_has_instance (ecma_object_t *func_obj_p,

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -30,8 +30,7 @@ extern bool ecma_op_is_callable (ecma_value_t value);
 extern bool ecma_is_constructor (ecma_value_t value);
 
 extern ecma_object_t*
-ecma_op_create_function_object (ecma_string_t* formal_parameter_list_p[],
-                                ecma_length_t formal_parameters_number,
+ecma_op_create_function_object (ecma_collection_header_t *formal_params_collection_p,
                                 ecma_object_t *scope_p,
                                 bool is_strict,
                                 bool do_instantiate_arguments_object,
@@ -60,8 +59,7 @@ ecma_op_function_declaration (ecma_object_t *lex_env_p,
                               ecma_string_t *function_name_p,
                               const vm_instr_t *instrs_p,
                               vm_instr_counter_t function_code_opcode_idx,
-                              ecma_string_t* formal_parameter_list_p[],
-                              ecma_length_t formal_parameter_list_length,
+                              ecma_collection_header_t *formal_params_collection_p,
                               bool is_strict,
                               bool do_instantiate_arguments_object,
                               bool is_configurable_bindings);

--- a/jerry-core/ecma/operations/ecma-get-put-value.cpp
+++ b/jerry-core/ecma/operations/ecma-get-put-value.cpp
@@ -146,8 +146,7 @@ ecma_op_get_value_object_base (ecma_reference_t ref) /**< ECMA-reference */
         // 7.
         ret_value = ecma_op_function_call (obj_p,
                                            base,
-                                           NULL,
-                                           0);
+                                           NULL);
       }
     }
 
@@ -324,7 +323,7 @@ ecma_op_put_value_object_base (ecma_reference_t ref, /**< ECMA-reference */
         JERRY_ASSERT (setter_p != NULL);
 
         ECMA_TRY_CATCH (call_ret,
-                        ecma_op_function_call (setter_p, base, &value, 1),
+                        ecma_op_function_call_array_args (setter_p, base, &value, 1),
                         ret_value);
 
         ret_value = ecma_make_empty_completion_value ();

--- a/jerry-core/ecma/operations/ecma-objects-arguments.cpp
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.cpp
@@ -138,6 +138,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
       MEM_DEFINE_LOCAL_ARRAY (formal_params, formal_params_number, ecma_string_t *);
 
       JERRY_ASSERT (formal_params_iterator.current_value_p == NULL);
+
       uint32_t param_index;
       for (param_index = 0;
            ecma_collection_iterator_next (&formal_params_iterator);
@@ -149,10 +150,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
         JERRY_ASSERT (ecma_is_value_string (*formal_params_iterator.current_value_p));
         ecma_string_t *param_name_p = ecma_get_string_from_value (*formal_params_iterator.current_value_p);
 
-        /*
-         * Formal parameter list is stored in reversed order
-         */
-        formal_params[formal_params_number - 1u - param_index] = param_name_p;
+        formal_params[param_index] = param_name_p;
       }
       JERRY_ASSERT (param_index == formal_params_number);
 

--- a/jerry-core/ecma/operations/ecma-objects-arguments.h
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.h
@@ -23,8 +23,7 @@ extern ecma_object_t*
 ecma_op_create_arguments_object (ecma_object_t *func_obj_p,
                                  ecma_object_t *lex_env_p,
                                  ecma_collection_header_t *formal_params_p,
-                                 const ecma_value_t *arguments_list_p,
-                                 ecma_length_t arguments_list_length,
+                                 ecma_collection_header_t *arg_collection_p,
                                  bool is_strict);
 
 extern ecma_completion_value_t ecma_op_arguments_object_get (ecma_object_t *obj_p,

--- a/jerry-core/ecma/operations/ecma-objects-general.cpp
+++ b/jerry-core/ecma/operations/ecma-objects-general.cpp
@@ -174,8 +174,7 @@ ecma_op_general_object_get (ecma_object_t *obj_p, /**< the object */
     {
       return ecma_op_function_call (getter_p,
                                     ecma_make_object_value (obj_p),
-                                    NULL,
-                                    0);
+                                    NULL);
     }
   }
 
@@ -314,10 +313,10 @@ ecma_op_general_object_put (ecma_object_t *obj_p, /**< the object */
     ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
 
     ECMA_TRY_CATCH (call_ret,
-                    ecma_op_function_call (setter_p,
-                                           ecma_make_object_value (obj_p),
-                                           &value,
-                                           1),
+                    ecma_op_function_call_array_args (setter_p,
+                                                      ecma_make_object_value (obj_p),
+                                                      &value,
+                                                      1),
                     ret_value);
 
     ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
@@ -569,7 +568,7 @@ ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
 
       call_completion = ecma_op_function_call (func_obj_p,
                                                ecma_make_object_value (obj_p),
-                                               NULL, 0);
+                                               NULL);
     }
 
     ecma_free_completion_value (function_value_get_completion);

--- a/jerry-core/jerry-internal.h
+++ b/jerry-core/jerry-internal.h
@@ -27,8 +27,7 @@ extern ecma_completion_value_t
 jerry_dispatch_external_function (ecma_object_t *function_object_p,
                                   ecma_external_pointer_t handler_p,
                                   ecma_value_t this_arg_value,
-                                  const ecma_value_t args_p[],
-                                  ecma_length_t args_count);
+                                  ecma_collection_header_t *arg_collection_p);
 
 extern void
 jerry_dispatch_object_free_callback (ecma_external_pointer_t freecb_p,

--- a/jerry-core/mem/mem-allocator.h
+++ b/jerry-core/mem/mem-allocator.h
@@ -36,7 +36,7 @@ typedef uint16_t mem_cpointer_t;
 /**
  * Representation of NULL value for compressed pointers
  */
-#define MEM_CP_NULL 0
+#define MEM_CP_NULL ((mem_cpointer_t) 0)
 
 /**
  * Required alignment for allocated units/blocks

--- a/jerry-core/vm/opcodes-ecma-support.h
+++ b/jerry-core/vm/opcodes-ecma-support.h
@@ -40,7 +40,7 @@ ecma_completion_value_t set_variable_value (vm_frame_ctx_t *, vm_instr_counter_t
 ecma_completion_value_t vm_fill_varg_list (vm_frame_ctx_t *frame_ctx_p,
                                            ecma_length_t args_number,
                                            ecma_collection_header_t *args_values_p);
-void fill_params_list (vm_frame_ctx_t *frame_ctx_p,
-                       ecma_length_t params_number,
-                       ecma_string_t* params_names[]);
+extern void vm_fill_params_list (vm_frame_ctx_t *frame_ctx_p,
+                                 ecma_length_t params_number,
+                                 ecma_collection_header_t *formal_params_collection_p);
 #endif /* OPCODES_ECMA_SUPPORT_H */

--- a/jerry-core/vm/opcodes-varg.cpp
+++ b/jerry-core/vm/opcodes-varg.cpp
@@ -70,9 +70,10 @@ vm_fill_varg_list (vm_frame_ctx_t *frame_ctx_p, /**< interpreter context */
  * Fill parameters' list
  */
 void
-fill_params_list (vm_frame_ctx_t *frame_ctx_p, /**< interpreter context */
-                  ecma_length_t params_number, /**< number of parameters */
-                  ecma_string_t* params_names[]) /**< out: parameters' names */
+vm_fill_params_list (vm_frame_ctx_t *frame_ctx_p, /**< interpreter context */
+                     ecma_length_t params_number, /**< number of parameters */
+                     ecma_collection_header_t *formal_params_collection_p) /**< collection to fill with
+                                                                            *   parameters' names */
 {
   uint32_t param_index;
   for (param_index = 0;
@@ -87,10 +88,16 @@ fill_params_list (vm_frame_ctx_t *frame_ctx_p, /**< interpreter context */
                                                                                 frame_ctx_p->instrs_p,
                                                                                 frame_ctx_p->pos);
 
-    params_names[param_index] = ecma_new_ecma_string_from_lit_cp (param_name_lit_idx);
+
+    ecma_string_t *param_name_str_p = ecma_new_ecma_string_from_lit_cp (param_name_lit_idx);
+    ecma_value_t param_name_value = ecma_make_string_value (param_name_str_p);
+
+    ecma_append_to_values_collection (formal_params_collection_p, param_name_value, false);
+
+    ecma_deref_ecma_string (param_name_str_p);
 
     frame_ctx_p->pos++;
   }
 
   JERRY_ASSERT (param_index == params_number);
-} /* fill_params_list */
+} /* vm_fill_params_list */

--- a/jerry-core/vm/opcodes.cpp
+++ b/jerry-core/vm/opcodes.cpp
@@ -478,8 +478,7 @@ opfunc_var_decl (vm_instr_t instr, /**< instruction */
 static ecma_completion_value_t
 function_declaration (vm_frame_ctx_t *frame_ctx_p, /**< interpreter context */
                       lit_cpointer_t function_name_lit_cp, /**< compressed pointer to literal with function name */
-                      ecma_string_t* args_names[], /**< names of arguments */
-                      ecma_length_t args_number) /**< number of arguments */
+                      ecma_collection_header_t *formal_params_collection_p) /** formal parameters collection */
 {
   bool is_strict = frame_ctx_p->is_strict;
   bool do_instantiate_arguments_object = true;
@@ -510,8 +509,7 @@ function_declaration (vm_frame_ctx_t *frame_ctx_p, /**< interpreter context */
                                                                     function_name_string_p,
                                                                     frame_ctx_p->instrs_p,
                                                                     frame_ctx_p->pos,
-                                                                    args_names,
-                                                                    args_number,
+                                                                    formal_params_collection_p,
                                                                     is_strict,
                                                                     do_instantiate_arguments_object,
                                                                     is_configurable_bindings);
@@ -543,23 +541,13 @@ opfunc_func_decl_n (vm_instr_t instr, /**< instruction */
 
   ecma_completion_value_t ret_value;
 
-  MEM_DEFINE_LOCAL_ARRAY (params_names, params_number, ecma_string_t*);
+  ecma_collection_header_t *formal_params_collection_p = ecma_new_values_collection (NULL, 0, false);
 
-  fill_params_list (frame_ctx_p, params_number, params_names);
+  vm_fill_params_list (frame_ctx_p, params_number, formal_params_collection_p);
 
   ret_value = function_declaration (frame_ctx_p,
                                     function_name_lit_cp,
-                                    params_names,
-                                    params_number);
-
-  for (uint32_t param_index = 0;
-       param_index < params_number;
-       param_index++)
-  {
-    ecma_deref_ecma_string (params_names[param_index]);
-  }
-
-  MEM_FINALIZE_LOCAL_ARRAY (params_names);
+                                    formal_params_collection_p);
 
   return ret_value;
 } /* opfunc_func_decl_n */
@@ -587,9 +575,9 @@ opfunc_func_expr_n (vm_instr_t instr, /**< instruction */
 
   vm_instr_counter_t function_code_end_oc;
 
-  MEM_DEFINE_LOCAL_ARRAY (params_names, params_number, ecma_string_t*);
+  ecma_collection_header_t *formal_params_collection_p = ecma_new_values_collection (NULL, 0, false);
 
-  fill_params_list (frame_ctx_p, params_number, params_names);
+  vm_fill_params_list (frame_ctx_p, params_number, formal_params_collection_p);
 
   bool is_strict = frame_ctx_p->is_strict;
   bool do_instantiate_arguments_object = true;
@@ -634,8 +622,7 @@ opfunc_func_expr_n (vm_instr_t instr, /**< instruction */
     ecma_ref_object (scope_p);
   }
 
-  ecma_object_t *func_obj_p = ecma_op_create_function_object (params_names,
-                                                              params_number,
+  ecma_object_t *func_obj_p = ecma_op_create_function_object (formal_params_collection_p,
                                                               scope_p,
                                                               is_strict,
                                                               do_instantiate_arguments_object,
@@ -656,15 +643,6 @@ opfunc_func_expr_n (vm_instr_t instr, /**< instruction */
 
   ecma_deref_object (func_obj_p);
   ecma_deref_object (scope_p);
-
-  for (uint32_t param_index = 0;
-       param_index < params_number;
-       param_index++)
-  {
-    ecma_deref_ecma_string (params_names[param_index]);
-  }
-
-  MEM_FINALIZE_LOCAL_ARRAY (params_names);
 
   frame_ctx_p->pos = function_code_end_oc;
 


### PR DESCRIPTION
Performance measurements (ff580ca33ecb49bda044c6f975c7603443b63f02 -> 778fc1b1bde2d8fb3d0c2fbd4c277846bc346800):

Benchmark | Rss <br>(positive percent is improvement) | Perf <br>(positive percent is improvement)
------------ | ------------- | -------------
                                ./sunspider-0.9.1/3d-cube.js |    0.000% |  +2.781% | 
                    ./sunspider-0.9.1/access-binary-trees.js |    0.000% |   +15.097% | 
                        ./sunspider-0.9.1/access-fannkuch.js |     0.000% |  -1.277% | 
                           ./sunspider-0.9.1/access-nbody.js |    0.000% |  -2.017% | 
               ./sunspider-0.9.1/bitops-3bit-bits-in-byte.js |     0.000% |   +0.854% | 
                    ./sunspider-0.9.1/bitops-bits-in-byte.js |    0.000% |  -2.249% | 
                     ./sunspider-0.9.1/bitops-bitwise-and.js |     -16.667% |  -5.766% | 
                  ./sunspider-0.9.1/controlflow-recursive.js |   +8.621% |  +14.039% | 
                      ./sunspider-0.9.1/date-format-xparb.js |    0.000% |  -0.214% | 
                            ./sunspider-0.9.1/math-cordic.js |     +8.333% |  +1.765% | 
                      ./sunspider-0.9.1/math-partial-sums.js |    -11.111% | -10.592% | 
                     ./sunspider-0.9.1/math-spectral-norm.js |     0.000% |  +2.366% | 
                                              Geometric mean |                          -0.689% |                          +1.4864%

The patch partially restores performance of `./sunspider-0.9.1/access-binary-trees.js` benchmarks, reduced after merging #509 (both of the performance changes on the benchmark mostly relate to #535).