### PR TITLE
Fix 'property_p != NULL' assertion fail in RegExp

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.cpp
+++ b/jerry-core/ecma/base/ecma-helpers.cpp
@@ -829,8 +829,12 @@ ecma_free_internal_property (ecma_property_t *property_p) /**< the property */
     }
     case ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE:
     {
-      void *bytecode_p = ECMA_GET_NON_NULL_POINTER (void, property_value);
-      mem_heap_free_block (bytecode_p);
+      void *bytecode_p = ECMA_GET_POINTER (void, property_value);
+
+      if (bytecode_p)
+      {
+        mem_heap_free_block (bytecode_p);
+      }
     }
   }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.cpp
@@ -167,8 +167,18 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ECMA_SET_POINTER (prim_value_prop_p->u.internal_property.value, prim_prop_num_value_p);
       break;
     }
-#endif /* CONFIG_ECMA_COMPACT_PROFILE_DISABLE_DATE_BUILTIN */
+#endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_DATE_BUILTIN */
 
+#ifndef CONFIG_ECMA_COMPACT_PROFILE_DISABLE_REGEXP_BUILTIN
+    case ECMA_BUILTIN_ID_REGEXP_PROTOTYPE:
+    {
+      ecma_property_t *bytecode_prop_p;
+      bytecode_prop_p = ecma_create_internal_property (object_obj_p,
+                                                       ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
+      bytecode_prop_p->u.internal_property.value = ECMA_NULL_POINTER;
+      break;
+    }
+#endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_REGEXP_BUILTIN */
     default:
     {
       break;

--- a/jerry-core/ecma/operations/ecma-regexp-object.h
+++ b/jerry-core/ecma/operations/ecma-regexp-object.h
@@ -59,6 +59,11 @@ ecma_regexp_exec_helper (ecma_value_t, ecma_value_t, bool);
 extern ecma_char_t
 re_canonicalize (ecma_char_t ch,
                  bool is_ignorecase);
+extern void
+re_set_result_array_properties (ecma_object_t *array_obj_p,
+                                ecma_string_t *input_str_p,
+                                uint32_t num_of_elements,
+                                int32_t index);
 
 /**
  * @}

--- a/tests/jerry/regression-test-issue-312.js
+++ b/tests/jerry/regression-test-issue-312.js
@@ -1,0 +1,21 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var res = RegExp.prototype.exec(10);
+
+assert (res[0] === "");
+assert (res.input === "10");
+assert (res.index === 0);
+assert (res.length === 1);


### PR DESCRIPTION
Related issue: #312

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com