### PR TITLE
Fix hoisting of function declaration from function expression

### DIFF
--- a/jerry-core/parser/js/opcodes-dumper.cpp
+++ b/jerry-core/parser/js/opcodes-dumper.cpp
@@ -1269,19 +1269,14 @@ dump_function_end_for_rewrite (void)
 }
 
 void
-rewrite_function_end (varg_list_type vlt)
+rewrite_function_end ()
 {
   vm_instr_counter_t oc;
-  if (vlt == VARG_FUNC_DECL)
   {
     oc = (vm_instr_counter_t) (get_diff_from (STACK_TOP (function_ends))
                                + serializer_count_instrs_in_subscopes ());
   }
-  else
-  {
-    JERRY_ASSERT (vlt == VARG_FUNC_EXPR);
-    oc = (vm_instr_counter_t) (get_diff_from (STACK_TOP (function_ends)));
-  }
+
   idx_t id1, id2;
   split_instr_counter (oc, &id1, &id2);
   const vm_instr_t instr = getop_meta (OPCODE_META_TYPE_FUNCTION_END, id1, id2);

--- a/jerry-core/parser/js/opcodes-dumper.h
+++ b/jerry-core/parser/js/opcodes-dumper.h
@@ -93,7 +93,7 @@ operand dump_prop_getter_res (operand, operand);
 void dump_prop_setter (operand, operand, operand);
 
 void dump_function_end_for_rewrite (void);
-void rewrite_function_end (varg_list_type);
+void rewrite_function_end ();
 
 void dump_this (operand);
 operand dump_this_res (void);

--- a/jerry-core/parser/js/serializer.h
+++ b/jerry-core/parser/js/serializer.h
@@ -29,6 +29,7 @@ vm_instr_t serializer_get_instr (const vm_instr_t*, vm_instr_counter_t);
 lit_cpointer_t serializer_get_literal_cp_by_uid (uint8_t, const vm_instr_t*, vm_instr_counter_t);
 void serializer_set_strings_buffer (const ecma_char_t *);
 void serializer_set_scope (scopes_tree);
+void serializer_dump_subscope (scopes_tree);
 const vm_instr_t *serializer_merge_scopes_into_bytecode (void);
 void serializer_dump_op_meta (op_meta);
 vm_instr_counter_t serializer_get_current_instr_counter (void);

--- a/tests/jerry/function-scopes.js
+++ b/tests/jerry/function-scopes.js
@@ -1,0 +1,36 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  (function() {
+    function decl() {}
+  })();
+  decl();
+  assert(false);
+} catch (e) {
+  assert(e instanceof ReferenceError);
+}
+
+try {
+  var o = {
+    get p() {
+      function decl() {
+      }
+    }
+  };
+  decl();
+  assert(false);
+} catch (e) {
+  assert(e instanceof ReferenceError);
+}


### PR DESCRIPTION
This patch solves issue with hoisting of function declarations. 

For example, it appears in the following code:
```
(function() {
  function decl() {}
})();

decl();
```
In corresponding bytecode `decl` becomes available out of function expression's scope:
```
  0:                 meta   12    6          // [no 'arguments'] [no 'eval'] 
  1:         reg_var_decl  128               // var tmp128 .. tmp131;
  2:          func_decl_n    0               // function decl ();
  3:                 meta    7    0          // function end: 7;
  4:                 meta   12    6          // [no 'arguments'] [no 'eval']
  5:         reg_var_decl  128               // var tmp128 .. tmp130;
  6:                  ret                    // ret;
  7:          func_expr_n  130  255          // tmp130 = function ();
  8:                 meta    7    0          // function end: 12;
  9:                 meta   12    6          // [no 'arguments'] [no 'eval'] 
 10:         reg_var_decl  128               // var tmp128 .. tmp130;
 11:                  ret                    // ret;
 12:               call_n  131  130          // 
 13:               call_n  130    0          // 
 14:                  ret                    // ret;
```

The patch fixes the issue, so that resulting bytecode is:
```
  0:                 meta   12    6          // [no 'arguments'] [no 'eval'] 
  1:         reg_var_decl  128               // var tmp128 .. tmp131;
  2:          func_expr_n  130  255          // tmp130 = function ();
  3:                 meta    7    0          // function end: 12;
  4:                 meta   12    6          // [no 'arguments'] [no 'eval'] 
  5:         reg_var_decl  128               // var tmp128 .. tmp130;
  6:          func_decl_n    0               // function decl ();
  7:                 meta    7    0          // function end: 11;
  8:                 meta   12    6          // [no 'arguments'] [no 'eval'] 
  9:         reg_var_decl  128               // var tmp128 .. tmp130;
 10:                  ret                    // ret;
 11:                  ret                    // ret;
 12:               call_n  131  130          // 
 13:               call_n  130    0          // 
 14:                  ret                    // ret;
```

The patch fixes ch13/13.0/S13_A19_T2.js from Test262.
