### PR TITLE
Improve performance of lit_utf8_string_calc_hash_last_bytes.

### DIFF
--- a/jerry-core/lit/lit-literal-storage.cpp
+++ b/jerry-core/lit/lit-literal-storage.cpp
@@ -235,7 +235,7 @@ lit_literal_storage_t::create_charset_record (const lit_utf8_byte_t *str, /**< s
 
   ret->set_alignment_bytes_count (alignment);
   ret->set_charset (str, buf_size);
-  ret->set_hash (lit_utf8_string_calc_hash_last_bytes (str, ret->get_length ()));
+  ret->set_hash (lit_utf8_string_calc_hash (str, ret->get_length ()));
 
   return ret;
 } /* lit_literal_storage_t::create_charset_record */
@@ -478,4 +478,3 @@ template lit_charset_record_t *rcs_recordset_t::alloc_record<lit_charset_record_
                                                                                     size_t size);
 template lit_magic_record_t *rcs_recordset_t::alloc_record<lit_magic_record_t> (rcs_record_t::type_t type);
 template lit_number_record_t *rcs_recordset_t::alloc_record<lit_number_record_t> (rcs_record_t::type_t type);
-

--- a/jerry-core/lit/lit-literal.cpp
+++ b/jerry-core/lit/lit-literal.cpp
@@ -107,7 +107,7 @@ lit_find_literal_by_utf8_string (const lit_utf8_byte_t *str_p, /**< a string to 
 {
   JERRY_ASSERT (str_p || !str_size);
 
-  lit_string_hash_t str_hash = lit_utf8_string_calc_hash_last_bytes (str_p, str_size);
+  lit_string_hash_t str_hash = lit_utf8_string_calc_hash (str_p, str_size);
 
   for (literal_t lit = lit_storage.get_first (); lit != NULL; lit = lit_storage.get_next (lit))
   {

--- a/jerry-core/lit/lit-strings.h
+++ b/jerry-core/lit/lit-strings.h
@@ -159,7 +159,8 @@ lit_utf8_size_t lit_zt_utf8_string_size (const lit_utf8_byte_t *);
 ecma_length_t lit_utf8_string_length (const lit_utf8_byte_t *, lit_utf8_size_t);
 
 /* hash */
-lit_string_hash_t lit_utf8_string_calc_hash_last_bytes (const lit_utf8_byte_t *, lit_utf8_size_t);
+lit_string_hash_t lit_utf8_string_calc_hash (const lit_utf8_byte_t *, lit_utf8_size_t);
+lit_string_hash_t lit_utf8_string_hash_combine (lit_string_hash_t, const lit_utf8_byte_t *, lit_utf8_size_t);
 
 /* code unit access */
 ecma_char_t lit_utf8_string_code_unit_at (const lit_utf8_byte_t *, lit_utf8_size_t, ecma_length_t);

--- a/tests/jerry/hash.js
+++ b/tests/jerry/hash.js
@@ -1,0 +1,24 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+a = {};
+a['12345']=1;
+a['13345']=3;
+a['sss45']=4;
+a['1'] = 2;
+
+assert (a[12345] === 1);
+assert (a[1] === 2);
+assert (a[13345] === 3);
+assert (a['sss45'] === 4);


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Evgeny Gavrin e.gavrin@samsung.com

Native build on RaspPi2

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          160->   160 (0.000) |        5.984-> 5.726 (4.311) | 
                  access-binary-trees.js |           96->    96 (0.000) |        3.082-> 3.062 (0.649) | 
                      access-fannkuch.js |           48->    48 (0.000) |       14.096->14.032 (0.454) | 
                         access-nbody.js |           68->    68 (0.000) |        6.316-> 5.816 (7.916) | 
             bitops-3bit-bits-in-byte.js |           36->    36 (0.000) |        4.742->  4.68 (1.308) | 
                  bitops-bits-in-byte.js |           36->    36 (0.000) |        6.608-> 6.608 (0.000) | 
                   bitops-bitwise-and.js |           28->    28 (0.000) |       4.056-> 4.076 (-0.493) | 
                controlflow-recursive.js |          224->   224 (0.000) |        3.578-> 3.534 (1.230) | 
                    date-format-xparb.js |          108->   108 (0.000) |        3.762->  3.43 (8.825) | 
                          math-cordic.js |           48->    48 (0.000) |        7.486->   7.3 (2.485) | 
                    math-partial-sums.js |           40->    40 (0.000) |        3.064->  2.83 (7.637) | 
                   math-spectral-norm.js |           56->    56 (0.000) |         4.19-> 3.862 (7.828) | 
                         string-fasta.js |           52->    52 (0.000) |      35.024-> 28.67 (18.142) | 
                         Geometric mean: |            RSS reduction: 0% |            Speed up: 4.7813% |
