### PR TITLE
Fix invalid preparsing of variable declarations which are not splitted by comma.

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -3026,6 +3026,12 @@ preparse_scope (bool is_global)
         }
 
         skip_newlines ();
+
+        if (!token_is (TOK_COMMA)
+            && !token_is (TOK_EQ))
+        {
+          is_in_var_declaration_list = false;
+        }
       }
       else if (is_in_var_declaration_list)
       {

--- a/tests/jerry/var-decl.js
+++ b/tests/jerry/var-decl.js
@@ -17,6 +17,7 @@ assert (y === undefined);
 assert (z === undefined);
 assert (i === undefined);
 assert (j === undefined);
+assert (k === undefined);
 assert (q === undefined);
 assert (v === undefined);
 
@@ -49,3 +50,14 @@ for (var q in {})
 }
 
 { var v = 1 }
+
+try
+{
+  var k
+  l
+  assert (false)
+}
+catch (e)
+{
+  assert (e instanceof ReferenceError);
+}


### PR DESCRIPTION
Preparser incorrectly determined end of variable declaration list, i.e. for the code:
```
var x 
y 
```
it thought that `y` also belongs to variable declaration list.

The patch fixes ch07/7.9/S7.9_A7_T7.js.

