### PR TITLE
Fix semicolon checking after variable declaration list

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -2684,6 +2684,10 @@ parse_statement (jsp_label_t *outermost_stmt_label_p) /**< outermost (first) lab
     {
       skip_newlines ();
     }
+    else
+    {
+      insert_semicolon ();
+    }
     return;
   }
   if (is_keyword (KW_FUNCTION))

--- a/tests/jerry/var-decl.js
+++ b/tests/jerry/var-decl.js
@@ -38,7 +38,7 @@ catch (e)
 }
 var x = y;
 
-do var z while (0);
+do var z; while (0);
 
 for (var i, j = function () {var p;}; i === undefined; i = null)
 {

--- a/tests/unit/test-api.cpp
+++ b/tests/unit/test-api.cpp
@@ -41,7 +41,7 @@ const char *test_source = (
                            "  return this.external ('1', true); "
                            "} "
                            "function call_throw_test() { "
-                           "  var catched = false "
+                           "  var catched = false; "
                            "  try { "
                            "    this.throw_test(); "
                            "  } catch (e) { "


### PR DESCRIPTION
Fixes the following tests from test262:
- ch08/8.4/S8.4_A13_T3.js
- ch08/8.4/S8.4_A14_T3.js