### PR TITLE
Date toString methods follow the date format used by other JS engines

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.cpp
@@ -70,7 +70,7 @@ ecma_builtin_date_prototype_to_string (ecma_value_t this_arg) /**< this argument
   }
   else
   {
-    ret_value = ecma_date_value_to_string (*prim_num_p, ECMA_DATE_LOCAL);
+    ret_value = ecma_date_value_to_string (*prim_num_p);
   }
 
   ECMA_FINALIZE (prim_value);
@@ -1136,7 +1136,7 @@ ecma_builtin_date_prototype_to_utc_string (ecma_value_t this_arg) /**< this argu
   }
   else
   {
-    ret_value = ecma_date_value_to_string (*prim_num_p, ECMA_DATE_UTC);
+    ret_value = ecma_date_value_to_utc_string (*prim_num_p);
   }
 
   ECMA_FINALIZE (prim_value);
@@ -1170,7 +1170,7 @@ ecma_builtin_date_prototype_to_iso_string (ecma_value_t this_arg) /**< this argu
   }
   else
   {
-    ret_value = ecma_date_value_to_string (*prim_num_p, ECMA_DATE_UTC);
+    ret_value = ecma_date_value_to_iso_string (*prim_num_p);
   }
 
   ECMA_FINALIZE (prim_value);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.cpp
@@ -476,7 +476,7 @@ ecma_builtin_date_dispatch_call (const ecma_value_t *arguments_list_p __attr_unu
                   ecma_builtin_date_now (ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED)),
                   ret_value);
 
-  ret_value = ecma_date_value_to_string (*ecma_get_number_from_value (now_val), ECMA_DATE_LOCAL);
+  ret_value = ecma_date_value_to_string (*ecma_get_number_from_value (now_val));
 
   ECMA_FINALIZE (now_val);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -125,7 +125,9 @@ extern void ecma_date_insert_num_with_sep (ecma_string_t **str_p,
                                            lit_magic_string_id_t magic_str_id,
                                            uint32_t length);
 
-extern ecma_completion_value_t ecma_date_value_to_string (ecma_number_t datetime_num, ecma_date_timezone_t timezone);
+extern ecma_completion_value_t ecma_date_value_to_string (ecma_number_t datetime_num);
+extern ecma_completion_value_t ecma_date_value_to_utc_string (ecma_number_t datetime_num);
+extern ecma_completion_value_t ecma_date_value_to_iso_string (ecma_number_t datetime_num);
 extern ecma_completion_value_t ecma_date_get_primitive_value (ecma_value_t this_arg);
 
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_DATE_BUILTIN */

--- a/tests/jerry/date-construct.js
+++ b/tests/jerry/date-construct.js
@@ -74,5 +74,6 @@ catch (e)
 assert (typeof Date (2015) == "string");
 assert (typeof Date() != typeof (new Date ()));
 assert (Date (Number.NaN) == Date ());
+
 // Fixme: remove this case when Date() gives the current time.
-assert (Date (2015,1,2) == "1970-01-01T00:00:00.000");
+assert (Date (2015,1,2) == "Thu Jan 01 1970 00:00:00 GMT+0000");

--- a/tests/jerry/date-tostring.js
+++ b/tests/jerry/date-tostring.js
@@ -20,8 +20,8 @@ assert (new Date (2015, 7, 1, 0, Infinity, 0) == "Invalid Date");
 assert (new Date (NaN, 1, 1, 0, 0, 0) == "Invalid Date");
 assert (new Date (2015, NaN, 1, 0, 0, 0) == "Invalid Date");
 assert (new Date (2015, 7, 1, 0, NaN, 0) == "Invalid Date");
-assert (new Date ("2015-02-13") == "2015-02-13T00:00:00.000");
-assert (new Date ("2015-07-08T11:29:05.023") == "2015-07-08T11:29:05.023");
+assert (new Date ("2015-02-13") == "Fri Feb 13 2015 00:00:00 GMT+0000");
+assert (new Date ("2015-07-08T11:29:05.023") == "Wed Jul 08 2015 11:29:05 GMT+0000");
 
 try
 {
@@ -33,6 +33,16 @@ catch (e)
   assert (e instanceof TypeError);
   assert (e.message === "Incompatible type");
 }
+
+var date = new Date(0);
+assert (date.toString() === "Thu Jan 01 1970 00:00:00 GMT+0000");
+assert (date.toUTCString() === "Thu, 01 Jan 1970 00:00:00 GMT");
+assert (date.toISOString() === "1970-01-01T00:00:00.000Z");
+
+date = new Date("2015-08-12T09:40:20.000Z")
+assert (date.toString() === "Wed Aug 12 2015 09:40:20 GMT+0000");
+assert (date.toUTCString() === "Wed, 12 Aug 2015 09:40:20 GMT");
+assert (date.toISOString() === "2015-08-12T09:40:20.000Z");
 
 assert (new Date (NaN).toDateString () == "Invalid Date");
 assert (new Date ("2015-02-13").toDateString () == "2015-02-13");
@@ -100,8 +110,8 @@ catch (e)
 }
 
 assert (new Date (NaN).toUTCString () == "Invalid Date");
-assert (new Date ("2015-07-16").toUTCString () == "2015-07-16T00:00:00.000Z");
-assert (new Date ("2015-07-16T11:29:05.023").toUTCString () == "2015-07-16T11:29:05.023Z");
+assert (new Date ("2015-07-16").toUTCString () == "Thu, 16 Jul 2015 00:00:00 GMT");
+assert (new Date ("2015-07-16T11:29:05.023").toUTCString () == "Thu, 16 Jul 2015 11:29:05 GMT");
 
 try
 {
@@ -129,7 +139,7 @@ catch (e)
 }
 
 date_time = new Date ("2015-07-08T11:29:05.023").toJSON ();
-assert (new Date (date_time) == "2015-07-08T11:29:05.023");
+assert (new Date (date_time).toISOString () == "2015-07-08T11:29:05.023Z");
 
 assert (typeof Date (2015) == "string");
 assert (typeof Date() != typeof (new Date ()));
@@ -138,7 +148,7 @@ assert (Date (2015, 1, 1) == (new Date ()).toString ());
 assert (Date (Number.NaN) == Date ());
 
 // Fixme: remove these cases when TZA and DST are supported.
-assert (new Date ("2015-07-08T11:29:05.023-02:00").toString() == "2015-07-08T13:29:05.023");
-assert (new Date ("2015-07-08T11:29:05.023-02:00").toLocaleString() == "2015-07-08T13:29:05.023");
+assert (new Date ("2015-07-08T11:29:05.023-02:00").toString () == "Wed Jul 08 2015 13:29:05 GMT+0000");
+assert (new Date ("2015-07-08T11:29:05.023-02:00").toLocaleString () == "Wed Jul 08 2015 13:29:05 GMT+0000");
 
 assert (new Date ("2015-07-08T11:29:05.023Z").toISOString() == "2015-07-08T11:29:05.023Z");


### PR DESCRIPTION
new Date(0).toString () == "Thu Jan 01 1970 00:00:00 GMT+0000"
new Date(0).toUTCString () == "Thu, 01 Jan 1970 00:00:00 GMT"
new Date(0).toISOString () == "1970-01-01T00:00:00.000Z"

Fixes S15.5.4.7_A1_T11.js test case.

JerryScript-DCO-1.0-Signed-off-by: Zoltan Herczeg zherczeg@inf.u-szeged.hu