### PR TITLE
Parse integer numbers from back to front.

### DIFF
--- a/jerry-core/parser/js/lexer.cpp
+++ b/jerry-core/parser/js/lexer.cpp
@@ -980,9 +980,10 @@ lexer_parse_number (void)
       const lit_utf8_byte_t *fp_buf_p = TOK_START ();
       /* token is constructed at end of function */
 
-      for (i = 0; i < tok_length; i++)
+      ecma_number_t mult = 1.0f;
+      for (i = tok_length; i > 0; i--, mult *= 10)
       {
-        fp_res = fp_res * 10 + (ecma_number_t) lit_char_hex_to_int (fp_buf_p[i]);
+        fp_res += (ecma_number_t) lit_char_hex_to_int (fp_buf_p[i - 1]) * mult;
       }
     }
   }

--- a/tests/jerry/arithmetics-bignums.js
+++ b/tests/jerry/arithmetics-bignums.js
@@ -22,3 +22,5 @@ assert(big == 2147483648); // overflow on 32bit numbers
 
 big++;
 assert(big == 2147483649); // overflow on 32bit numbers
+
+assert ((1152921504606846900).toString() === "1152921504606847000")


### PR DESCRIPTION
Parsing from back to front prevents precision loss in case of large numbers.
Fixes: S15.1.2.2_A7.2_T3.js