### PR TITLE
Fix for EXTERNAL compilation

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -180,6 +180,7 @@ project (JerryCore CXX C ASM)
    target_include_directories(${TARGET_NAME}.jerry-core PRIVATE ${INCLUDE_CORE})
    target_include_directories(${TARGET_NAME}.jerry-core PRIVATE ${INCLUDE_FDLIBM})
    target_include_directories(${TARGET_NAME}.jerry-core SYSTEM PRIVATE ${INCLUDE_LIBC_INTERFACE})
+   target_include_directories(${TARGET_NAME}.jerry-core SYSTEM PRIVATE ${INCLUDE_EXTERNAL_LIBS_INTERFACE})
 
    if("${BUILD_MODE}" STREQUAL "UNITTESTS")
     target_compile_definitions(${TARGET_NAME}.jerry-core INTERFACE ${DEFINES_JERRY})

--- a/third-party/fdlibm/CMakeLists.txt
+++ b/third-party/fdlibm/CMakeLists.txt
@@ -28,6 +28,13 @@ set(COMPILE_FLAGS_FDLIBM "${COMPILE_FLAGS_FDLIBM} -Wno-error=maybe-uninitialized
 set(COMPILE_FLAGS_FDLIBM "${COMPILE_FLAGS_FDLIBM} -Wno-error=unused-but-set-variable")
 set(COMPILE_FLAGS_FDLIBM "${COMPILE_FLAGS_FDLIBM} -Wno-error=unused-variable")
 set(COMPILE_FLAGS_FDLIBM "${COMPILE_FLAGS_FDLIBM} -Wno-error=conversion")
+set(COMPILE_FLAGS_FDLIBM "${COMPILE_FLAGS_FDLIBM} -Wno-sign-conversion")
+set(COMPILE_FLAGS_FDLIBM "${COMPILE_FLAGS_FDLIBM} -Wno-sign-compare")
+set(COMPILE_FLAGS_FDLIBM "${COMPILE_FLAGS_FDLIBM} -Wno-parentheses")
+set(COMPILE_FLAGS_FDLIBM "${COMPILE_FLAGS_FDLIBM} -Wno-maybe-uninitialized")
+set(COMPILE_FLAGS_FDLIBM "${COMPILE_FLAGS_FDLIBM} -Wno-unknown-pragmas")
+set(COMPILE_FLAGS_FDLIBM "${COMPILE_FLAGS_FDLIBM} -Wno-unused-but-set-variable")
+set(COMPILE_FLAGS_FDLIBM "${COMPILE_FLAGS_FDLIBM} -Wno-unused-variable")
 
 # Include directories
 set(INCLUDE_FDLIBM ${CMAKE_SOURCE_DIR}/third-party/fdlibm/include)


### PR DESCRIPTION
Two fixes for EXTERNAL mips core compilation
* disable warnings in fdlibm compilation by adding -Wno-xxxx (mips-sde-elf)
* add external libs include path for jerry-core for EXTERNAL system

