### PR TITLE
Fix assertion 'mem_pools == NULL' fail in JSON.stringify

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
@@ -1014,6 +1014,10 @@ ecma_builtin_json_stringify (ecma_value_t this_arg __attr_unused___, /**< 'this'
             ecma_append_to_values_collection (context.property_list_p, item, true);
             ecma_deref_ecma_string (ecma_get_string_from_value (item));
           }
+          else
+          {
+            ecma_free_value (item, true);
+          }
         }
 
         ECMA_FINALIZE (value);

--- a/tests/jerry/json-stringify.js
+++ b/tests/jerry/json-stringify.js
@@ -133,6 +133,8 @@ assert (JSON.stringify (object, replacer_function) == '{"c":3,"b":"JSON","a":"FO
 filter = ["a", "b"];
 assert (JSON.stringify (object, filter) == '{"a":"JSON","b":"JSON"}');
 
+assert (JSON.stringify ([], [ 'foo', 'foo' ]) === '[]');
+
 number = new Number(2.2);
 number.toString = {};
 number.valueOf = [];


### PR DESCRIPTION
We should free values that are already in the collection.