### PR TITLE
Remove two extra lexer passes

### DIFF
--- a/jerry-core/parser/js/opcodes-dumper.cpp
+++ b/jerry-core/parser/js/opcodes-dumper.cpp
@@ -2507,31 +2507,36 @@ dump_throw (operand op)
   dump_single_address (getop_throw_value, op);
 }
 
+/**
+ * Checks if variable is already declared
+ *
+ * @return true if variable declaration already exists
+ *         false otherwise
+ */
 bool
-dumper_variable_declaration_exists (lit_cpointer_t lit_id)
+dumper_variable_declaration_exists (lit_cpointer_t lit_id) /**< literal which holds variable's name */
 {
-  for (vm_instr_counter_t oc = (vm_instr_counter_t) (serializer_get_current_instr_counter () - 1);
-       oc > 0; oc--)
+  vm_instr_counter_t var_decls_count = (vm_instr_counter_t) serializer_get_current_var_decls_counter ();
+  for (vm_instr_counter_t oc = (vm_instr_counter_t) (0); oc < var_decls_count; oc++)
   {
-    const op_meta var_decl_op_meta = serializer_get_op_meta (oc);
-    if (var_decl_op_meta.op.op_idx != VM_OP_VAR_DECL)
-    {
-      break;
-    }
+    const op_meta var_decl_op_meta = serializer_get_var_decl (oc);
     if (var_decl_op_meta.lit_id[0].packed_value == lit_id.packed_value)
     {
       return true;
     }
   }
   return false;
-}
+} /* dumper_variable_declaration_exists */
 
+/**
+ * Dump instruction designating variable declaration
+ */
 void
-dump_variable_declaration (lit_cpointer_t lit_id)
+dump_variable_declaration (lit_cpointer_t lit_id) /**< literal which holds variable's name */
 {
   const vm_instr_t instr = getop_var_decl (LITERAL_TO_REWRITE);
-  serializer_dump_op_meta (create_op_meta_100 (instr, lit_id));
-}
+  serializer_dump_var_decl (create_op_meta_100 (instr, lit_id));
+} /* dump_variable_declaration */
 
 /**
  * Dump template of 'meta' instruction for scope's code flags.

--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -829,7 +829,18 @@ parse_primary_expression (void)
     case TOK_NUMBER:
     case TOK_REGEXP:
     case TOK_STRING: return parse_literal ();
-    case TOK_NAME: return literal_operand (token_data_as_lit_cp ());
+    case TOK_NAME:
+    {
+      if (lit_literal_equal_type_cstr (lit_get_literal_by_cp (token_data_as_lit_cp ()), "arguments"))
+      {
+        scopes_tree_set_arguments_used (STACK_TOP (scopes));
+      }
+      if (lit_literal_equal_type_cstr (lit_get_literal_by_cp (token_data_as_lit_cp ()), "eval"))
+      {
+        scopes_tree_set_eval_used (STACK_TOP (scopes));
+      }
+      return literal_operand (token_data_as_lit_cp ());
+    }
     case TOK_OPEN_SQUARE: return parse_array_literal ();
     case TOK_OPEN_BRACE: return parse_object_literal ();
     case TOK_OPEN_PAREN:
@@ -1812,6 +1823,15 @@ parse_variable_declaration (void)
   current_token_must_be (TOK_NAME);
   const operand name = literal_operand (token_data_as_lit_cp ());
 
+  if (!dumper_variable_declaration_exists (token_data_as_lit_cp ()))
+  {
+    jsp_early_error_check_for_eval_and_arguments_in_strict_mode (literal_operand (token_data_as_lit_cp ()),
+                                                                 is_strict_mode (),
+                                                                 tok.loc);
+
+    dump_variable_declaration (token_data_as_lit_cp ());
+  }
+
   skip_newlines ();
   if (token_is (TOK_EQ))
   {
@@ -1825,7 +1845,7 @@ parse_variable_declaration (void)
   }
 
   return name;
-}
+} /* parse_variable_declaration */
 
 /* variable_declaration_list
   : variable_declaration
@@ -2886,65 +2906,12 @@ parse_source_element (void)
 }
 
 /**
- * Skip function's optional name and parentheses
- *
- * @return: true, if skipped successfully
- *          false, if open parentheses wasn't found (this means that keyword 'function' is used as
- *                                                   a property name)
+ * Check for "use strict" in directive prologue
  */
-static bool
-skip_optional_name_and_parens (void)
-{
-  if (token_is (TOK_NAME))
-  {
-    token_after_newlines_must_be (TOK_OPEN_PAREN);
-  }
-
-  if (token_is (TOK_OPEN_PAREN))
-  {
-    skip_newlines ();
-  }
-  else
-  {
-    return false;
-  }
-
-  while (!token_is (TOK_CLOSE_PAREN))
-  {
-    skip_newlines ();
-  }
-
-  return true;
-} /* skip_optional_name_and_parens */
-
 static void
-skip_function (void)
-{
-  skip_newlines ();
-  if (skip_optional_name_and_parens ())
-  {
-    skip_newlines ();
-    jsp_skip_braces (TOK_OPEN_BRACE);
-  }
-}
-
-static bool
-var_declared (lit_cpointer_t var_cp)
-{
-  return dumper_variable_declaration_exists (var_cp);
-}
-
-static void
-preparse_scope (bool is_global)
+check_directive_prologue_for_use_strict ()
 {
   const locus start_loc = tok.loc;
-  const token_type end_tt = is_global ? TOK_EOF : TOK_CLOSE_BRACE;
-
-  vm_instr_counter_t scope_code_flags_oc = dump_scope_code_flags_for_rewrite ();
-
-  bool is_use_strict = false;
-  bool is_ref_arguments_identifier = false;
-  bool is_ref_eval_identifier = false;
 
   /*
    * Check Directive Prologue for Use Strict directive (see ECMA-262 5.1 section 14.1)
@@ -2954,7 +2921,8 @@ preparse_scope (bool is_global)
     if (lit_literal_equal_type_cstr (lit_get_literal_by_cp (token_data_as_lit_cp ()), "use strict")
         && lexer_is_no_escape_sequences_in_token_string (tok))
     {
-      is_use_strict = true;
+      scopes_tree_set_strict_mode (STACK_TOP (scopes), true);
+      lexer_set_strict_mode (scopes_tree_strict_mode (STACK_TOP (scopes)));
       break;
     }
 
@@ -2966,186 +2934,15 @@ preparse_scope (bool is_global)
     }
   }
 
-  size_t nesting_level = 0;
-  while (nesting_level > 0 || !token_is (end_tt))
-  {
-    if (token_is (TOK_OPEN_BRACE))
-    {
-      nesting_level++;
-    }
-    else if (token_is (TOK_CLOSE_BRACE))
-    {
-      nesting_level--;
-    }
-    else if (token_is (TOK_NAME))
-    {
-      if (lit_literal_equal_type_cstr (lit_get_literal_by_cp (token_data_as_lit_cp ()), "arguments"))
-      {
-        is_ref_arguments_identifier = true;
-      }
-      else if (lit_literal_equal_type_cstr (lit_get_literal_by_cp (token_data_as_lit_cp ()), "eval"))
-      {
-        is_ref_eval_identifier = true;
-      }
-    }
-
-    skip_newlines ();
-  }
-
-  opcode_scope_code_flags_t scope_flags = OPCODE_SCOPE_CODE_FLAGS__EMPTY;
-
-  if (is_use_strict)
-  {
-    scopes_tree_set_strict_mode (STACK_TOP (scopes), true);
-
-    scope_flags = (opcode_scope_code_flags_t) (scope_flags | OPCODE_SCOPE_CODE_FLAGS_STRICT);
-  }
-
-  if (!is_ref_arguments_identifier)
-  {
-    scope_flags = (opcode_scope_code_flags_t) (scope_flags | OPCODE_SCOPE_CODE_FLAGS_NOT_REF_ARGUMENTS_IDENTIFIER);
-  }
-
-  if (!is_ref_eval_identifier)
-  {
-    scope_flags = (opcode_scope_code_flags_t) (scope_flags | OPCODE_SCOPE_CODE_FLAGS_NOT_REF_EVAL_IDENTIFIER);
-  }
-
-  rewrite_scope_code_flags (scope_code_flags_oc, scope_flags);
-
-  lexer_set_strict_mode (scopes_tree_strict_mode (STACK_TOP (scopes)));
-
-  dump_reg_var_decl_for_rewrite ();
-
   if (lit_utf8_iterator_pos_cmp (start_loc, tok.loc) != 0)
   {
-    lexer_seek (start_loc);
-    skip_newlines ();
-
-    bool is_in_var_declaration_list = false;
-
-    size_t nesting_level = 0;
-    while (nesting_level > 0 || !token_is (end_tt))
-    {
-      /*
-       * FIXME:
-       *       Remove preparse_scope; move variable declaration search to main pass of parser.
-       *       When byte-code and scope storages would be introduced, move variable declarations
-       *       from byte-code to scope descriptor.
-       */
-      if (token_is (TOK_NAME))
-      {
-        if (is_in_var_declaration_list)
-        {
-          if (!var_declared (token_data_as_lit_cp ()))
-          {
-            jsp_early_error_check_for_eval_and_arguments_in_strict_mode (literal_operand (token_data_as_lit_cp ()),
-                                                                         is_strict_mode (),
-                                                                         tok.loc);
-            dump_variable_declaration (token_data_as_lit_cp ());
-          }
-        }
-
-        skip_newlines ();
-
-        if (!token_is (TOK_COMMA)
-            && !token_is (TOK_EQ))
-        {
-          is_in_var_declaration_list = false;
-        }
-      }
-      else if (is_in_var_declaration_list)
-      {
-        if (token_is (TOK_EQ))
-        {
-          skip_newlines ();
-
-          while (!token_is (end_tt)
-                 && !token_is (TOK_COMMA)
-                 && !token_is (TOK_SEMICOLON))
-          {
-            if (is_keyword (KW_FUNCTION))
-            {
-              skip_function ();
-            }
-            else if (token_is (TOK_OPEN_BRACE))
-            {
-              jsp_skip_braces (TOK_OPEN_BRACE);
-            }
-            else if (token_is (TOK_OPEN_SQUARE))
-            {
-              jsp_skip_braces (TOK_OPEN_SQUARE);
-            }
-            else if (token_is (TOK_OPEN_PAREN))
-            {
-              jsp_skip_braces (TOK_OPEN_PAREN);
-            }
-            else if (token_is (TOK_KEYWORD))
-            {
-              if (is_keyword (KW_VAR))
-              {
-                is_in_var_declaration_list = false;
-              }
-              break;
-            }
-            else if (token_is (TOK_CLOSE_BRACE))
-            {
-              /* the '}' would be handled during next iteration, reducing nesting level counter */
-              is_in_var_declaration_list = false;
-
-              break;
-            }
-
-            skip_token ();
-          }
-        }
-        else if (token_is (TOK_COMMA))
-        {
-          skip_newlines ();
-        }
-        else
-        {
-          is_in_var_declaration_list = false;
-
-          skip_newlines ();
-        }
-      }
-      else
-      {
-        if (token_is (TOK_OPEN_BRACE))
-        {
-          nesting_level++;
-        }
-        else if (token_is (TOK_CLOSE_BRACE))
-        {
-          nesting_level--;
-        }
-        else if (token_is (TOK_OPEN_SQUARE))
-        {
-          jsp_skip_braces (TOK_OPEN_SQUARE);
-        }
-        else if (is_keyword (KW_VAR))
-        {
-          is_in_var_declaration_list = true;
-        }
-        else if (is_keyword (KW_FUNCTION))
-        {
-          skip_function ();
-        }
-
-        skip_newlines ();
-      }
-    }
-
     lexer_seek (start_loc);
   }
   else
   {
-    JERRY_ASSERT (token_is (end_tt));
-
     lexer_save_token (tok);
   }
-}
+} /* check_directive_prologue_for_use_strict */
 
 /**
  * Parse source element list
@@ -3155,10 +2952,17 @@ preparse_scope (bool is_global)
  *   ;
  */
 static void
-parse_source_element_list (bool is_global) /**< flag indicating if we are parsing the global scope */
+parse_source_element_list (bool is_global) /**< flag, indicating that we parsing global context */
 {
+  const token_type end_tt = is_global ? TOK_EOF : TOK_CLOSE_BRACE;
+
   dumper_new_scope ();
-  preparse_scope (is_global);
+
+  vm_instr_counter_t scope_code_flags_oc = dump_scope_code_flags_for_rewrite ();
+
+  check_directive_prologue_for_use_strict ();
+
+  dump_reg_var_decl_for_rewrite ();
 
   if (inside_eval
       && !inside_function)
@@ -3172,7 +2976,33 @@ parse_source_element_list (bool is_global) /**< flag indicating if we are parsin
     parse_source_element ();
     skip_newlines ();
   }
+
+  if (!token_is (end_tt))
+  {
+    PARSE_ERROR (JSP_EARLY_ERROR_SYNTAX, "Unexpected token", tok.loc);
+  }
+
   lexer_save_token (tok);
+
+  opcode_scope_code_flags_t scope_flags = OPCODE_SCOPE_CODE_FLAGS__EMPTY;
+
+  scopes_tree fe_scope_tree = STACK_TOP (scopes);
+  if (fe_scope_tree->strict_mode)
+  {
+    scope_flags = (opcode_scope_code_flags_t) (scope_flags | OPCODE_SCOPE_CODE_FLAGS_STRICT);
+  }
+
+  if (!fe_scope_tree->ref_arguments)
+  {
+    scope_flags = (opcode_scope_code_flags_t) (scope_flags | OPCODE_SCOPE_CODE_FLAGS_NOT_REF_ARGUMENTS_IDENTIFIER);
+  }
+
+  if (!fe_scope_tree->ref_eval)
+  {
+    scope_flags = (opcode_scope_code_flags_t) (scope_flags | OPCODE_SCOPE_CODE_FLAGS_NOT_REF_EVAL_IDENTIFIER);
+  }
+  rewrite_scope_code_flags (scope_code_flags_oc, scope_flags);
+
   rewrite_reg_var_decl ();
   dumper_finish_scope ();
 } /* parse_source_element_list */

--- a/jerry-core/parser/js/scopes-tree.h
+++ b/jerry-core/parser/js/scopes-tree.h
@@ -39,12 +39,19 @@ typedef struct tree_header
   uint8_t children_num;
 } tree_header;
 
+/**
+ * Structure for holding scope information during parsing
+ */
 typedef struct
 {
-  tree_header t;
-  linked_list instrs;
-  vm_instr_counter_t instrs_num;
-  unsigned strict_mode:1;
+  tree_header t; /**< header */
+  linked_list instrs; /**< instructions */
+  vm_instr_counter_t instrs_count; /**< count of instructions */
+  linked_list var_decls; /**< instructions for variable declarations */
+  uint8_t var_decls_cout; /**< number of instructions for variable declarations */
+  bool strict_mode: 1; /**< flag, indicating that scope's code should be executed in strict mode */
+  bool ref_arguments: 1; /**< flag, indicating that "arguments" variable is used inside the scope */
+  bool ref_eval: 1; /**< flag, indicating that "eval" is used inside the scope */
 } scopes_tree_int;
 
 typedef scopes_tree_int * scopes_tree;
@@ -52,14 +59,19 @@ typedef scopes_tree_int * scopes_tree;
 scopes_tree scopes_tree_init (scopes_tree);
 void scopes_tree_free (scopes_tree);
 vm_instr_counter_t scopes_tree_instrs_num (scopes_tree);
+vm_instr_counter_t scopes_tree_var_decls_num (scopes_tree);
 void scopes_tree_add_op_meta (scopes_tree, op_meta);
+void scopes_tree_add_var_decl (scopes_tree, op_meta);
 void scopes_tree_set_op_meta (scopes_tree, vm_instr_counter_t, op_meta);
 void scopes_tree_set_instrs_num (scopes_tree, vm_instr_counter_t);
 op_meta scopes_tree_op_meta (scopes_tree, vm_instr_counter_t);
+op_meta scopes_tree_var_decl (scopes_tree, vm_instr_counter_t);
 size_t scopes_tree_count_literals_in_blocks (scopes_tree);
 vm_instr_counter_t scopes_tree_count_instructions (scopes_tree);
 vm_instr_t *scopes_tree_raw_data (scopes_tree, uint8_t *, size_t, lit_id_hash_table *);
 void scopes_tree_set_strict_mode (scopes_tree, bool);
+void scopes_tree_set_arguments_used (scopes_tree);
+void scopes_tree_set_eval_used (scopes_tree);
 bool scopes_tree_strict_mode (scopes_tree);
 
 #endif /* SCOPES_TREE_H */

--- a/jerry-core/parser/js/serializer.h
+++ b/jerry-core/parser/js/serializer.h
@@ -25,6 +25,7 @@
 void serializer_init ();
 void serializer_set_show_instrs (bool show_instrs);
 op_meta serializer_get_op_meta (vm_instr_counter_t);
+op_meta serializer_get_var_decl (vm_instr_counter_t);
 vm_instr_t serializer_get_instr (const vm_instr_t*, vm_instr_counter_t);
 lit_cpointer_t serializer_get_literal_cp_by_uid (uint8_t, const vm_instr_t*, vm_instr_counter_t);
 void serializer_set_strings_buffer (const ecma_char_t *);
@@ -32,7 +33,9 @@ void serializer_set_scope (scopes_tree);
 void serializer_dump_subscope (scopes_tree);
 const vm_instr_t *serializer_merge_scopes_into_bytecode (void);
 void serializer_dump_op_meta (op_meta);
+void serializer_dump_var_decl (op_meta);
 vm_instr_counter_t serializer_get_current_instr_counter (void);
+vm_instr_counter_t serializer_get_current_var_decls_counter (void);
 vm_instr_counter_t serializer_count_instrs_in_subscopes (void);
 void serializer_set_writing_position (vm_instr_counter_t);
 void serializer_rewrite_op_meta (vm_instr_counter_t, op_meta);

--- a/jerry-core/vm/opcodes.cpp
+++ b/jerry-core/vm/opcodes.cpp
@@ -1810,6 +1810,7 @@ vm_read_instr_counter_from_meta (opcode_meta_type expected_type, /**< expected t
         vm_instr_t getop_##opcode_name (void) \
         { \
           vm_instr_t instr; \
+          memset (&instr, 0, sizeof(instr)); \
           instr.op_idx = VM_OP_##opcode_name_uppercase; \
           return instr; \
         }
@@ -1817,6 +1818,7 @@ vm_read_instr_counter_from_meta (opcode_meta_type expected_type, /**< expected t
         vm_instr_t getop_##opcode_name (idx_t arg1_v) \
         { \
           vm_instr_t instr; \
+          memset (&instr, 0, sizeof(instr)); \
           instr.op_idx = VM_OP_##opcode_name_uppercase; \
           instr.data.opcode_name.arg1 = arg1_v; \
           return instr; \
@@ -1825,6 +1827,7 @@ vm_read_instr_counter_from_meta (opcode_meta_type expected_type, /**< expected t
         vm_instr_t getop_##opcode_name (idx_t arg1_v, idx_t arg2_v) \
         { \
           vm_instr_t instr; \
+          memset (&instr, 0, sizeof(instr)); \
           instr.op_idx = VM_OP_##opcode_name_uppercase; \
           instr.data.opcode_name.arg1 = arg1_v; \
           instr.data.opcode_name.arg2 = arg2_v; \


### PR DESCRIPTION
Remove preparser lexer pass (searches for variable declarations inside a scope) and pass for searching of "eval" and "arguments" literals.
