### PR TITLE
Introduce GC start heuristics for low-severity memory-back requests

### DIFF
--- a/jerry-core/config.h
+++ b/jerry-core/config.h
@@ -125,6 +125,15 @@
 // #define CONFIG_ECMA_LCACHE_DISABLE
 
 /**
+ * Share of newly allocated since last GC objects among all currently allocated objects,
+ * after achieving which, GC is started upon low severity try-give-memory-back requests.
+ *
+ * Share is calculated as the following:
+ *                1.0 / CONFIG_ECMA_GC_NEW_OBJECTS_SHARE_TO_START_GC
+ */
+#define CONFIG_ECMA_GC_NEW_OBJECTS_SHARE_TO_START_GC (16)
+
+/**
  * Link Global Environment to an empty declarative lexical environment
  * instead of lexical environment bound to Global Object.
  */


### PR DESCRIPTION
Benchmark | Rss | Perf
-------- | -------- | --------
./sunspider-1.0.2/3d-cube.js | 168 -> 168 (0.000%) | 3.07 -> 2.997 (2.378%) | 
./sunspider-1.0.2/access-binary-trees.js | 104 -> 104 (0.000%) | 2.075 -> 1.888 (9.012%) | 
./sunspider-1.0.2/access-fannkuch.js | 44 -> 44 (0.000%) | 7.305 -> 7.185 (1.643%) | 
./sunspider-1.0.2/access-nbody.js | 68 -> 68 (0.000%) | 3.287 -> 3.335 (-1.460%) | 
./sunspider-1.0.2/bitops-3bit-bits-in-byte.js | 40 -> 40 (0.000%) | 2.272 -> 2.26 (0.528%) | 
./sunspider-1.0.2/bitops-bits-in-byte.js | 40 -> 40 (0.000%) | 3.163 -> 3.1 (1.992%) | 
./sunspider-1.0.2/bitops-bitwise-and.js | 28 -> 28 (0.000%) | 1.77 -> 1.844 (-4.181%) | 
./sunspider-1.0.2/controlflow-recursive.js | 224 -> 224 (0.000%) | 1.837 -> 1.871 (-1.851%) | 
./sunspider-1.0.2/math-cordic.js | 48 -> 48 (0.000%) | 3.709 -> 3.691 (0.485%) | 
./sunspider-1.0.2/math-partial-sums.js | 40 -> 40 (0.000%) | 1.564 -> 1.615 (-3.261%) | 
./sunspider-1.0.2/math-spectral-norm.js | 56 -> 56 (0.000%) | 1.972 -> 1.993 (-1.065%) | 
Geometric mean | 0% | 0.4433%