### PR TITLE
Fix 'control reaches end of non-void function' compile error for 'noreturn'

### DIFF
--- a/jerry-core/jrt/jrt-fatals.cpp
+++ b/jerry-core/jrt/jrt-fatals.cpp
@@ -68,6 +68,11 @@ jerry_fatal (jerry_fatal_code_t code) /**< status code */
   {
     exit (code);
   }
+
+  /* to make compiler happy for some RTOS: 'control reaches end of non-void function' */
+  while (true)
+  {
+  }
 } /* jerry_fatal */
 
 /**


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: SaeHie Park saehie.park@samsung.com