### PR TITLE
Fix perf scripts

### DIFF
--- a/tools/perf.sh
+++ b/tools/perf.sh
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ITERS=$1
-ENGINE=$2
-BENCHMARK=$3
-PRINT_MIN=$4
+ITERS="$1"
+ENGINE="$2"
+BENCHMARK="$3"
+PRINT_MIN="$4"
 
-perf_values=$(( ( for i in `seq 1 1 $ITERS`; do time "$ENGINE" "$BENCHMARK"; done ) 2>&1 ) | \
+perf_values=$(( ( for i in `seq 1 1 $ITERS`; do time $ENGINE "$BENCHMARK"; done ) 2>&1 ) | \
               grep user | \
               sed 's/user[ \t]*\([0-9]*\)m\([0-9.]*\)s/\1 \2/g' | \
               awk 'BEGIN { min_v = -1; } { v = $1 * 60 + $2; if (min_v == -1 || v < min_v) { min_v = v; }; s += v; n += 1; } END { print s / n, min_v; }');

--- a/tools/run-perf-test.sh
+++ b/tools/run-perf-test.sh
@@ -40,16 +40,6 @@ REPEATS="$3"
 TIMEOUT="$4"
 BENCH_FOLDER="$5"
 
-if [ ! -x "${ENGINE_OLD}" ]
-then
-  exit_err "\"${ENGINE_OLD}\" is not an executable file..."
-fi
-
-if [ ! -x "${ENGINE_NEW}" ]
-then
-  exit_err "\"${ENGINE_NEW}\" is not an executable file..."
-fi
-
 if [ "${REPEATS}" -lt 1 ]
 then
   exit_err "REPEATS must be greater than 0"


### PR DESCRIPTION
Current scripts doesn't allow to pass engine with flags as arguments - this is the fix.

Now it's possible to do the following:
`./tools/perf.sh 5 "./jr-master --parse-only"`