### PR TITLE
Force inline of hot functions.

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-value.cpp
+++ b/jerry-core/ecma/base/ecma-helpers-value.cpp
@@ -282,7 +282,7 @@ ecma_make_object_value (const ecma_object_t* object_p) /**< object to reference 
  *
  * @return the pointer
  */
-ecma_number_t* __attr_pure___
+ecma_number_t* __attr_pure___ __attr_always_inline___
 ecma_get_number_from_value (ecma_value_t value) /**< ecma-value */
 {
   JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_NUMBER);
@@ -296,7 +296,7 @@ ecma_get_number_from_value (ecma_value_t value) /**< ecma-value */
  *
  * @return the pointer
  */
-ecma_string_t* __attr_pure___
+ecma_string_t* __attr_pure___ __attr_always_inline___
 ecma_get_string_from_value (ecma_value_t value) /**< ecma-value */
 {
   JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_STRING);
@@ -310,7 +310,7 @@ ecma_get_string_from_value (ecma_value_t value) /**< ecma-value */
  *
  * @return the pointer
  */
-ecma_object_t* __attr_pure___
+ecma_object_t* __attr_pure___ __attr_always_inline___
 ecma_get_object_from_value (ecma_value_t value) /**< ecma-value */
 {
   JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_OBJECT);


### PR DESCRIPTION
This is PoC patch and work still in progress, so ignore it for now.

Binary size:
- Before 198352 Aug 19 14:00 jr-master*
- After:  198352 Aug 19 14:43 jr-jrt*

Native build on RaspPi2:

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          164->   164 (0.000) |       5.816->5.57067 (4.218) | 
                  access-binary-trees.js |           96->    96 (0.000) |       3.088->2.98133 (3.454) | 
                      access-fannkuch.js |           48->    48 (0.000) |      14.0613->13.468 (4.219) | 
                         access-nbody.js |           76->    76 (0.000) |        6.208-> 5.952 (4.124) | 
             bitops-3bit-bits-in-byte.js |           36->    36 (0.000) |     4.61867->4.46267 (3.378) | 
                  bitops-bits-in-byte.js |           36->    36 (0.000) |     6.59733->6.30933 (4.365) | 
                   bitops-bitwise-and.js |           28->    28 (0.000) |      4.01333->   3.9 (2.824) | 
                controlflow-recursive.js |         224->   228 (-1.786) |     3.56667->3.43067 (3.813) | 
                    date-format-xparb.js |          112->   112 (0.000) |       3.784->3.72933 (1.445) | 
                          math-cordic.js |           48->    48 (0.000) |      7.37067-> 7.052 (4.324) | 
                    math-partial-sums.js |           40->    40 (0.000) |       3.004->2.91867 (2.841) | 
                   math-spectral-norm.js |           56->    56 (0.000) |      4.02267-> 3.844 (4.442) | 
                         string-fasta.js |           56->    56 (0.000) |     35.3053->35.0893 (0.612) | 
                         Geometric mean: |       RSS reduction: -0.136% |            Speed up: 3.3958% |
