### PR TITLE
Free eval's code and literal hash-table after its execution  if it does not contain functions

### DIFF
--- a/jerry-core/ecma/operations/ecma-eval.cpp
+++ b/jerry-core/ecma/operations/ecma-eval.cpp
@@ -158,6 +158,11 @@ ecma_op_eval_chars_buffer (const jerry_api_char_t *code_p, /**< code characters 
       JERRY_ASSERT (ecma_is_completion_value_throw (completion));
     }
 
+    if (!parser_is_code_contains_functions ())
+    {
+      serializer_remove_instructions (instrs_p);
+    }
+
     ecma_deref_object (lex_env_p);
     ecma_free_value (this_binding, true);
   }

--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -50,6 +50,10 @@ static token tok;
 static bool inside_eval = false;
 static bool inside_function = false;
 static bool parser_show_instrs = false;
+/**
+ * flag, indicating that code contains function declarations or function expressions
+ */
+static bool code_contains_functions = false;
 
 enum
 {
@@ -379,6 +383,8 @@ parse_property_assignment (void)
       return;
     }
 
+    code_contains_functions = true;
+
     STACK_DECLARE_USAGE (scopes);
 
     const operand name = parse_property_name ();
@@ -646,6 +652,8 @@ parse_function_declaration (void)
 {
   STACK_DECLARE_USAGE (scopes);
 
+  code_contains_functions = true;
+
   assert_keyword (KW_FUNCTION);
 
   jsp_label_t *masked_label_set_p = jsp_label_mask_set ();
@@ -700,6 +708,8 @@ parse_function_expression (void)
 {
   STACK_DECLARE_USAGE (scopes);
   assert_keyword (KW_FUNCTION);
+
+  code_contains_functions = true;
 
   operand res;
 
@@ -3031,6 +3041,7 @@ parser_parse_program (const jerry_api_char_t *source_p, /**< source code buffer 
 
   inside_function = in_function;
   inside_eval = in_eval;
+  code_contains_functions = false;
 
 #ifndef JERRY_NDEBUG
   volatile bool is_parse_finished = false;
@@ -3196,6 +3207,17 @@ parser_parse_new_function (const jerry_api_char_t **params, /**< array of argume
                                false,
                                out_instrs_p);
 } /* parser_parse_new_function */
+
+/**
+ * Indicates whether code contains functions
+ *
+ * @return true/false
+ */
+bool
+parser_is_code_contains_functions ()
+{
+  return code_contains_functions;
+} /* parser_is_code_contains_functions */
 
 /**
  * Tell parser whether to dump bytecode

--- a/jerry-core/parser/js/parser.h
+++ b/jerry-core/parser/js/parser.h
@@ -32,5 +32,6 @@ void parser_set_show_instrs (bool);
 jsp_status_t parser_parse_script (const jerry_api_char_t *, size_t, const vm_instr_t **);
 jsp_status_t parser_parse_eval (const jerry_api_char_t *, size_t, bool, const vm_instr_t **);
 jsp_status_t parser_parse_new_function (const jerry_api_char_t **, const size_t *, size_t, const vm_instr_t **);
+bool parser_is_code_contains_functions ();
 
 #endif /* PARSER_H */

--- a/jerry-core/parser/js/serializer.cpp
+++ b/jerry-core/parser/js/serializer.cpp
@@ -291,6 +291,37 @@ void serializer_set_show_instrs (bool show_instrs)
   print_instrs = show_instrs;
 }
 
+/**
+ * Deletes bytecode and associated hash table
+ */
+void
+serializer_remove_instructions (const vm_instr_t *instrs_p) /**< pointer to instructions which should be deleted */
+{
+  insts_data_header_t *prev_header = NULL;
+  const vm_instr_t *cur_instrs_p = bytecode_data.instrs_p;
+  while (cur_instrs_p != NULL)
+  {
+    insts_data_header_t *cur_header_p = GET_BYTECODE_HEADER (cur_instrs_p);
+
+    if (cur_instrs_p == instrs_p)
+    {
+      if (prev_header)
+      {
+        prev_header->next_instrs_cp = cur_header_p->next_instrs_cp;
+      }
+      else
+      {
+        bytecode_data.instrs_p = MEM_CP_GET_POINTER (vm_instr_t, cur_header_p->next_instrs_cp);
+      }
+      mem_heap_free_block (cur_header_p);
+      break;
+    }
+
+    prev_header = GET_BYTECODE_HEADER (cur_instrs_p);
+    cur_instrs_p = MEM_CP_GET_POINTER (vm_instr_t, cur_header_p->next_instrs_cp);
+  }
+} /* serializer_remove_instructions */
+
 void
 serializer_free (void)
 {

--- a/jerry-core/parser/js/serializer.h
+++ b/jerry-core/parser/js/serializer.h
@@ -39,6 +39,7 @@ vm_instr_counter_t serializer_get_current_var_decls_counter (void);
 vm_instr_counter_t serializer_count_instrs_in_subscopes (void);
 void serializer_set_writing_position (vm_instr_counter_t);
 void serializer_rewrite_op_meta (vm_instr_counter_t, op_meta);
+void serializer_remove_instructions (const vm_instr_t *instrs_p);
 void serializer_free (void);
 
 #endif // SERIALIZER_H


### PR DESCRIPTION
Fixes:
- ch07/7.4/S7.4_A5.js
- ch07/7.4/S7.4_A6.js

from test262.