### PR TITLE
Replace heap allocator's block headers with bitmap

### DIFF
--- a/jerry-core/jrt/jrt-bit-fields.cpp
+++ b/jerry-core/jrt/jrt-bit-fields.cpp
@@ -23,9 +23,9 @@
  */
 uint64_t __attr_const___
 jrt_extract_bit_field (uint64_t container, /**< container to extract bit-field from */
-                       uint32_t lsb, /**< least significant bit of the value
-                                      *   to be extracted */
-                       uint32_t width) /**< width of the bit-field to be extracted */
+                       size_t lsb, /**< least significant bit of the value
+                                    *   to be extracted */
+                       size_t width) /**< width of the bit-field to be extracted */
 {
   JERRY_ASSERT (lsb < JERRY_BITSINBYTE * sizeof (uint64_t));
   JERRY_ASSERT (width < JERRY_BITSINBYTE * sizeof (uint64_t));
@@ -45,9 +45,9 @@ jrt_extract_bit_field (uint64_t container, /**< container to extract bit-field f
 uint64_t __attr_const___
 jrt_set_bit_field_value (uint64_t container, /**< container to insert bit-field to */
                          uint64_t new_bit_field_value, /**< value of bit-field to insert */
-                         uint32_t lsb, /**< least significant bit of the value
-                                        *   to be extracted */
-                         uint32_t width) /**< width of the bit-field to be extracted */
+                         size_t lsb, /**< least significant bit of the value
+                                      *   to be extracted */
+                         size_t width) /**< width of the bit-field to be extracted */
 {
   JERRY_ASSERT (lsb < JERRY_BITSINBYTE * sizeof (uint64_t));
   JERRY_ASSERT (width < JERRY_BITSINBYTE * sizeof (uint64_t));

--- a/jerry-core/jrt/jrt-bit-fields.h
+++ b/jerry-core/jrt/jrt-bit-fields.h
@@ -16,9 +16,8 @@
 #ifndef JERRY_BIT_FIELDS_H
 #define JERRY_BIT_FIELDS_H
 
-extern uint64_t __attr_const___ jrt_extract_bit_field (uint64_t value, uint32_t lsb,
-                                                           uint32_t width);
+extern uint64_t __attr_const___ jrt_extract_bit_field (uint64_t value, size_t lsb, size_t width);
 extern uint64_t __attr_const___ jrt_set_bit_field_value (uint64_t value, uint64_t bit_field_value,
-                                                             uint32_t lsb, uint32_t width);
+                                                         size_t lsb, size_t width);
 
 #endif /* !JERRY_BIT_FIELDS_H */

--- a/jerry-core/mem/mem-allocator.h
+++ b/jerry-core/mem/mem-allocator.h
@@ -128,10 +128,6 @@ extern void* mem_decompress_pointer (uintptr_t compressed_pointer);
 extern void mem_register_a_try_give_memory_back_callback (mem_try_give_memory_back_callback_t callback);
 extern void mem_unregister_a_try_give_memory_back_callback (mem_try_give_memory_back_callback_t callback);
 
-#ifndef JERRY_NDEBUG
-extern bool mem_is_heap_pointer (void *pointer);
-#endif /* !JERRY_NDEBUG */
-
 #ifdef MEM_STATS
 extern void mem_stats_reset_peak (void);
 extern void mem_stats_print (void);

--- a/jerry-core/mem/mem-config.h
+++ b/jerry-core/mem/mem-config.h
@@ -26,7 +26,7 @@
 /**
  * Size of heap
  */
-#define MEM_HEAP_AREA_SIZE ((size_t) (CONFIG_MEM_HEAP_AREA_SIZE))
+#define MEM_HEAP_SIZE ((size_t) (CONFIG_MEM_HEAP_AREA_SIZE))
 
 /**
  * Size of heap chunk

--- a/jerry-core/mem/mem-heap.h
+++ b/jerry-core/mem/mem-heap.h
@@ -39,13 +39,16 @@ typedef enum
   MEM_HEAP_ALLOC_LONG_TERM /**< allocated region most likely will not be freed soon */
 } mem_heap_alloc_term_t;
 
-extern void mem_heap_init (uint8_t *heap_start, size_t heap_size);
+extern void mem_heap_init (void);
 extern void mem_heap_finalize (void);
 extern void* mem_heap_alloc_block (size_t size_in_bytes, mem_heap_alloc_term_t alloc_term);
 extern void* mem_heap_alloc_chunked_block (mem_heap_alloc_term_t alloc_term);
 extern void mem_heap_free_block (void *ptr);
 extern void* mem_heap_get_chunked_block_start (void *ptr);
 extern size_t mem_heap_get_chunked_block_data_size (void);
+extern uintptr_t mem_heap_compress_pointer (const void *pointer);
+extern void* mem_heap_decompress_pointer (uintptr_t compressed_pointer);
+extern bool mem_is_heap_pointer (const void *pointer);
 extern size_t __attr_pure___ mem_heap_recommend_allocation_size (size_t minimum_allocation_size);
 extern void mem_heap_print (bool dump_block_headers, bool dump_block_data, bool dump_stats);
 

--- a/jerry-core/mem/mem-poolman.cpp
+++ b/jerry-core/mem/mem-poolman.cpp
@@ -629,6 +629,8 @@ mem_pools_stat_alloc_pool (void)
   {
     mem_pools_stats.global_peak_pools_count = mem_pools_stats.pools_count;
   }
+
+  mem_pools_stats.free_chunks += MEM_POOL_CHUNKS_NUMBER;
 } /* mem_pools_stat_alloc_pool */
 
 /**
@@ -637,6 +639,10 @@ mem_pools_stat_alloc_pool (void)
 static void
 mem_pools_stat_free_pool (void)
 {
+  JERRY_ASSERT (mem_pools_stats.free_chunks >= MEM_POOL_CHUNKS_NUMBER);
+
+  mem_pools_stats.free_chunks -= MEM_POOL_CHUNKS_NUMBER;
+
   JERRY_ASSERT (mem_pools_stats.pools_count > 0);
 
   mem_pools_stats.pools_count--;

--- a/tests/unit/test-heap.cpp
+++ b/tests/unit/test-heap.cpp
@@ -21,7 +21,7 @@
 #define test_heap_size (32 * 1024)
 
 // Iterations count
-#define test_iters (64 * 1024)
+#define test_iters (4 * 1024)
 
 // Subiterations count
 #define test_sub_iters 32
@@ -75,16 +75,13 @@ test_heap_give_some_memory_back (mem_try_give_memory_back_severity_t severity)
   }
 } /* test_heap_give_some_memory_back */
 
-uint8_t test_native_heap[test_heap_size] __attribute__ ((aligned (JERRY_MAX (MEM_ALIGNMENT,
-                                                                             MEM_HEAP_CHUNK_SIZE))));
-
 int
 main (int __attr_unused___ argc,
       char __attr_unused___ **argv)
 {
   TEST_INIT ();
 
-  mem_heap_init (test_native_heap, sizeof (test_native_heap));
+  mem_heap_init ();
 
   mem_register_a_try_give_memory_back_callback (test_heap_give_some_memory_back);
 


### PR DESCRIPTION
                                                   Benchmark |                              Rss |                             Perf
-------- | -------- | --------
                                ./sunspider-1.0.2/3d-cube.js |    164 ->    132 (19.512%) |  2.094 ->   1.94 (7.354%) | 
                    ./sunspider-1.0.2/access-binary-trees.js |     96 ->     88 (8.333%) |  1.857 ->  1.653 (10.986%) | 
                        ./sunspider-1.0.2/access-fannkuch.js |     44 ->     44 (0.000%) |  5.197 ->  5.079 (2.271%) | 
                           ./sunspider-1.0.2/access-nbody.js |     64 ->     64 (0.000%) |  2.574 ->  2.526 (1.865%) | 
               ./sunspider-1.0.2/bitops-3bit-bits-in-byte.js |     36 ->     36 (0.000%) |   1.59 ->  1.568 (1.384%) | 
                    ./sunspider-1.0.2/bitops-bits-in-byte.js |     36 ->     36 (0.000%) |    2.1 ->  2.038 (2.952%) | 
                     ./sunspider-1.0.2/bitops-bitwise-and.js |     28 ->     28 (0.000%) |  2.003 ->  2.013 (-0.499%) | 
                  ./sunspider-1.0.2/controlflow-recursive.js |    224 ->    212 (5.357%) |  1.991 ->  1.695 (14.867%) | 
                      ./sunspider-1.0.2/date-format-xparb.js |    112 ->     96 (14.286%) |  1.971 ->  1.791 (9.132%) | 
                            ./sunspider-1.0.2/math-cordic.js |     44 ->     40 (9.091%) |  2.448 ->  2.387 (2.492%) | 
                      ./sunspider-1.0.2/math-partial-sums.js |     40 ->     40 (0.000%) |  1.423 ->  1.431 (-0.562%) | 
                     ./sunspider-1.0.2/math-spectral-norm.js |     52 ->     48 (7.692%) |  1.744 ->  1.621 (7.053%) | 
                           ./sunspider-1.0.2/string-fasta.js |     52 ->     52 (0.000%) | 15.675 -> 15.469 (1.314%) | 
                                              Geometric mean |                          5.1594% |                           4.776%