### PR TITLE
Remove incorrect package

### DIFF
--- a/02.how-to.md
+++ b/02.how-to.md
@@ -35,7 +35,7 @@ These tools are required for development:
 
 {% highlight bash %}
 sudo apt-get install gcc g++
-sudo apt-get install gcc-arm-none-eabi g++-arm-none-eabi
+sudo apt-get install gcc-arm-none-eabi
 sudo apt-get install cmake
 sudo apt-get install libpcre3 libpcre3-dev
 sudo apt-get install tcl8.6 tcl8.6-dev tk8.6-dev libboost-all-dev


### PR DESCRIPTION
g++-arm-none-eabi is not in package list. so someone can be confused by this.
Actually, g++ is contained in gcc-arm-none-eabi.