### PR TITLE
Change internal encoding of strings to CESU-8

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-conversion.cpp
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.cpp
@@ -354,15 +354,16 @@ ecma_utf8_string_to_number (const lit_utf8_byte_t *str_p, /**< utf-8 string */
     return ECMA_NUMBER_ZERO;
   }
 
-  lit_utf8_iterator_t iter = lit_utf8_iterator_create (str_p, str_size);
+  lit_utf8_byte_t *str_curr_p = (lit_utf8_byte_t *) str_p;
+  const lit_utf8_byte_t *str_end_p = str_p + str_size;
   ecma_char_t code_unit;
 
-  while (!lit_utf8_iterator_is_eos (&iter))
+  while (str_curr_p < str_end_p)
   {
-    code_unit = lit_utf8_iterator_peek_next (&iter);
+    code_unit = lit_utf8_peek_next (str_curr_p);
     if (lit_char_is_white_space (code_unit) || lit_char_is_line_terminator (code_unit))
     {
-      lit_utf8_iterator_incr (&iter);
+      lit_utf8_incr (&str_curr_p);
     }
     else
     {
@@ -370,17 +371,15 @@ ecma_utf8_string_to_number (const lit_utf8_byte_t *str_p, /**< utf-8 string */
     }
   }
 
-  JERRY_ASSERT (!iter.buf_pos.is_non_bmp_middle);
-  const lit_utf8_byte_t *begin_p = iter.buf_p + iter.buf_pos.offset;
+  const lit_utf8_byte_t *begin_p = str_curr_p;
+  str_curr_p = (lit_utf8_byte_t *) str_end_p;
 
-  iter = lit_utf8_iterator_create (iter.buf_p + iter.buf_pos.offset, str_size - iter.buf_pos.offset);
-  lit_utf8_iterator_seek_eos (&iter);
-  while (!lit_utf8_iterator_is_bos (&iter))
+  while (str_curr_p > str_p)
   {
-    code_unit = lit_utf8_iterator_peek_prev (&iter);
+    code_unit = lit_utf8_peek_prev (str_curr_p);
     if (lit_char_is_white_space (code_unit) || lit_char_is_line_terminator (code_unit))
     {
-      lit_utf8_iterator_decr (&iter);
+      lit_utf8_decr (&str_curr_p);
     }
     else
     {
@@ -388,8 +387,7 @@ ecma_utf8_string_to_number (const lit_utf8_byte_t *str_p, /**< utf-8 string */
     }
   }
 
-  JERRY_ASSERT (!iter.buf_pos.is_non_bmp_middle);
-  const lit_utf8_byte_t *end_p = iter.buf_p + iter.buf_pos.offset - 1;
+  const lit_utf8_byte_t *end_p = str_curr_p - 1;
 
   if (begin_p > end_p)
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.cpp
@@ -48,27 +48,22 @@
  * @return NaN if cannot read from string, ToNumber() otherwise
  */
 static ecma_number_t
-ecma_date_parse_date_chars (lit_utf8_iterator_t *iter, /**< iterator of the utf8 string */
+ecma_date_parse_date_chars (lit_utf8_byte_t **str_p, /**< pointer to the cesu8 string */
+                            const lit_utf8_byte_t *str_end_p, /**< pointer to the end of the string */
                             uint32_t num_of_chars) /**< number of characters to read and convert */
 {
   JERRY_ASSERT (num_of_chars > 0);
-
-  lit_utf8_size_t copy_size = 0;
-  const lit_utf8_byte_t *str_start_p = iter->buf_p + iter->buf_pos.offset;
+  const lit_utf8_byte_t *str_start_p = *str_p;
 
   while (num_of_chars--)
   {
-    if (lit_utf8_iterator_is_eos (iter)
-        || !lit_char_is_decimal_digit (lit_utf8_iterator_peek_next (iter)))
+    if (*str_p >= str_end_p || !lit_char_is_decimal_digit (lit_utf8_read_next (str_p)))
     {
       return ecma_number_make_nan ();
     }
-
-    copy_size += lit_get_unicode_char_size_by_utf8_first_byte (*(iter->buf_p + iter->buf_pos.offset));
-    lit_utf8_iterator_incr (iter);
   }
 
-  return ecma_utf8_string_to_number (str_start_p, copy_size);
+  return ecma_utf8_string_to_number (str_start_p, (lit_utf8_size_t) (*str_p - str_start_p));
 } /* ecma_date_parse_date_chars */
 
 /**
@@ -211,10 +206,11 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
   ssize_t sz = ecma_string_to_utf8_string (date_str_p, date_start_p, (ssize_t) date_str_size);
   JERRY_ASSERT (sz >= 0);
 
-  lit_utf8_iterator_t iter = lit_utf8_iterator_create (date_start_p, date_str_size);
+  lit_utf8_byte_t *date_str_curr_p = date_start_p;
+  const lit_utf8_byte_t *date_str_end_p = date_start_p + date_str_size;
 
   /* 1. read year */
-  ecma_number_t year = ecma_date_parse_date_chars (&iter, 4);
+  ecma_number_t year = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 4);
 
   if (!ecma_number_is_nan (year)
       && year >= 0)
@@ -224,12 +220,12 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
     ecma_number_t time = ECMA_NUMBER_ZERO;
 
     /* 2. read month if any */
-    if (!lit_utf8_iterator_is_eos (&iter)
-        && lit_utf8_iterator_peek_next (&iter) == '-')
+    if (date_str_curr_p < date_str_end_p
+        && *date_str_curr_p == '-')
     {
       /* eat up '-' */
-      lit_utf8_iterator_incr (&iter);
-      month = ecma_date_parse_date_chars (&iter, 2);
+      date_str_curr_p++;
+      month = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2);
 
       if (month > 12 || month < 1)
       {
@@ -238,12 +234,12 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
     }
 
     /* 3. read day if any */
-    if (!lit_utf8_iterator_is_eos (&iter)
-        && lit_utf8_iterator_peek_next (&iter) == '-')
+    if (date_str_curr_p < date_str_end_p
+        && *date_str_curr_p == '-')
     {
       /* eat up '-' */
-      lit_utf8_iterator_incr (&iter);
-      day = ecma_date_parse_date_chars (&iter, 2);
+      date_str_curr_p++;
+      day = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2);
 
       if (day < 1 || day > 31)
       {
@@ -252,24 +248,24 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
     }
 
     /* 4. read time if any */
-    if (!lit_utf8_iterator_is_eos (&iter)
-        && lit_utf8_iterator_peek_next (&iter) == 'T')
+    if (date_str_curr_p < date_str_end_p
+        && *date_str_curr_p == 'T')
     {
+      /* eat up 'T' */
+      date_str_curr_p++;
+
       ecma_number_t hours = ECMA_NUMBER_ZERO;
       ecma_number_t minutes = ECMA_NUMBER_ZERO;
       ecma_number_t seconds = ECMA_NUMBER_ZERO;
       ecma_number_t milliseconds = ECMA_NUMBER_ZERO;
 
-      ecma_length_t num_of_visited_chars = lit_utf8_iterator_get_index (&iter);
-      ecma_length_t date_str_len = lit_utf8_string_length (iter.buf_p, iter.buf_size) - 1;
+      ecma_length_t remaining_length = lit_utf8_string_length (date_str_curr_p,
+                                                               (lit_utf8_size_t) (date_str_end_p - date_str_curr_p));
 
-      if ((date_str_len - num_of_visited_chars) >= 5)
+      if (remaining_length >= 5)
       {
-        /* eat up 'T' */
-        lit_utf8_iterator_incr (&iter);
-
         /* 4.1 read hours and minutes */
-        hours = ecma_date_parse_date_chars (&iter, 2);
+        hours = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2);
 
         if (hours < 0 || hours > 24)
         {
@@ -281,9 +277,9 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
         }
 
         /* eat up ':' */
-        lit_utf8_iterator_incr (&iter);
+        date_str_curr_p++;
 
-        minutes = ecma_date_parse_date_chars (&iter, 2);
+        minutes = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2);
 
         if (minutes < 0 || minutes > 59)
         {
@@ -291,11 +287,12 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
         }
 
         /* 4.2 read seconds if any */
-        if (!lit_utf8_iterator_is_eos (&iter) && lit_utf8_iterator_peek_next (&iter) == ':')
+        if (date_str_curr_p < date_str_end_p
+            && *date_str_curr_p == ':')
         {
           /* eat up ':' */
-          lit_utf8_iterator_incr (&iter);
-          seconds = ecma_date_parse_date_chars (&iter, 2);
+          date_str_curr_p++;
+          seconds = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2);
 
           if (seconds < 0 || seconds > 59)
           {
@@ -303,11 +300,12 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
           }
 
           /* 4.3 read milliseconds if any */
-          if (!lit_utf8_iterator_is_eos (&iter) && lit_utf8_iterator_peek_next (&iter) == '.')
+          if (date_str_curr_p < date_str_end_p
+              && *date_str_curr_p == '.')
           {
             /* eat up '.' */
-            lit_utf8_iterator_incr (&iter);
-            milliseconds = ecma_date_parse_date_chars (&iter, 3);
+            date_str_curr_p++;
+            milliseconds = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 3);
 
             if (milliseconds < 0)
             {
@@ -324,34 +322,34 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
       }
 
       /* 4.4 read timezone if any */
-      if (!lit_utf8_iterator_is_eos (&iter)
-          && lit_utf8_iterator_peek_next (&iter) == 'Z'
+      if (date_str_curr_p < date_str_end_p
+          && *date_str_curr_p == 'Z'
           && !ecma_number_is_nan (time))
       {
-        lit_utf8_iterator_incr (&iter);
+        date_str_curr_p++;
         time = ecma_date_make_time (hours, minutes, seconds, milliseconds);
       }
-      else if (!lit_utf8_iterator_is_eos (&iter)
-               && (lit_utf8_iterator_peek_next (&iter) == '+'
-                   || lit_utf8_iterator_peek_next (&iter) == '-'))
+      else if (date_str_curr_p < date_str_end_p
+               && (*date_str_curr_p == '+' || *date_str_curr_p == '-'))
       {
-        ecma_length_t num_of_visited_chars = lit_utf8_iterator_get_index (&iter);
-        ecma_length_t date_str_len = lit_utf8_string_length (iter.buf_p, iter.buf_size) - 1;
+        ecma_length_t remaining_length;
+        remaining_length = lit_utf8_string_length (date_str_curr_p,
+                                                   (lit_utf8_size_t) (date_str_end_p - date_str_curr_p)) - 1;
 
-        if ((date_str_len - num_of_visited_chars) == 5)
+        if (remaining_length == 5)
         {
           bool is_negative = false;
 
-          if (lit_utf8_iterator_peek_next (&iter) == '-')
+          if (*date_str_curr_p == '-')
           {
             is_negative = true;
           }
 
           /* eat up '+/-' */
-          lit_utf8_iterator_incr (&iter);
+          date_str_curr_p++;
 
           /* read hours and minutes */
-          hours = ecma_date_parse_date_chars (&iter, 2);
+          hours = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2);
 
           if (hours < 0 || hours > 24)
           {
@@ -363,9 +361,9 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
           }
 
           /* eat up ':' */
-          lit_utf8_iterator_incr (&iter);
+          date_str_curr_p++;
 
-          minutes = ecma_date_parse_date_chars (&iter, 2);
+          minutes = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2);
 
           if (minutes < 0 || minutes > 59)
           {
@@ -384,7 +382,7 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
       }
     }
 
-    if (lit_utf8_iterator_is_eos (&iter))
+    if (date_str_curr_p >= date_str_end_p)
     {
       ecma_number_t date = ecma_date_make_day (year, month - 1, day);
       *date_num_p = ecma_date_make_date (date, time);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.cpp
@@ -598,10 +598,9 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_value_t this_arg, /**
                                                (ssize_t) (original_size));
       JERRY_ASSERT (sz >= 0);
 
-      lit_utf8_iterator_t original_it = lit_utf8_iterator_create (original_str_utf8_p, original_size);
-
       ecma_length_t index = start;
-      lit_utf8_iterator_advance (&original_it, index);
+
+      lit_utf8_byte_t *original_str_curr_p = original_str_utf8_p + index;
 
       /* create utf8 string from search string */
       MEM_DEFINE_LOCAL_ARRAY (search_str_utf8_p,
@@ -613,7 +612,7 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_value_t this_arg, /**
                                                (ssize_t) (search_size));
       JERRY_ASSERT (sz >= 0);
 
-      lit_utf8_iterator_t search_it = lit_utf8_iterator_create (search_str_utf8_p, search_size);
+      lit_utf8_byte_t *search_str_curr_p = search_str_utf8_p;
 
       /* iterate original string and try to match at each position */
       bool searching = true;
@@ -622,11 +621,11 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_value_t this_arg, /**
       {
         /* match as long as possible */
         ecma_length_t match_len = 0;
-        lit_utf8_iterator_t stored_original_it = original_it;
+        lit_utf8_byte_t *stored_original_str_curr_p = original_str_curr_p;
 
         while (match_len < search_len &&
                index + match_len < original_len &&
-               lit_utf8_iterator_read_next (&original_it) == lit_utf8_iterator_read_next (&search_it))
+               lit_utf8_read_next (&original_str_curr_p) == lit_utf8_read_next (&search_str_curr_p))
         {
           match_len++;
         }
@@ -640,14 +639,14 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_value_t this_arg, /**
         else
         {
           /* inc/dec index and update iterators and search condition */
-          lit_utf8_iterator_seek_bos (&search_it);
-          original_it = stored_original_it;
+          search_str_curr_p = search_str_utf8_p;
+          original_str_curr_p = stored_original_str_curr_p;
 
           if (firstIndex)
           {
             if ((searching = (index <= original_len - search_len)))
             {
-              lit_utf8_iterator_incr (&original_it);
+              lit_utf8_incr (&original_str_curr_p);
               index++;
             }
           }
@@ -655,7 +654,7 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_value_t this_arg, /**
           {
             if ((searching = (index > 0)))
             {
-              lit_utf8_iterator_decr (&original_it);
+              lit_utf8_decr (&original_str_curr_p);
               index--;
             }
           }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
@@ -1145,11 +1145,12 @@ ecma_builtin_json_quote (ecma_string_t *string_p) /**< string that should be quo
 
   JERRY_ASSERT (bytes_copied > 0 || !string_size);
 
-  lit_utf8_iterator_t iter = lit_utf8_iterator_create (string_buff, string_size);
+  lit_utf8_byte_t *str_p = string_buff;
+  const lit_utf8_byte_t *str_end_p = str_p + string_size;
 
-  while (!lit_utf8_iterator_is_eos (&iter))
+  while (str_p < str_end_p)
   {
-    ecma_char_t current_char = lit_utf8_iterator_read_next (&iter);
+    ecma_char_t current_char = lit_utf8_read_next (&str_p);
 
     /* 2.a */
     if (current_char == LIT_CHAR_BACKSLASH || current_char == LIT_CHAR_DOUBLE_QUOTE)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
@@ -186,7 +186,7 @@ ecma_builtin_json_parse_string (ecma_json_token_t *token_p) /**< token argument 
           }
 
           current_p += 5;
-          write_p += lit_code_point_to_utf8 (code_point, write_p);
+          write_p += lit_code_point_to_cesu8 (code_point, write_p);
           continue;
           /* FALLTHRU */
         }
@@ -198,57 +198,6 @@ ecma_builtin_json_parse_string (ecma_json_token_t *token_p) /**< token argument 
     }
     *write_p++ = *current_p++;
   }
-
-  /*
-   * Post processing surrogate pairs.
-   *
-   * The general issue is, that surrogate fragments can come from
-   * the original stream and can be constructed by \u sequences
-   * as well. We need to construct code points from them.
-   *
-   * Example: JSON.parse ('"\\ud801\udc00"') === "\ud801\udc00"
-   *          The first \u is parsed by JSON, the second is by the lexer.
-   *
-   * The rewrite happens in-place, since the write pointer is always
-   * precede the read-pointer. We also cannot create an UTF8 iterator,
-   * because the lit_is_utf8_string_valid assertion may fail.
-   */
-
-  lit_utf8_byte_t *read_p = token_p->u.string.start_p;
-  lit_utf8_byte_t *read_end_p = write_p;
-  write_p = read_p;
-
-  while (read_p < read_end_p)
-  {
-    lit_code_point_t code_point;
-    read_p += lit_read_code_point_from_utf8 (read_p,
-                                             (lit_utf8_size_t) (read_end_p - read_p),
-                                             &code_point);
-
-    /* The lit_is_code_unit_high_surrogate expects ecma_char_t argument
-       so code_points above maximum UTF16 code unit must not be tested. */
-    if (read_p < read_end_p
-        && code_point <= LIT_UTF16_CODE_UNIT_MAX
-        && lit_is_code_unit_high_surrogate ((ecma_char_t) code_point))
-    {
-      lit_code_point_t next_code_point;
-      lit_utf8_size_t next_code_point_size = lit_read_code_point_from_utf8 (read_p,
-                                                                            (lit_utf8_size_t) (read_end_p - read_p),
-                                                                            &next_code_point);
-
-      if (next_code_point <= LIT_UTF16_CODE_UNIT_MAX
-          && lit_is_code_unit_low_surrogate ((ecma_char_t) next_code_point))
-      {
-        code_point = lit_convert_surrogate_pair_to_code_point ((ecma_char_t) code_point,
-                                                               (ecma_char_t) next_code_point);
-        read_p += next_code_point_size;
-      }
-    }
-    write_p += lit_code_point_to_utf8 (code_point, write_p);
-  }
-
-  JERRY_ASSERT (lit_is_utf8_string_valid (token_p->u.string.start_p,
-                                          (lit_utf8_size_t) (write_p - token_p->u.string.start_p)));
 
   token_p->u.string.size = (lit_utf8_size_t) (write_p - token_p->u.string.start_p);
   token_p->current_p = current_p + 1;

--- a/jerry-core/ecma/operations/ecma-regexp-object.cpp
+++ b/jerry-core/ecma/operations/ecma-regexp-object.cpp
@@ -74,12 +74,13 @@ re_parse_regexp_flags (ecma_string_t *flags_str_p, /**< Input string with flags 
   ssize_t sz = ecma_string_to_utf8_string (flags_str_p, flags_start_p, (ssize_t) flags_str_size);
   JERRY_ASSERT (sz >= 0);
 
-  lit_utf8_iterator_t iter = lit_utf8_iterator_create (flags_start_p, flags_str_size);
+  lit_utf8_byte_t *flags_str_curr_p = flags_start_p;
+  const lit_utf8_byte_t *flags_str_end_p = flags_start_p + flags_str_size;
 
-  while (!lit_utf8_iterator_is_eos (&iter)
+  while (flags_str_curr_p < flags_str_end_p
          && ecma_is_completion_value_empty (ret_value))
   {
-    switch (lit_utf8_iterator_read_next (&iter))
+    switch (*flags_str_curr_p++)
     {
       case 'g':
       {
@@ -335,11 +336,13 @@ re_canonicalize (ecma_char_t ch, /**< character */
 static ecma_completion_value_t
 re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
                  re_bytecode_t *bc_p, /**< pointer to the current RegExp bytecode */
-                 lit_utf8_iterator_t iter, /**< input string iterator */
-                 lit_utf8_iterator_t *out_iter_p) /**< Output: matching substring iterator */
+                 lit_utf8_byte_t *str_p, /**< input string pointer */
+                 lit_utf8_byte_t **out_str_p) /**< Output: matching substring iterator */
 {
   ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
   re_opcode_t op;
+
+  lit_utf8_byte_t *str_curr_p = str_p;
 
   while ((op = re_get_opcode (&bc_p)))
   {
@@ -348,20 +351,20 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_MATCH:
       {
         JERRY_DDLOG ("Execute RE_OP_MATCH: match\n");
-        *out_iter_p = iter;
+        *out_str_p = str_curr_p;
         ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
         return ret_value; /* match */
       }
       case RE_OP_CHAR:
       {
-        if (lit_utf8_iterator_is_eos (&iter))
+        if (str_curr_p >= re_ctx_p->input_end_p)
         {
           return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE); /* fail */
         }
 
         bool is_ignorecase = re_ctx_p->flags & RE_FLAG_IGNORE_CASE;
         ecma_char_t ch1 = (ecma_char_t) re_get_value (&bc_p); /* Already canonicalized. */
-        ecma_char_t ch2 = re_canonicalize (lit_utf8_iterator_read_next (&iter), is_ignorecase);
+        ecma_char_t ch2 = re_canonicalize (lit_utf8_read_next (&str_curr_p), is_ignorecase);
         JERRY_DDLOG ("Character matching %d to %d: ", ch1, ch2);
 
         if (ch1 != ch2)
@@ -376,12 +379,12 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       }
       case RE_OP_PERIOD:
       {
-        if (lit_utf8_iterator_is_eos (&iter))
+        if (str_curr_p >= re_ctx_p->input_end_p)
         {
           return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE); /* fail */
         }
 
-        ecma_char_t ch = lit_utf8_iterator_read_next (&iter);
+        ecma_char_t ch = lit_utf8_read_next (&str_curr_p);
         JERRY_DDLOG ("Period matching '.' to %d: ", (uint32_t) ch);
 
         if (lit_char_is_line_terminator (ch))
@@ -397,7 +400,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       {
         JERRY_DDLOG ("Execute RE_OP_ASSERT_START: ");
 
-        if ((iter.buf_p + iter.buf_pos.offset) <= re_ctx_p->input_start_p)
+        if (str_curr_p <= re_ctx_p->input_start_p)
         {
           JERRY_DDLOG ("match\n");
           break;
@@ -409,7 +412,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
           return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE); /* fail */
         }
 
-        if (lit_char_is_line_terminator (lit_utf8_iterator_peek_prev (&iter)))
+        if (lit_char_is_line_terminator (lit_utf8_peek_prev (str_curr_p)))
         {
           JERRY_DDLOG ("match\n");
           break;
@@ -422,7 +425,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       {
         JERRY_DDLOG ("Execute RE_OP_ASSERT_END: ");
 
-        if ((iter.buf_p + iter.buf_pos.offset) >= re_ctx_p->input_end_p)
+        if (str_curr_p >= re_ctx_p->input_end_p)
         {
           JERRY_DDLOG ("match\n");
           break; /* tail merge */
@@ -434,7 +437,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
           return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE); /* fail */
         }
 
-        if (lit_char_is_line_terminator (lit_utf8_iterator_peek_next (&iter)))
+        if (lit_char_is_line_terminator (lit_utf8_peek_next (str_curr_p)))
         {
           JERRY_DDLOG ("match\n");
           break; /* tail merge */
@@ -448,22 +451,22 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       {
         bool is_wordchar_left, is_wordchar_right;
 
-        if ((iter.buf_p + iter.buf_pos.offset) <= re_ctx_p->input_start_p)
+        if (str_curr_p <= re_ctx_p->input_start_p)
         {
           is_wordchar_left = false;  /* not a wordchar */
         }
         else
         {
-          is_wordchar_left = lit_char_is_word_char (lit_utf8_iterator_peek_prev (&iter));
+          is_wordchar_left = lit_char_is_word_char (lit_utf8_peek_prev (str_curr_p));
         }
 
-        if ((iter.buf_p + iter.buf_pos.offset) >= re_ctx_p->input_end_p)
+        if (str_curr_p >= re_ctx_p->input_end_p)
         {
           is_wordchar_right = false;  /* not a wordchar */
         }
         else
         {
-          is_wordchar_right = lit_char_is_word_char (lit_utf8_iterator_peek_next (&iter));
+          is_wordchar_right = lit_char_is_word_char (lit_utf8_peek_next (str_curr_p));
         }
 
         if (op == RE_OP_ASSERT_WORD_BOUNDARY)
@@ -494,21 +497,21 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_LOOKAHEAD_NEG:
       {
         ecma_completion_value_t match_value = ecma_make_empty_completion_value ();
-        lit_utf8_iterator_t sub_iter = lit_utf8_iterator_create (NULL, 0);
+        lit_utf8_byte_t *sub_str_p = NULL;
 
         uint32_t array_size = re_ctx_p->num_of_captures + re_ctx_p->num_of_non_captures;
-        MEM_DEFINE_LOCAL_ARRAY (saved_bck_p, array_size, lit_utf8_iterator_t);
+        MEM_DEFINE_LOCAL_ARRAY (saved_bck_p, array_size, lit_utf8_byte_t *);
 
-        size_t size = (size_t) (array_size) * sizeof (lit_utf8_iterator_t);
+        size_t size = (size_t) (array_size) * sizeof (lit_utf8_byte_t *);
         memcpy (saved_bck_p, re_ctx_p->saved_p, size);
 
         do
         {
           uint32_t offset = re_get_value (&bc_p);
 
-          if (!sub_iter.buf_p)
+          if (!sub_str_p)
           {
-            match_value = re_match_regexp (re_ctx_p, bc_p, iter, &sub_iter);
+            match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
             if (ecma_is_completion_value_throw (match_value))
             {
               break;
@@ -522,11 +525,11 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         {
           JERRY_DDLOG ("Execute RE_OP_LOOKAHEAD_POS/NEG: ");
           ecma_free_completion_value (match_value);
-          if ((op == RE_OP_LOOKAHEAD_POS && sub_iter.buf_p)
-              || (op == RE_OP_LOOKAHEAD_NEG && !sub_iter.buf_p))
+          if ((op == RE_OP_LOOKAHEAD_POS && sub_str_p)
+              || (op == RE_OP_LOOKAHEAD_NEG && !sub_str_p))
           {
             JERRY_DDLOG ("match\n");
-            match_value = re_match_regexp (re_ctx_p, bc_p, iter, &sub_iter);
+            match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
           }
           else
           {
@@ -539,7 +542,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         {
           if (ecma_is_value_true (match_value))
           {
-            *out_iter_p = sub_iter;
+            *out_str_p = sub_str_p;
           }
           else
           {
@@ -559,14 +562,14 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         bool is_match;
 
         JERRY_DDLOG ("Execute RE_OP_CHAR_CLASS/RE_OP_INV_CHAR_CLASS, ");
-        if (lit_utf8_iterator_is_eos (&iter))
+        if (str_curr_p >= re_ctx_p->input_end_p)
         {
           JERRY_DDLOG ("fail\n");
           return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE); /* fail */
         }
 
         bool is_ignorecase = re_ctx_p->flags & RE_FLAG_IGNORE_CASE;
-        ecma_char_t curr_ch = re_canonicalize (lit_utf8_iterator_read_next (&iter), is_ignorecase);
+        ecma_char_t curr_ch = re_canonicalize (lit_utf8_read_next (&str_curr_p), is_ignorecase);
 
         num_of_ranges = re_get_value (&bc_p);
         is_match = false;
@@ -615,26 +618,26 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         backref_idx *= 2;  /* backref n -> saved indices [n*2, n*2+1] */
         JERRY_ASSERT (backref_idx >= 2 && backref_idx + 1 < re_ctx_p->num_of_captures);
 
-        if (!re_ctx_p->saved_p[backref_idx].buf_p || !re_ctx_p->saved_p[backref_idx + 1].buf_p)
+        if (!re_ctx_p->saved_p[backref_idx] || !re_ctx_p->saved_p[backref_idx + 1])
         {
           JERRY_DDLOG ("match\n");
           break; /* capture is 'undefined', always matches! */
         }
 
-        lit_utf8_iterator_t sub_iter = re_ctx_p->saved_p[backref_idx];
+        lit_utf8_byte_t *sub_str_p = re_ctx_p->saved_p[backref_idx];
 
-        while (sub_iter.buf_pos.offset < re_ctx_p->saved_p[backref_idx + 1].buf_pos.offset)
+        while (sub_str_p < re_ctx_p->saved_p[backref_idx + 1])
         {
           ecma_char_t ch1, ch2;
 
-          if ((iter.buf_p + iter.buf_pos.offset) >= re_ctx_p->input_end_p)
+          if (str_curr_p >= re_ctx_p->input_end_p)
           {
             JERRY_DDLOG ("fail\n");
             return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE); /* fail */
           }
 
-          ch1 = lit_utf8_iterator_read_next (&sub_iter);
-          ch2 = lit_utf8_iterator_read_next (&iter);
+          ch1 = lit_utf8_read_next (&sub_str_p);
+          ch2 = lit_utf8_read_next (&str_curr_p);
 
           if (ch1 != ch2)
           {
@@ -650,17 +653,17 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         re_bytecode_t *old_bc_p;
 
         JERRY_DDLOG ("Execute RE_OP_SAVE_AT_START\n");
-        lit_utf8_iterator_t old_start_p = re_ctx_p->saved_p[RE_GLOBAL_START_IDX];
-        re_ctx_p->saved_p[RE_GLOBAL_START_IDX] = iter;
+        lit_utf8_byte_t *old_start_p = re_ctx_p->saved_p[RE_GLOBAL_START_IDX];
+        re_ctx_p->saved_p[RE_GLOBAL_START_IDX] = str_curr_p;
 
         do
         {
           uint32_t offset = re_get_value (&bc_p);
-          lit_utf8_iterator_t sub_iter = lit_utf8_iterator_create (NULL, 0);
-          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, iter, &sub_iter);
+          lit_utf8_byte_t *sub_str_p = NULL;
+          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
           if (ecma_is_value_true (match_value))
           {
-            *out_iter_p = sub_iter;
+            *out_str_p = sub_str_p;
             return match_value; /* match */
           }
           else if (ecma_is_completion_value_throw (match_value))
@@ -679,8 +682,8 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_SAVE_AND_MATCH:
       {
         JERRY_DDLOG ("End of pattern is reached: match\n");
-        re_ctx_p->saved_p[RE_GLOBAL_END_IDX] = iter;
-        *out_iter_p = iter;
+        re_ctx_p->saved_p[RE_GLOBAL_END_IDX] = str_curr_p;
+        *out_str_p = str_curr_p;
         return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE); /* match */
       }
       case RE_OP_ALTERNATIVE:
@@ -711,8 +714,8 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         *  after the group first, if zero iteration is allowed.
         */
         uint32_t start_idx, iter_idx, offset;
-        lit_utf8_iterator_t old_start = lit_utf8_iterator_create (NULL, 0);
-        lit_utf8_iterator_t sub_iter = lit_utf8_iterator_create (NULL, 0);
+        lit_utf8_byte_t *old_start_p = NULL;
+        lit_utf8_byte_t *sub_str_p = NULL;
         re_bytecode_t *old_bc_p;
 
         old_bc_p = bc_p; /* save the bytecode start position of the group start */
@@ -725,8 +728,8 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
           iter_idx = start_idx - 1;
           start_idx *= 2;
 
-          old_start = re_ctx_p->saved_p[start_idx];
-          re_ctx_p->saved_p[start_idx] = iter;
+          old_start_p = re_ctx_p->saved_p[start_idx];
+          re_ctx_p->saved_p[start_idx] = str_curr_p;
         }
         else
         {
@@ -740,11 +743,11 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         bc_p += offset;
 
         /* Try to match after the close paren if zero is allowed */
-        ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, iter, &sub_iter);
+        ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
 
         if (ecma_is_value_true (match_value))
         {
-          *out_iter_p = sub_iter;
+          *out_str_p = sub_str_p;
           return match_value; /* match */
         }
         else if (ecma_is_completion_value_throw (match_value))
@@ -753,7 +756,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         }
         if (RE_IS_CAPTURE_GROUP (op))
         {
-          re_ctx_p->saved_p[start_idx] = old_start;
+          re_ctx_p->saved_p[start_idx] = old_start_p;
         }
 
         bc_p = old_bc_p;
@@ -765,7 +768,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_NON_CAPTURE_GREEDY_ZERO_GROUP_START:
       {
         uint32_t start_idx, iter_idx, old_iteration_cnt, offset;
-        lit_utf8_iterator_t sub_iter = lit_utf8_iterator_create (NULL, 0);
+        lit_utf8_byte_t *sub_str_p = NULL;
         re_bytecode_t *old_bc_p;
         re_bytecode_t *end_bc_p = NULL;
         start_idx = re_get_value (&bc_p);
@@ -790,18 +793,18 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
           start_idx += re_ctx_p->num_of_captures;
         }
 
-        lit_utf8_iterator_t old_start = re_ctx_p->saved_p[start_idx];
+        lit_utf8_byte_t *old_start_p = re_ctx_p->saved_p[start_idx];
         old_iteration_cnt = re_ctx_p->num_of_iterations_p[iter_idx];
-        re_ctx_p->saved_p[start_idx] = iter;
+        re_ctx_p->saved_p[start_idx] = str_curr_p;
         re_ctx_p->num_of_iterations_p[iter_idx] = 0;
 
         do
         {
           offset = re_get_value (&bc_p);
-          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, iter, &sub_iter);
+          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
           if (ecma_is_value_true (match_value))
           {
-            *out_iter_p = sub_iter;
+            *out_str_p = sub_str_p;
             return match_value; /* match */
           }
           else if (ecma_is_completion_value_throw (match_value))
@@ -820,11 +823,11 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             || op == RE_OP_NON_CAPTURE_GREEDY_ZERO_GROUP_START)
         {
           JERRY_ASSERT (end_bc_p);
-          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, end_bc_p, iter, &sub_iter);
+          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, end_bc_p, str_curr_p, &sub_str_p);
 
           if (ecma_is_value_true (match_value))
           {
-            *out_iter_p = sub_iter;
+            *out_str_p = sub_str_p;
             return match_value; /* match */
           }
           else if (ecma_is_completion_value_throw (match_value))
@@ -833,7 +836,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
           }
         }
 
-        re_ctx_p->saved_p[start_idx] = old_start;
+        re_ctx_p->saved_p[start_idx] = old_start_p;
         return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE); /* fail */
       }
       case RE_OP_CAPTURE_NON_GREEDY_GROUP_END:
@@ -870,14 +873,14 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         if (re_ctx_p->num_of_iterations_p[iter_idx] >= min
             && re_ctx_p->num_of_iterations_p[iter_idx] <= max)
         {
-          lit_utf8_iterator_t old_end = re_ctx_p->saved_p[end_idx];
-          re_ctx_p->saved_p[end_idx] = iter;
+          lit_utf8_byte_t *old_end_p = re_ctx_p->saved_p[end_idx];
+          re_ctx_p->saved_p[end_idx] = str_curr_p;
 
-          lit_utf8_iterator_t sub_iter = lit_utf8_iterator_create (NULL, 0);
-          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, iter, &sub_iter);
+          lit_utf8_byte_t *sub_str_p = NULL;
+          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
           if (ecma_is_value_true (match_value))
           {
-            *out_iter_p = sub_iter;
+            *out_str_p = sub_str_p;
             return match_value; /* match */
           }
           else if (ecma_is_completion_value_throw (match_value))
@@ -885,7 +888,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             return match_value;
           }
 
-          re_ctx_p->saved_p[end_idx] = old_end;
+          re_ctx_p->saved_p[end_idx] = old_end_p;
         }
         re_ctx_p->num_of_iterations_p[iter_idx]--;
         bc_p = old_bc_p;
@@ -897,9 +900,9 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_NON_CAPTURE_GREEDY_GROUP_END:
       {
         uint32_t start_idx, end_idx, iter_idx, min, max, offset;
-        lit_utf8_iterator_t old_start = lit_utf8_iterator_create (NULL, 0);
-        lit_utf8_iterator_t old_end = lit_utf8_iterator_create (NULL, 0);
-        lit_utf8_iterator_t sub_iter = lit_utf8_iterator_create (NULL, 0);
+        lit_utf8_byte_t *old_start_p = NULL;
+        lit_utf8_byte_t *old_end_p = NULL;
+        lit_utf8_byte_t *sub_str_p = NULL;
         re_bytecode_t *old_bc_p;
 
         end_idx = re_get_value (&bc_p);
@@ -924,8 +927,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
 
         /* Check the empty iteration if the minimum number of iterations is reached. */
         if (re_ctx_p->num_of_iterations_p[iter_idx] >= min
-            && iter.buf_p == re_ctx_p->saved_p[start_idx].buf_p
-            && iter.buf_pos.offset == re_ctx_p->saved_p[start_idx].buf_pos.offset)
+            && str_curr_p== re_ctx_p->saved_p[start_idx])
         {
           return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE); /* fail */
         }
@@ -933,21 +935,21 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         re_ctx_p->num_of_iterations_p[iter_idx]++;
 
         old_bc_p = bc_p; /* Save the bytecode end position of the END opcodes for matching after it. */
-        old_end = re_ctx_p->saved_p[end_idx];
-        re_ctx_p->saved_p[end_idx] = iter;
+        old_end_p = re_ctx_p->saved_p[end_idx];
+        re_ctx_p->saved_p[end_idx] = str_curr_p;
 
         if (re_ctx_p->num_of_iterations_p[iter_idx] < max)
         {
           bc_p -= offset;
           offset = re_get_value (&bc_p);
 
-          old_start = re_ctx_p->saved_p[start_idx];
-          re_ctx_p->saved_p[start_idx] = iter;
-          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, iter, &sub_iter);
+          old_start_p = re_ctx_p->saved_p[start_idx];
+          re_ctx_p->saved_p[start_idx] = str_curr_p;
+          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
 
           if (ecma_is_value_true (match_value))
           {
-            *out_iter_p = sub_iter;
+            *out_str_p = sub_str_p;
             return match_value; /* match */
           }
           else if (ecma_is_completion_value_throw (match_value))
@@ -955,7 +957,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             return match_value;
           }
 
-          re_ctx_p->saved_p[start_idx] = old_start;
+          re_ctx_p->saved_p[start_idx] = old_start_p;
 
           /* Try to match alternatives if any. */
           bc_p += offset;
@@ -964,14 +966,14 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             bc_p++; /* RE_OP_ALTERNATIVE */
             offset = re_get_value (&bc_p);
 
-            old_start = re_ctx_p->saved_p[start_idx];
-            re_ctx_p->saved_p[start_idx] = iter;
+            old_start_p = re_ctx_p->saved_p[start_idx];
+            re_ctx_p->saved_p[start_idx] = str_curr_p;
 
-            ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, iter, &sub_iter);
+            ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
 
             if (ecma_is_value_true (match_value))
             {
-              *out_iter_p = sub_iter;
+              *out_str_p = sub_str_p;
               return match_value; /* match */
             }
             else if (ecma_is_completion_value_throw (match_value))
@@ -979,7 +981,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
               return match_value;
             }
 
-            re_ctx_p->saved_p[start_idx] = old_start;
+            re_ctx_p->saved_p[start_idx] = old_start_p;
             bc_p += offset;
           }
         }
@@ -988,11 +990,11 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             && re_ctx_p->num_of_iterations_p[iter_idx] <= max)
         {
           /* Try to match the rest of the bytecode. */
-          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, old_bc_p, iter, &sub_iter);
+          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, old_bc_p, str_curr_p, &sub_str_p);
 
           if (ecma_is_value_true (match_value))
           {
-            *out_iter_p = sub_iter;
+            *out_str_p = sub_str_p;
             return match_value; /* match */
           }
           else if (ecma_is_completion_value_throw (match_value))
@@ -1002,14 +1004,14 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         }
 
         /* restore if fails */
-        re_ctx_p->saved_p[end_idx] = old_end;
+        re_ctx_p->saved_p[end_idx] = old_end_p;
         re_ctx_p->num_of_iterations_p[iter_idx]--;
         return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE); /* fail */
       }
       case RE_OP_NON_GREEDY_ITERATOR:
       {
         uint32_t min, max, offset, num_of_iter;
-        lit_utf8_iterator_t sub_iter = lit_utf8_iterator_create (NULL, 0);
+        lit_utf8_byte_t *sub_str_p = NULL;
 
         min = re_get_value (&bc_p);
         max = re_get_value (&bc_p);
@@ -1023,11 +1025,14 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         {
           if (num_of_iter >= min)
           {
-            ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p + offset, iter, &sub_iter);
+            ecma_completion_value_t match_value = re_match_regexp (re_ctx_p,
+                                                                   bc_p + offset,
+                                                                   str_curr_p,
+                                                                   &sub_str_p);
 
             if (ecma_is_value_true (match_value))
             {
-              *out_iter_p = sub_iter;
+              *out_str_p = sub_str_p;
               return match_value; /* match */
             }
             else if (ecma_is_completion_value_throw (match_value))
@@ -1036,7 +1041,10 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             }
           }
 
-          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, iter, &sub_iter);
+          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p,
+                                                                 bc_p,
+                                                                 str_curr_p,
+                                                                 &sub_str_p);
 
           if (!ecma_is_value_true (match_value))
           {
@@ -1048,7 +1056,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             break;
           }
 
-          iter = sub_iter;
+          str_curr_p = sub_str_p;
           num_of_iter++;
         }
         return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE); /* fail */
@@ -1056,7 +1064,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_GREEDY_ITERATOR:
       {
         uint32_t min, max, offset, num_of_iter;
-        lit_utf8_iterator_t sub_iter = lit_utf8_iterator_create (NULL, 0);
+        lit_utf8_byte_t *sub_str_p = NULL;
 
         min = re_get_value (&bc_p);
         max = re_get_value (&bc_p);
@@ -1069,7 +1077,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
 
         while (num_of_iter < max)
         {
-          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, iter, &sub_iter);
+          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
 
           if (!ecma_is_value_true (match_value))
           {
@@ -1081,17 +1089,20 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             break;
           }
 
-          iter = sub_iter;
+          str_curr_p = sub_str_p;
           num_of_iter++;
         }
 
         while (num_of_iter >= min)
         {
-          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p, bc_p + offset, iter, &sub_iter);
+          ecma_completion_value_t match_value = re_match_regexp (re_ctx_p,
+                                                                 bc_p + offset,
+                                                                 str_curr_p,
+                                                                 &sub_str_p);
 
           if (ecma_is_value_true (match_value))
           {
-            *out_iter_p = sub_iter;
+            *out_str_p = sub_str_p;
             return match_value; /* match */
           }
           else if (ecma_is_completion_value_throw (match_value))
@@ -1104,7 +1115,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             break;
           }
 
-          lit_utf8_iterator_read_prev (&iter);
+          lit_utf8_read_prev (&str_curr_p);
           num_of_iter--;
         }
         return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE); /* fail */
@@ -1236,16 +1247,22 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
   ecma_string_t *input_string_p = ecma_get_string_from_value (input_string);
   lit_utf8_size_t input_string_size = ecma_string_get_size (input_string_p);
 
-  MEM_DEFINE_LOCAL_ARRAY (input_utf8_buffer_p, input_string_size, lit_utf8_byte_t);
+  MEM_DEFINE_LOCAL_ARRAY (input_buffer_p, input_string_size, lit_utf8_byte_t);
 
-  ssize_t sz = ecma_string_to_utf8_string (input_string_p, input_utf8_buffer_p, (ssize_t) input_string_size);
+  ssize_t sz = ecma_string_to_utf8_string (input_string_p, input_buffer_p, (ssize_t) input_string_size);
   JERRY_ASSERT (sz >= 0);
 
-  lit_utf8_iterator_t iterator = lit_utf8_iterator_create (input_utf8_buffer_p, input_string_size);
+  lit_utf8_byte_t *input_curr_p = input_buffer_p;
+
+  if (!input_string_size)
+  {
+    input_curr_p = (lit_utf8_byte_t *) lit_get_magic_string_utf8 (LIT_MAGIC_STRING__EMPTY);
+  }
+  lit_utf8_byte_t *input_end_p = input_buffer_p + input_string_size;
 
   re_matcher_ctx_t re_ctx;
-  re_ctx.input_start_p = iterator.buf_p;
-  re_ctx.input_end_p = iterator.buf_p + iterator.buf_size;
+  re_ctx.input_start_p = input_buffer_p;
+  re_ctx.input_end_p = input_buffer_p + input_string_size;
 
   /* 1. Read bytecode header and init regexp matcher context. */
   re_ctx.flags = (uint8_t) re_get_value (&bc_p);
@@ -1264,15 +1281,12 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
   JERRY_ASSERT (re_ctx.num_of_captures % 2 == 0);
   re_ctx.num_of_non_captures = re_get_value (&bc_p);
 
-  /* We create an invalid iterator, that will be used to identify unused result values. */
-  lit_utf8_iterator_t unused_iter = lit_utf8_iterator_create (NULL, 0);
-  unused_iter.buf_p = (lit_utf8_byte_t *) 1;
 
-  MEM_DEFINE_LOCAL_ARRAY (saved_p, re_ctx.num_of_captures + re_ctx.num_of_non_captures, lit_utf8_iterator_t);
+  MEM_DEFINE_LOCAL_ARRAY (saved_p, re_ctx.num_of_captures + re_ctx.num_of_non_captures, lit_utf8_byte_t *);
 
   for (uint32_t i = 0; i < re_ctx.num_of_captures + re_ctx.num_of_non_captures; i++)
   {
-    saved_p[i] = unused_iter;
+    saved_p[i] = NULL;
   }
   re_ctx.saved_p = saved_p;
 
@@ -1287,9 +1301,9 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
   bool is_match = false;
   re_ctx.num_of_iterations_p = num_of_iter_p;
   int32_t index = 0;
-  ecma_length_t input_str_len = lit_utf8_string_length (iterator.buf_p, iterator.buf_size);
+  ecma_length_t input_str_len = lit_utf8_string_length (input_buffer_p, input_string_size);
 
-  if (iterator.buf_p && (re_ctx.flags & RE_FLAG_GLOBAL))
+  if (input_buffer_p && (re_ctx.flags & RE_FLAG_GLOBAL))
   {
     ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
     ecma_property_t *lastindex_prop_p = ecma_op_object_get_property (regexp_object_p, magic_str_p);
@@ -1297,19 +1311,21 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
     ECMA_OP_TO_NUMBER_TRY_CATCH (lastindex_num, lastindex_prop_p->u.named_data_property.value, ret_value)
     index = ecma_number_to_int32 (lastindex_num);
 
-    JERRY_ASSERT (iterator.buf_pos.offset == 0 && !iterator.buf_pos.is_non_bmp_middle);
-    if (!lit_utf8_iterator_is_eos (&iterator)
+    if (input_curr_p < input_end_p
         && index <= (int32_t) input_str_len
         && index > 0)
     {
-      lit_utf8_iterator_advance (&iterator, (ecma_length_t) index);
+      for (int i = 0; i < index; i++)
+      {
+        lit_utf8_incr (&input_curr_p);
+      }
     }
     ECMA_OP_TO_NUMBER_FINALIZE (lastindex_num);
     ecma_deref_ecma_string (magic_str_p);
   }
 
   /* 2. Try to match */
-  lit_utf8_iterator_t sub_iter = lit_utf8_iterator_create (NULL, 0);
+  lit_utf8_byte_t *sub_str_p = NULL;
 
   while (ecma_is_completion_value_empty (ret_value))
   {
@@ -1330,17 +1346,16 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
     }
     else
     {
-      ECMA_TRY_CATCH (match_value, re_match_regexp (&re_ctx, bc_p, iterator, &sub_iter), ret_value);
-
+      ECMA_TRY_CATCH (match_value, re_match_regexp (&re_ctx, bc_p, input_curr_p, &sub_str_p), ret_value);
       if (ecma_is_value_true (match_value))
       {
         is_match = true;
         break;
       }
 
-      if (!lit_utf8_iterator_is_eos (&iterator))
+      if (input_curr_p < input_end_p)
       {
-        lit_utf8_iterator_advance (&iterator, 1);
+        lit_utf8_incr (&input_curr_p);
       }
       index++;
 
@@ -1348,11 +1363,21 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
     }
   }
 
-  if (iterator.buf_p && (re_ctx.flags & RE_FLAG_GLOBAL))
+  if (input_curr_p && (re_ctx.flags & RE_FLAG_GLOBAL))
   {
     ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
     ecma_number_t *lastindex_num_p = ecma_alloc_number ();
-    *lastindex_num_p = sub_iter.buf_pos.offset;
+
+    if (sub_str_p)
+    {
+      *lastindex_num_p = lit_utf8_string_length (input_buffer_p,
+                                                  (lit_utf8_size_t) (sub_str_p - input_buffer_p));
+    }
+    else
+    {
+      *lastindex_num_p = ECMA_NUMBER_ZERO;
+    }
+
     ecma_op_object_put (regexp_object_p, magic_str_p, ecma_make_number_value (lastindex_num_p), true);
     ecma_dealloc_number (lastindex_num_p);
     ecma_deref_ecma_string (magic_str_p);
@@ -1366,7 +1391,7 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
       ecma_completion_value_t result_array = ecma_op_create_array_object (0, 0, false);
       ecma_object_t *result_array_obj_p = ecma_get_object_from_completion_value (result_array);
 
-      ecma_string_t *input_str_p = ecma_new_ecma_string_from_utf8 (iterator.buf_p, iterator.buf_size);
+      ecma_string_t *input_str_p = ecma_new_ecma_string_from_utf8 (input_buffer_p, input_string_size);
       re_set_result_array_properties (result_array_obj_p, input_str_p, re_ctx.num_of_captures / 2, index);
       ecma_deref_ecma_string (input_str_p);
 
@@ -1374,18 +1399,16 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
       {
         ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (i / 2);
 
-        /* Note: 'iter_p->buf_p == NULL' means the input is empty string */
-        if ((re_ctx.saved_p[i].buf_p != unused_iter.buf_p && re_ctx.saved_p[i + 1].buf_p != unused_iter.buf_p)
-            && re_ctx.saved_p[i + 1].buf_pos.offset >= re_ctx.saved_p[i].buf_pos.offset)
+        if (((re_ctx.saved_p[i] && re_ctx.saved_p[i + 1])
+             && re_ctx.saved_p[i + 1] >= re_ctx.saved_p[i]))
         {
           ecma_length_t capture_str_len;
-          capture_str_len = (ecma_length_t) re_ctx.saved_p[i + 1].buf_pos.offset - re_ctx.saved_p[i].buf_pos.offset;
+          capture_str_len = (ecma_length_t) (re_ctx.saved_p[i + 1] - re_ctx.saved_p[i]);
           ecma_string_t *capture_str_p;
 
           if (capture_str_len > 0)
           {
-            const lit_utf8_byte_t *utf8_str_p = re_ctx.saved_p[i].buf_p + re_ctx.saved_p[i].buf_pos.offset;
-            capture_str_p = ecma_new_ecma_string_from_utf8 (utf8_str_p, capture_str_len);
+            capture_str_p = ecma_new_ecma_string_from_utf8 (re_ctx.saved_p[i], capture_str_len);
           }
           else
           {
@@ -1413,7 +1436,7 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
 
   MEM_FINALIZE_LOCAL_ARRAY (num_of_iter_p);
   MEM_FINALIZE_LOCAL_ARRAY (saved_p);
-  MEM_FINALIZE_LOCAL_ARRAY (input_utf8_buffer_p);
+  MEM_FINALIZE_LOCAL_ARRAY (input_buffer_p);
 
   return ret_value;
 } /* ecma_regexp_exec_helper */

--- a/jerry-core/ecma/operations/ecma-regexp-object.h
+++ b/jerry-core/ecma/operations/ecma-regexp-object.h
@@ -41,7 +41,7 @@
  */
 typedef struct
 {
-  lit_utf8_iterator_t *saved_p; /**< saved result string pointers, ECMA 262 v5, 15.10.2.1, State */
+  lit_utf8_byte_t **saved_p; /**< saved result string pointers, ECMA 262 v5, 15.10.2.1, State */
   const lit_utf8_byte_t *input_start_p; /**< start of input pattern string */
   const lit_utf8_byte_t *input_end_p; /**< end of input pattern string */
   uint32_t num_of_captures; /**< number of capture groups */

--- a/jerry-core/lit/lit-char-helpers.cpp
+++ b/jerry-core/lit/lit-char-helpers.cpp
@@ -326,7 +326,7 @@ lit_char_hex_to_int (ecma_char_t c) /**< code unit, corresponding to
  * @return true if decoding was successful, false otherwise
  */
 bool
-lit_read_code_point_from_hex (const lit_utf8_byte_t *buf_p, /**< buffer with characters */
+lit_read_code_point_from_hex (lit_utf8_byte_t *buf_p, /**< buffer with characters */
                               lit_utf8_size_t number_of_characters, /**< number of characters to be read */
                               lit_code_point_t *out_code_point_p) /**< @out: decoded result */
 {

--- a/jerry-core/lit/lit-char-helpers.cpp
+++ b/jerry-core/lit/lit-char-helpers.cpp
@@ -360,6 +360,7 @@ lit_read_code_point_from_hex (const lit_utf8_byte_t *buf_p, /**< buffer with cha
 
     buf_p++;
   }
+
   *out_code_point_p = code_point;
   return true;
 } /* lit_read_code_point_from_hex */

--- a/jerry-core/lit/lit-char-helpers.h
+++ b/jerry-core/lit/lit-char-helpers.h
@@ -216,7 +216,7 @@ extern bool lit_char_is_hex_digit (ecma_char_t);
 extern uint32_t lit_char_hex_to_int (ecma_char_t);
 
 /* read a hex encoded code point from a zero terminated buffer */
-bool lit_read_code_point_from_hex (const lit_utf8_byte_t *, lit_utf8_size_t, lit_code_point_t *);
+bool lit_read_code_point_from_hex (lit_utf8_byte_t *, lit_utf8_size_t, lit_code_point_t *);
 
 /**
  * Null character

--- a/jerry-core/lit/lit-globals.h
+++ b/jerry-core/lit/lit-globals.h
@@ -94,6 +94,16 @@ typedef ecma_char_t *ecma_char_ptr_t;
 #define LIT_UTF8_MAX_BYTES_IN_CODE_POINT (4)
 
 /**
+ * Max bytes needed to represent a code unit (utf-16 char) via cesu-8 encoding
+ */
+#define LIT_CESU8_MAX_BYTES_IN_CODE_UNIT (3)
+
+/**
+ * Max bytes needed to represent a code point (Unicode character) via cesu-8 encoding
+ */
+#define LIT_CESU8_MAX_BYTES_IN_CODE_POINT (6)
+
+/**
  * A byte of utf-8 string
  */
 typedef uint8_t lit_utf8_byte_t;

--- a/jerry-core/lit/lit-literal.cpp
+++ b/jerry-core/lit/lit-literal.cpp
@@ -57,7 +57,7 @@ lit_dump_literals ()
  */
 literal_t
 lit_create_literal_from_utf8_string (const lit_utf8_byte_t *str_p, /**< string to initialize the record,
-                                                                  * could be non-zero-terminated */
+                                                                    * could be non-zero-terminated */
                                      lit_utf8_size_t str_size) /**< length of the string */
 {
   JERRY_ASSERT (str_p || !str_size);

--- a/jerry-core/lit/lit-magic-strings.cpp
+++ b/jerry-core/lit/lit-magic-strings.cpp
@@ -182,7 +182,7 @@ lit_magic_strings_ex_set (const lit_utf8_byte_t **ex_str_items, /**< character a
 
 
 /**
- * Check if passed utf-8 string equals to one of magic strings
+ * Check if passed cesu-8 string equals to one of magic strings
  * and if equal magic string was found, return it's id in 'out_id_p' argument.
  *
  * @return true - if magic string equal to passed string was found,

--- a/jerry-core/lit/lit-strings.h
+++ b/jerry-core/lit/lit-strings.h
@@ -123,6 +123,7 @@ int32_t lit_utf8_iterator_pos_cmp (lit_utf8_iterator_pos_t, lit_utf8_iterator_po
 
 /* validation */
 bool lit_is_utf8_string_valid (const lit_utf8_byte_t *, lit_utf8_size_t);
+bool lit_is_cesu8_string_valid (const lit_utf8_byte_t *, lit_utf8_size_t);
 
 /* checks */
 bool lit_is_code_unit_low_surrogate (ecma_char_t);
@@ -169,16 +170,30 @@ lit_utf8_size_t lit_get_unicode_char_size_by_utf8_first_byte (lit_utf8_byte_t);
 /* conversion */
 lit_utf8_size_t lit_code_unit_to_utf8 (ecma_char_t, lit_utf8_byte_t *);
 lit_utf8_size_t lit_code_point_to_utf8 (lit_code_point_t, lit_utf8_byte_t *);
+lit_utf8_size_t lit_code_point_to_cesu8 (lit_code_point_t, lit_utf8_byte_t *);
 lit_code_point_t lit_convert_surrogate_pair_to_code_point (ecma_char_t, ecma_char_t);
 
-/* comparison */
-bool lit_compare_utf8_strings (const lit_utf8_byte_t *, lit_utf8_size_t, const lit_utf8_byte_t *, lit_utf8_size_t);
+bool lit_compare_utf8_strings (const lit_utf8_byte_t *, lit_utf8_size_t,
+                               const lit_utf8_byte_t *, lit_utf8_size_t);
 
-bool lit_compare_utf8_strings_relational (const lit_utf8_byte_t *, lit_utf8_size_t,
-                                          const lit_utf8_byte_t *, lit_utf8_size_t);
+bool lit_compare_utf8_strings_relational (const lit_utf8_byte_t *string1_p, lit_utf8_size_t,
+                                          const lit_utf8_byte_t *string2_p, lit_utf8_size_t);
 
 /* read code point from buffer */
 lit_utf8_size_t lit_read_code_point_from_utf8 (const lit_utf8_byte_t *, lit_utf8_size_t, lit_code_point_t *);
+
+lit_utf8_size_t lit_read_code_unit_from_utf8 (const lit_utf8_byte_t *,
+                                              ecma_char_t *);
+
+lit_utf8_size_t lit_read_prev_code_unit_from_utf8 (const lit_utf8_byte_t *,
+                                                   ecma_char_t *);
+
+ecma_char_t lit_utf8_read_next (lit_utf8_byte_t **);
+ecma_char_t lit_utf8_read_prev (lit_utf8_byte_t **);
+ecma_char_t lit_utf8_peek_next (lit_utf8_byte_t *);
+ecma_char_t lit_utf8_peek_prev (lit_utf8_byte_t *);
+void lit_utf8_incr (lit_utf8_byte_t **);
+void lit_utf8_decr (lit_utf8_byte_t **);
 
 /* print */
 void lit_put_ecma_char (ecma_char_t);

--- a/jerry-core/lit/lit-strings.h
+++ b/jerry-core/lit/lit-strings.h
@@ -133,25 +133,18 @@ bool lit_is_code_unit_high_surrogate (ecma_char_t);
 lit_utf8_iterator_t lit_utf8_iterator_create (const lit_utf8_byte_t *, lit_utf8_size_t);
 
 void lit_utf8_iterator_seek_bos (lit_utf8_iterator_t *);
-void lit_utf8_iterator_seek_eos (lit_utf8_iterator_t *);
 
 lit_utf8_iterator_pos_t lit_utf8_iterator_get_pos (const lit_utf8_iterator_t *);
 void lit_utf8_iterator_seek (lit_utf8_iterator_t *, lit_utf8_iterator_pos_t);
 
-ecma_length_t lit_utf8_iterator_get_index (const lit_utf8_iterator_t *);
-
 ecma_char_t lit_utf8_iterator_peek_next (const lit_utf8_iterator_t *);
-ecma_char_t lit_utf8_iterator_peek_prev (const lit_utf8_iterator_t *);
 
 void lit_utf8_iterator_incr (lit_utf8_iterator_t *);
-void lit_utf8_iterator_decr (lit_utf8_iterator_t *);
 void lit_utf8_iterator_advance (lit_utf8_iterator_t *, ecma_length_t);
 
 ecma_char_t lit_utf8_iterator_read_next (lit_utf8_iterator_t *);
-ecma_char_t lit_utf8_iterator_read_prev (lit_utf8_iterator_t *);
 
 bool lit_utf8_iterator_is_eos (const lit_utf8_iterator_t *);
-bool lit_utf8_iterator_is_bos (const lit_utf8_iterator_t *);
 
 /* size */
 lit_utf8_size_t lit_zt_utf8_string_size (const lit_utf8_byte_t *);

--- a/jerry-core/parser/js/lexer.cpp
+++ b/jerry-core/parser/js/lexer.cpp
@@ -177,7 +177,7 @@ lexer_create_token_for_charset (token_type tt, /**< token type */
 
   lit_utf8_byte_t *converted_str_p;
 
-  if (should_convert)
+  if (unlikely (should_convert))
   {
     lit_utf8_iterator_seek_bos (&iter);
     converted_str_p = (lit_utf8_byte_t *) jsp_mm_alloc (new_size);
@@ -198,7 +198,7 @@ lexer_create_token_for_charset (token_type tt, /**< token type */
   literal_t lit = lit_find_literal_by_utf8_string (converted_str_p, new_length);
   if (lit != NULL)
   {
-    if (should_convert)
+    if (unlikely (should_convert))
     {
       jsp_mm_free (converted_str_p);
     }
@@ -210,7 +210,7 @@ lexer_create_token_for_charset (token_type tt, /**< token type */
                 || lit->get_type () == LIT_MAGIC_STR_T
                 || lit->get_type () == LIT_MAGIC_STR_EX_T);
 
-  if (should_convert)
+  if (unlikely (should_convert))
   {
     jsp_mm_free (converted_str_p);
   }

--- a/jerry-core/parser/regexp/re-parser.h
+++ b/jerry-core/parser/regexp/re-parser.h
@@ -81,7 +81,9 @@ typedef struct
   */
 typedef struct
 {
-  lit_utf8_iterator_t iter; /**< iterator of input pattern */
+  lit_utf8_byte_t *input_start_p; /**< start of input pattern */
+  lit_utf8_byte_t *input_curr_p; /**< current position in input pattern */
+  lit_utf8_byte_t *input_end_p; /**< end of input pattern */
   int num_of_groups; /**< number of groups */
   uint32_t num_of_classes; /**< number of character classes */
 } re_parser_ctx_t;


### PR DESCRIPTION
Use CESU-8 encoding internally for strings instead of UTF-8. This simplifies handling of strings, since in this case we don't need special handling for surrogate pairs.
This is still work in progress.

Current status (measured on x86 linux):

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js | 156->152 (2.564) | 0.429->0.417 (2.797) | 
                  access-binary-trees.js | 96->92 (4.167) | 0.382->0.369 (3.403) | 
                      access-fannkuch.js | 44->48 (-9.091) | 1.111->1.053 (5.221) | 
                         access-nbody.js | 68->68 (0.000) | 0.617->0.565 (8.428) | 
             bitops-3bit-bits-in-byte.js | 44->44 (0.000) | 0.407->0.39 (4.177) | 
                  bitops-bits-in-byte.js | 40->36 (10.000) | 0.519->0.509 (1.927) | 
                   bitops-bitwise-and.js | 32->36 (-12.500) | 0.438->0.433 (1.142) | 
                controlflow-recursive.js | 292->288 (1.370) | 0.384->0.384 (0.000) | 
                    date-format-xparb.js | 108->104 (3.704) | 0.422->0.26 (38.389) | 
                          math-cordic.js | 52->48 (7.692) | 0.491->0.463 (5.703) | 
                    math-partial-sums.js | 44->40 (9.091) | 0.294->0.285 (3.061) | 
                   math-spectral-norm.js | 52->56 (-7.692) | 0.392->0.379 (3.316) | 
                         string-fasta.js | 64->60 (6.250) | 3.79->2.172 (42.691) | 
                         Geometric mean: |       RSS reduction: 1.4238% |            Speed up: 10.505% |