### PR TITLE
Lazy instantiation of a function object's 'length' and 'prototype' properties

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.cpp
+++ b/jerry-core/ecma/base/ecma-gc.cpp
@@ -346,7 +346,7 @@ ecma_gc_mark (ecma_object_t *object_p) /**< object to mark from */
             case ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE: /* an external pointer */
             case ECMA_INTERNAL_PROPERTY_FREE_CALLBACK: /* an object's native free callback */
             case ECMA_INTERNAL_PROPERTY_BUILT_IN_ID: /* an integer */
-            case ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_ID: /* an integer */
+            case ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC: /* an integer */
             case ECMA_INTERNAL_PROPERTY_EXTENSION_ID: /* an integer */
             case ECMA_INTERNAL_PROPERTY_NON_INSTANTIATED_BUILT_IN_MASK_0_31: /* an integer (bit-mask) */
             case ECMA_INTERNAL_PROPERTY_NON_INSTANTIATED_BUILT_IN_MASK_32_63: /* an integer (bit-mask) */

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -240,8 +240,8 @@ typedef enum
 
   /** Implementation-defined identifier of built-in routine
       that corresponds to a built-in function object
-      ([[Built-in routine ID]]) */
-  ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_ID,
+      ([[Built-in routine's description]]) */
+  ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC,
 
   /** Identifier of implementation-defined extension object */
   ECMA_INTERNAL_PROPERTY_EXTENSION_ID,

--- a/jerry-core/ecma/base/ecma-helpers.cpp
+++ b/jerry-core/ecma/base/ecma-helpers.cpp
@@ -796,7 +796,7 @@ ecma_free_internal_property (ecma_property_t *property_p) /**< the property */
     case ECMA_INTERNAL_PROPERTY_CODE_BYTECODE: /* compressed pointer to a bytecode array */
     case ECMA_INTERNAL_PROPERTY_CODE_FLAGS_AND_OFFSET: /* an integer */
     case ECMA_INTERNAL_PROPERTY_BUILT_IN_ID: /* an integer */
-    case ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_ID: /* an integer */
+    case ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC: /* an integer */
     case ECMA_INTERNAL_PROPERTY_EXTENSION_ID: /* an integer */
     case ECMA_INTERNAL_PROPERTY_NON_INSTANTIATED_BUILT_IN_MASK_0_31: /* an integer (bit-mask) */
     case ECMA_INTERNAL_PROPERTY_NON_INSTANTIATED_BUILT_IN_MASK_32_63: /* an integer (bit-mask) */

--- a/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
@@ -24,32 +24,44 @@
 #include "ecma-globals.h"
 
 /**
- * Position of built-in object's id field in [[Built-in routine ID]] internal property
+ * Position of built-in object's id field in [[Built-in routine's description]] internal property
  */
 #define ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_OBJECT_ID_POS   (0)
 
 /**
- * Width of built-in object's id field in [[Built-in routine ID]] internal property
+ * Width of built-in object's id field in [[Built-in routine's description]] internal property
  */
-#define ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_OBJECT_ID_WIDTH (16)
+#define ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_OBJECT_ID_WIDTH (8)
 
 /**
- * Position of built-in routine's id field in [[Built-in routine ID]] internal property
+ * Position of built-in routine's id field in [[Built-in routine's description]] internal property
  */
 #define ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_ROUTINE_ID_POS \
   (ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_OBJECT_ID_POS + \
    ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_OBJECT_ID_WIDTH)
 
 /**
- * Width of built-in routine's id field in [[Built-in routine ID]] internal property
+ * Width of built-in routine's id field in [[Built-in routine's description]] internal property
  */
 #define ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_ROUTINE_ID_WIDTH (16)
+
+/**
+ * Position of built-in routine's length field in [[Built-in routine's description]] internal property
+ */
+#define ECMA_BUILTIN_ROUTINE_ID_LENGTH_VALUE_POS \
+  (ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_ROUTINE_ID_POS + \
+   ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_ROUTINE_ID_WIDTH)
+
+/**
+ * Width of built-in routine's id field in [[Built-in routine's description]] internal property
+ */
+#define ECMA_BUILTIN_ROUTINE_ID_LENGTH_VALUE_WIDTH (8)
 
 /* ecma-builtins.c */
 extern ecma_object_t*
 ecma_builtin_make_function_object_for_routine (ecma_builtin_id_t builtin_id,
                                                uint16_t routine_id,
-                                               ecma_number_t length_prop_num_value);
+                                               uint8_t length_prop_num_value);
 extern int32_t
 ecma_builtin_bin_search_for_magic_string_id_in_array (const lit_magic_string_id_t ids[],
                                                       ecma_length_t array_length,

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -44,6 +44,10 @@ ecma_op_function_call (ecma_object_t *func_obj_p,
                        ecma_value_t this_arg_value,
                        ecma_collection_header_t *arg_collection_p);
 
+extern ecma_property_t*
+ecma_op_function_object_get_own_property (ecma_object_t *obj_p,
+                                          ecma_string_t *property_name_p);
+
 extern ecma_completion_value_t
 ecma_op_function_call_array_args (ecma_object_t *func_obj_p,
                                   ecma_value_t this_arg_value,

--- a/jerry-core/ecma/operations/ecma-objects.cpp
+++ b/jerry-core/ecma/operations/ecma-objects.cpp
@@ -145,8 +145,7 @@ ecma_op_object_get_own_property_longpath (ecma_object_t *obj_p, /**< the object 
 
   if (unlikely (prop_p == NULL))
   {
-    if (is_builtin
-        && type != ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION)
+    if (is_builtin)
     {
       prop_p = ecma_builtin_try_to_instantiate_property (obj_p, property_name_p);
     }

--- a/jerry-core/ecma/operations/ecma-objects.cpp
+++ b/jerry-core/ecma/operations/ecma-objects.cpp
@@ -112,12 +112,18 @@ ecma_op_object_get_own_property_longpath (ecma_object_t *obj_p, /**< the object 
   {
     case ECMA_OBJECT_TYPE_GENERAL:
     case ECMA_OBJECT_TYPE_ARRAY:
-    case ECMA_OBJECT_TYPE_FUNCTION:
     case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     case ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION:
     case ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION:
     {
       prop_p = ecma_op_general_object_get_own_property (obj_p, property_name_p);
+
+      break;
+    }
+
+    case ECMA_OBJECT_TYPE_FUNCTION:
+    {
+      prop_p = ecma_op_function_object_get_own_property (obj_p, property_name_p);
 
       break;
     }


### PR DESCRIPTION
Memory consumption on IoT.js

`test_cwd.js`
 - Heap stats:
  - Peak allocated chunks count: 1105 -> 1040                                                                                                 
  - Peak allocated: 70184 bytes -> 66024 bytes                                                                                                       
  - Peak waste: 865 bytes -> 865 bytes
                                          
 - Pools stats:
   - Peak pools: 441 -> 342                                                                                                                    
   - Peak allocated chunks: 3525 -> 2734

 - Freya's report:
  - mem_pools_alloc: 27.5 kb -> 21.3 kb
  - mem_heap_alloc_block_try_give_memory_back: 52.9 kb -> 52.9 kb
  - total peak: 247.8 kb -> 243.7 kb

`test_httpserver.js`:
 - Heap stats:
  - Peak allocated chunks count: 2478 -> 2216                                                                                                 
  - Peak allocated: 157288 bytes -> 140892 bytes                                                                                                       
  - Peak waste: 1740 bytes -> 1740 bytes
                                          
 - Pools stats:
   - Peak pools: 1441 -> 1188                                                                                                                    
   - Peak allocated chunks: 11527 -> 9503

 - Freya's report:
  - mem_pools_alloc: 90.0 kb -> 74.2 kb
  - mem_heap_alloc_block_try_give_memory_back: 89.6 kb -> 89.6 kb
  - total peak: 391.4 kb -> 375.5 kb