### PR TITLE
Check if there is really an old bytecode when recompiling a regexp

### DIFF
--- a/tests/jerry/regression-test-issue-612.js
+++ b/tests/jerry/regression-test-issue-612.js
@@ -1,0 +1,17 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var result = RegExp.prototype.compile([]);
+assert(result === undefined);


### PR DESCRIPTION
Fixes #612

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com