### PR TITLE
Fix tr arguments in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@
    QLOG := >/dev/null
   endif
 
-export TARGET_NATIVE_SYSTEMS = $(shell uname -s | tr [:upper:] [:lower:])
+export TARGET_NATIVE_SYSTEMS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 # External build configuration
  # Flag, indicating whether to use compiler's default libc (YES / NO)


### PR DESCRIPTION
On Linux the original tr call did nothing and thus the Makefile
tried to load the toolchain_Linux_x86_64.cmake file, which doesn't exists.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com