### PR TITLE
Support `gcc` in Mac OS X build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,17 +21,18 @@ project (Jerry CXX C ASM)
 
 # Compiler configuration
  if(NOT ("${PLATFORM}" STREQUAL "DARWIN"))
-  # Require g++ of version >= 4.7.0
-   if(NOT CMAKE_COMPILER_IS_GNUCXX)
-    message(FATAL_ERROR "g++ compiler is required")
-   else()
-    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
-                    OUTPUT_VARIABLE GNU_CXX_VERSION
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT CMAKE_COMPILER_IS_GNUCXX)
+   message(FATAL_ERROR "g++ compiler is required")
+  endif()
+ endif()
 
-    if(${GNU_CXX_VERSION} VERSION_LESS 4.7.0)
-     message(FATAL_ERROR "g++ compiler version 4.7.0 or higher required")
-    endif()
+ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+  # Require g++ of version >= 4.7.0
+   execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
+                   OUTPUT_VARIABLE GNU_CXX_VERSION
+                   OUTPUT_STRIP_TRAILING_WHITESPACE)
+   if(${GNU_CXX_VERSION} VERSION_LESS 4.7.0)
+    message(FATAL_ERROR "g++ compiler version 4.7.0 or higher required")
    endif()
 
   # Use gcc-ar and gcc-ranlib to support LTO
@@ -239,7 +240,7 @@ project (Jerry CXX C ASM)
   set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Wconversion -Wsign-conversion -Wformat-security")
   set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Wmissing-declarations -Wno-attributes")
   set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Wfatal-errors")
-  if(CMAKE_COMPILER_IS_GNUCXX)
+  if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Werror -Wlogical-op")
   else()
     set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -Wno-nested-anon-types")
@@ -253,7 +254,7 @@ project (Jerry CXX C ASM)
  # C++
   set(CXX_FLAGS_JERRY "-std=c++11 -fno-exceptions -fno-rtti")
   # Turn off implicit template instantiation
-   if(CMAKE_COMPILER_IS_GNUCXX)
+   if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     set(CXX_FLAGS_JERRY "${CXX_FLAGS_JERRY} -fno-implicit-templates -fno-implicit-inline-templates")
    endif()
 
@@ -301,7 +302,7 @@ project (Jerry CXX C ASM)
   file(GLOB SOURCE_UNIT_TEST_MAIN_MODULES tests/unit/*.cpp)
 
 # Imported libraries
-if(("${PLATFORM}" STREQUAL "DARWIN") AND (NOT CMAKE_COMPILER_IS_GNUCXX))
+if(("${PLATFORM}" STREQUAL "DARWIN") AND (NOT (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)))
  # libclang_rt.osx
   add_library(${PREFIX_IMPORTED_LIB}libclang_rt.osx STATIC IMPORTED)
   execute_process(COMMAND ${CMAKE_C_COMPILER} ${FLAGS_COMMON_ARCH} -print-file-name=
@@ -395,7 +396,7 @@ endif()
     target_include_directories(${TARGET_NAME} PRIVATE ${INCLUDE_CORE_INTERFACE})
     target_include_directories(${TARGET_NAME} SYSTEM PRIVATE ${INCLUDE_LIBC_INTERFACE})
     target_include_directories(${TARGET_NAME} SYSTEM PRIVATE ${INCLUDE_EXTERNAL_LIBS_INTERFACE})
-    if(("${PLATFORM}" STREQUAL "DARWIN") AND (NOT CMAKE_COMPILER_IS_GNUCXX))
+    if(("${PLATFORM}" STREQUAL "DARWIN") AND (NOT (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)))
      target_link_libraries(${TARGET_NAME} ${CORE_TARGET_NAME} ${LIBC_TARGET_NAME}
 		                   ${FDLIBM_TARGET_NAME} ${PREFIX_IMPORTED_LIB}libclang_rt.osx)
 	else()
@@ -476,7 +477,7 @@ endif()
     target_include_directories(${TARGET_NAME} PRIVATE ${INCLUDE_CORE_INTERFACE})
     target_include_directories(${TARGET_NAME} SYSTEM PRIVATE ${INCLUDE_LIBC_INTERFACE})
 
-    if(("${PLATFORM}" STREQUAL "DARWIN") AND (NOT CMAKE_COMPILER_IS_GNUCXX))
+    if(("${PLATFORM}" STREQUAL "DARWIN") AND (NOT (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)))
       target_link_libraries(${TARGET_NAME} ${CORE_TARGET_NAME} ${LIBC_TARGET_NAME} ${FDLIBM_TARGET_NAME}
                             ${PREFIX_IMPORTED_LIB}libclang_rt.osx)
 	else()

--- a/build/configs/toolchain_darwin_x86_64.cmake
+++ b/build/configs/toolchain_darwin_x86_64.cmake
@@ -15,9 +15,9 @@
 set(CMAKE_SYSTEM_NAME Darwin)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
-find_program(CMAKE_C_COMPILER NAMES cc) 
-find_program(CMAKE_CXX_COMPILER NAMES c++)
+find_program(CMAKE_C_COMPILER NAMES gcc cc) 
+find_program(CMAKE_CXX_COMPILER NAMES g++ c++)
 # FIXME: This could break cross compilation, when the strip is not for the target architecture
 find_program(CMAKE_STRIP NAMES strip)
 
-#set(FLAGS_COMMON_ARCH -ffixed-rbp)
+#set(FLAGS_COMMON_ARCH )

--- a/tools/prerequisites.sh
+++ b/tools/prerequisites.sh
@@ -207,7 +207,6 @@ function setup_vera() {
   chmod -R u-w "$DEST" || fail_msg "$FAIL_MSG. Failed to remove write permission from '$DEST' directory contents."
 }
 
-TMP_DIR=`mktemp -d --tmpdir=./`
 HOST_OS=`uname -s`
 
 if [ "$HOST_OS" == "Darwin" ]


### PR DESCRIPTION
- if `gcc` exist, use `gcc` for build, otherwise use `cc(=clang)` for build.

JerryScript-DCO-1.0-Signed-off-by: Sung-Jae Lee sjlee@mail.com