### PR TITLE
Remove ECMA_STRING_CONTAINER_CONCATENATION type from ecma_string

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -783,7 +783,6 @@ typedef enum
   ECMA_STRING_CONTAINER_HEAP_NUMBER, /**< actual data is on the heap as a ecma_number_t */
   ECMA_STRING_CONTAINER_UINT32_IN_DESC, /**< actual data is UInt32-represeneted Number
                                              stored locally in the string's descriptor */
-  ECMA_STRING_CONTAINER_CONCATENATION, /**< the ecma-string is concatenation of two specified ecma-strings */
   ECMA_STRING_CONTAINER_MAGIC_STRING, /**< the ecma-string is equal to one of ECMA magic strings */
   ECMA_STRING_CONTAINER_MAGIC_STRING_EX /**< the ecma-string is equal to one of external magic strings */
 } ecma_string_container_t;
@@ -830,19 +829,6 @@ typedef struct ecma_string_t
 
     /** UInt32-represented number placed locally in the descriptor */
     uint32_t uint32_number;
-
-    /** Representation of concatenation */
-    struct
-    {
-      mem_cpointer_t string1_cp : ECMA_POINTER_FIELD_WIDTH;
-      mem_cpointer_t string2_cp : ECMA_POINTER_FIELD_WIDTH;
-
-      /**
-       * Flag indicating that last code_unit of first string in concatenation is high surrogate
-       * and first code_unit of second string is low surrogate
-       */
-      unsigned int is_surrogate_pair_sliced : 1;
-    } concatenation;
 
     /** Identifier of magic string */
     lit_magic_string_id_t magic_string_id;


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Kristof Kosztyo kkosztyo.u-szeged@partner.samsung.com

Base rev: 66975236bc42fdfcfcb74b6996601c1401f2b62e

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |         152->   156 (-2.632) |       0.3486->0.3409 (2.209) | 
                  access-binary-trees.js |          96->   100 (-4.167) |      0.2488->0.2504 (-0.643) | 
                      access-fannkuch.js |           52->    52 (0.000) |       0.9333->0.9112 (2.368) | 
                         access-nbody.js |           72->    68 (5.556) |      0.4593->0.4596 (-0.065) | 
             bitops-3bit-bits-in-byte.js |           44->    44 (0.000) |        0.319->0.3091 (3.103) | 
                  bitops-bits-in-byte.js |           36->    36 (0.000) |       0.4385->0.4246 (3.170) | 
                   bitops-bitwise-and.js |           44->    40 (9.091) |        0.364->0.3608 (0.879) | 
                controlflow-recursive.js |         288->   292 (-1.389) |       0.2875->0.2816 (2.052) | 
                           crypto-aes.js |         224->   164 (26.786) |      2.2872->0.6263 (72.617) | 
                    date-format-xparb.js |          108->   108 (0.000) |      0.2919->0.2522 (13.600) | 
                          math-cordic.js |          48->    52 (-8.333) |       0.4142->0.3866 (6.663) | 
                    math-partial-sums.js |           44->    44 (0.000) |       0.2331->0.2331 (0.000) | 
                   math-spectral-norm.js |           56->    56 (0.000) |       0.2981->0.2934 (1.577) | 
                         string-fasta.js |           68->    64 (5.882) |      2.9977->1.4992 (49.988) | 
                         Geometric mean: |       RSS reduction: 2.5681% |           Speed up: 15.4631% |
