### PR TITLE
Fix benchmark scripts to run on Mac OS X

### DIFF
--- a/tools/perf.sh
+++ b/tools/perf.sh
@@ -18,11 +18,20 @@ ITERS="$1"
 ENGINE="$2"
 BENCHMARK="$3"
 PRINT_MIN="$4"
+OS=`uname -s | tr [:upper:] [:lower:]`
 
+if [ "$OS" == "darwin" ]
+then
 perf_values=$(( ( for i in `seq 1 1 $ITERS`; do time $ENGINE "$BENCHMARK"; done ) 2>&1 ) | \
-              grep user | \
-              sed 's/user[ \t]*\([0-9]*\)m\([0-9.]*\)s/\1 \2/g' | \
-              awk 'BEGIN { min_v = -1; } { v = $1 * 60 + $2; if (min_v == -1 || v < min_v) { min_v = v; }; s += v; n += 1; } END { print s / n, min_v; }');
+			  grep user | \
+			  sed 's/user[ 	]*\([0-9]*\)m\([0-9.]*\)s/\1 \2/g' | \
+			  awk 'BEGIN { min_v = -1; } { v = $1 * 60 + $2; if (min_v == -1 || v < min_v) { min_v = v; }; s += v; n += 1; } END { print s / n, min_v; }');
+else
+perf_values=$(( ( for i in `seq 1 1 $ITERS`; do time $ENGINE "$BENCHMARK"; done ) 2>&1 ) | \
+			  grep user | \
+			  sed 's/user[ \t]*\([0-9]*\)m\([0-9.]*\)s/\1 \2/g' | \
+			  awk 'BEGIN { min_v = -1; } { v = $1 * 60 + $2; if (min_v == -1 || v < min_v) { min_v = v; }; s += v; n += 1; } END { print s / n, min_v; }');
+fi;
 
 if [ "$PRINT_MIN" == "-min" ]
 then

--- a/tools/rss-measure.sh
+++ b/tools/rss-measure.sh
@@ -17,6 +17,7 @@
 JERRY=$1
 TEST=$2
 SLEEP=0.1
+OS=`uname -s | tr [:upper:] [:lower:]`
 
 Rss_OUT=""
 
@@ -25,7 +26,12 @@ function collect_entry()
   OUT_NAME="$1_OUT";
   OUT=$OUT_NAME;
 
-  SUM=$(grep -o -e "^[0-9a-f][0-9a-f]*.*" -e "^Rss.*" /proc/$PID/smaps 2>/dev/null | grep -A 1 -- "r[w-]-p " | grep "^Rss"|awk '{s += $2;} END {print s;}')
+  if [ "$OS" == "darwin" ]
+  then
+    SUM=`ps -o rss $PID | grep [0-9]`
+  else
+    SUM=$(grep -o -e "^[0-9a-f][0-9a-f]*.*" -e "^Rss.*" /proc/$PID/smaps 2>/dev/null | grep -A 1 -- "r[w-]-p " | grep "^Rss"|awk '{s += $2;} END {print s;}')
+  fi;
 
   if [ "$SUM" != "" ];
   then

--- a/tools/run-perf-test.sh
+++ b/tools/run-perf-test.sh
@@ -107,6 +107,7 @@ function run-suite()
   done
 }
 
+date
 printf "%40s | %28s | %28s |\n" "Benchmark" "RSS<br>(+ is better)" "Perf<br>(+ is better)"
 printf "%40s | %28s | %28s |\n" "---------" "---" "----"
 
@@ -119,3 +120,4 @@ perf_rel_gmean=$(echo "$perf_rel_mult" "$perf_n" | awk '{print $1 ^ (1.0 / $2);}
 perf_percent_gmean=$(echo "$perf_rel_gmean" | awk '{print (1.0 - $1) * 100;}')
 
 printf "%40s | %28s | %28s |\n" "Geometric mean:" "RSS reduction: $mem_percent_gmean%" "Speed up: $perf_percent_gmean%"
+date


### PR DESCRIPTION
- perf: bypass the regex interpreting error of 'sed'.
- rss-measure: use alternative way to measure approx. RSS.

JerryScript-DCO-1.0-Signed-off-by: Sung-Jae Lee sjlee@mail.com