### PR TITLE
Fix recordset configuration dependencies on MEM_ALIGNMENT_LOG and MEM_CP_WIDTH parameters

### DIFF
--- a/jerry-core/lit/lit-literal-storage.h
+++ b/jerry-core/lit/lit-literal-storage.h
@@ -88,7 +88,7 @@ public:
   void
   set_alignment_bytes_count (size_t count) /**< count of the alignment bytes */
   {
-    JERRY_ASSERT (count <= RCS_DYN_STORAGE_ALIGNMENT);
+    JERRY_ASSERT (count <= RCS_DYN_STORAGE_LENGTH_UNIT);
     set_field (_alignment_field_pos, _alignment_field_width, count);
   } /* set_alignment_bytes_count */
 
@@ -141,9 +141,9 @@ private:
   void
   set_size (size_t size) /**< size in bytes */
   {
-    JERRY_ASSERT (JERRY_ALIGNUP (size, RCS_DYN_STORAGE_ALIGNMENT) == size);
+    JERRY_ASSERT (JERRY_ALIGNUP (size, RCS_DYN_STORAGE_LENGTH_UNIT) == size);
 
-    set_field (_length_field_pos, _length_field_width, size >> RCS_DYN_STORAGE_ALIGNMENT_LOG);
+    set_field (_length_field_pos, _length_field_width, size >> RCS_DYN_STORAGE_LENGTH_UNIT_LOG);
   } /* set_size */
 
   /**
@@ -163,12 +163,12 @@ private:
    * Offset and length of 'alignment' field, in bits
    */
   static const uint32_t _alignment_field_pos = _fields_offset_begin;
-  static const uint32_t _alignment_field_width = 2u;
+  static const uint32_t _alignment_field_width = RCS_DYN_STORAGE_LENGTH_UNIT_LOG;
 
   /**
    * Offset and length of 'hash' field, in bits
    */
-  static const uint32_t _hash_field_pos = _alignment_field_pos + _alignment_field_width + 2u;
+  static const uint32_t _hash_field_pos = _alignment_field_pos + _alignment_field_width;
   static const uint32_t _hash_field_width = 8u;
 
   /**

--- a/jerry-core/mem/mem-allocator.h
+++ b/jerry-core/mem/mem-allocator.h
@@ -54,11 +54,6 @@ typedef uint16_t mem_cpointer_t;
 #define MEM_CP_MASK ((1ull << MEM_CP_WIDTH) - 1)
 
 /**
- * Heap offset value mask
- */
-#define MEM_HEAP_OFFSET_MASK ((1ull << MEM_HEAP_OFFSET_LOG) - 1)
-
-/**
  * Severity of a 'try give memory back' request
  *
  * The request are posted sequentially beginning from

--- a/jerry-core/mem/mem-poolman.cpp
+++ b/jerry-core/mem/mem-poolman.cpp
@@ -95,8 +95,18 @@ typedef struct mem_pool_chunk_t
                                                *   in the pool containing this chunk */
       uint8_t list_id; /**< identifier of a pool list */
     } pool_gc;
+
+    /**
+     * The field is added to make sizeof (mem_pool_chunk_t) equal to MEM_POOL_CHUNK_SIZE
+     */
+    uint8_t allocated_area[MEM_POOL_CHUNK_SIZE];
   } u;
 } mem_pool_chunk_t;
+
+/**
+ * The condition is assumed when using pointer arithmetics on (mem_pool_chunk_t *) pointer type
+ */
+JERRY_STATIC_ASSERT (sizeof (mem_pool_chunk_t) == MEM_POOL_CHUNK_SIZE);
 
 /**
  * List of free pool chunks

--- a/jerry-core/rcs/rcs-chunked-list.cpp
+++ b/jerry-core/rcs/rcs-chunked-list.cpp
@@ -223,14 +223,14 @@ const
  *
  * @return pointer to beginning of the node's data space
  */
-uint8_t*
-rcs_chunked_list_t::get_data_space (rcs_chunked_list_t::node_t* node_p) /**< the node */
+uint8_t *
+rcs_chunked_list_t::get_node_data_space (rcs_chunked_list_t::node_t *node_p) /**< the node */
 const
 {
   assert_node_is_correct (node_p);
 
-  return (uint8_t*) (node_p + 1);
-} /* rcs_chunked_list_t::get_data_space */
+  return (uint8_t *) (node_p + 1);
+} /* rcs_chunked_list_t::get_node_data_space */
 
 /**
  * Get size of a node's data space
@@ -238,10 +238,10 @@ const
  * @return size
  */
 size_t
-rcs_chunked_list_t::get_data_space_size (void)
+rcs_chunked_list_t::get_node_data_space_size (void)
 {
   return rcs_chunked_list_t::get_node_size () - sizeof (node_t);
-} /* rcs_chunked_list_t::get_data_space_size */
+} /* rcs_chunked_list_t::get_node_data_space_size */
 
 /**
  * Set previous node for the specified node

--- a/jerry-core/rcs/rcs-chunked-list.h
+++ b/jerry-core/rcs/rcs-chunked-list.h
@@ -70,9 +70,9 @@ public:
   void remove (node_t *);
 
   node_t *get_node_from_pointer (void *) const;
-  uint8_t *get_data_space (node_t *) const;
+  uint8_t *get_node_data_space (node_t *) const;
 
-  static size_t get_data_space_size (void);
+  static size_t get_node_data_space_size (void);
 
 private:
   void set_prev (node_t *, node_t *);

--- a/jerry-core/rcs/rcs-recordset.h
+++ b/jerry-core/rcs/rcs-recordset.h
@@ -34,20 +34,12 @@
 /**
  * Logarithm of a dynamic storage unit alignment
  */
-#define RCS_DYN_STORAGE_ALIGNMENT_LOG (2u)
-
-/**
- * Dynamic storage unit alignment
- */
-#define RCS_DYN_STORAGE_ALIGNMENT     (1ull << RCS_DYN_STORAGE_ALIGNMENT_LOG)
+#define RCS_DYN_STORAGE_LENGTH_UNIT_LOG (2u)
 
 /**
  * Unit of length
- *
- * See also:
- *          rcs_dyn_storage_length_t
  */
-#define RCS_DYN_STORAGE_LENGTH_UNIT   (4u)
+#define RCS_DYN_STORAGE_LENGTH_UNIT   ((size_t) (1ull << RCS_DYN_STORAGE_LENGTH_UNIT_LOG))
 
 /**
  * Dynamic storage
@@ -65,7 +57,7 @@ public:
   {
     _chunk_list.init ();
 
-    JERRY_ASSERT (_chunk_list.get_data_space_size () % RCS_DYN_STORAGE_LENGTH_UNIT == 0);
+    JERRY_ASSERT (get_node_data_space_size () % RCS_DYN_STORAGE_LENGTH_UNIT == 0);
   } /* init */
 
   /* Destructor */
@@ -95,24 +87,24 @@ public:
      * Dynamic storage-specific extended compressed pointer
      *
      * Note:
-     *      the pointer can represent addresses aligned by RCS_DYN_STORAGE_ALIGNMENT,
-     *      while mem_cpointer_t can only represent addressed aligned by MEM_ALIGNMENT.
+     *      the pointer can represent addresses aligned by RCS_DYN_STORAGE_LENGTH_UNIT,
+     *      while mem_cpointer_t can only represent addresses aligned by MEM_ALIGNMENT.
      */
     struct cpointer_t
     {
-      static const uint32_t bit_field_width = MEM_CP_WIDTH + MEM_ALIGNMENT_LOG - RCS_DYN_STORAGE_ALIGNMENT_LOG;
+      static const uint32_t bit_field_width = MEM_CP_WIDTH + MEM_ALIGNMENT_LOG - RCS_DYN_STORAGE_LENGTH_UNIT_LOG;
 
       union
       {
         struct
         {
           mem_cpointer_t base_cp : MEM_CP_WIDTH; /**< pointer to base of addressed area */
-#if MEM_ALIGNMENT_LOG > RCS_DYN_STORAGE_ALIGNMENT_LOG
-          uint16_t ext     : (MEM_ALIGNMENT_LOG - RCS_DYN_STORAGE_ALIGNMENT_LOG); /**< extension of the basic
-                                                                                   *   compressed pointer
-                                                                                   *   used for more detailed
-                                                                                   *   addressing */
-#endif /* MEM_ALIGNMENT_LOG > RCS_DYN_STORAGE_ALIGNMENT_LOG */
+#if MEM_ALIGNMENT_LOG > RCS_DYN_STORAGE_LENGTH_UNIT_LOG
+          uint16_t ext : (MEM_ALIGNMENT_LOG - RCS_DYN_STORAGE_LENGTH_UNIT_LOG); /**< extension of the basic
+                                                                                 *   compressed pointer
+                                                                                 *   used for more detailed
+                                                                                 *   addressing */
+#endif /* MEM_ALIGNMENT_LOG > RCS_DYN_STORAGE_LENGTH_UNIT_LOG */
         } value;
         uint16_t packed_value;
       };
@@ -129,12 +121,12 @@ public:
     /**
      * Offset of 'type' field, in bits
      */
-    static const uint32_t _type_field_pos   = 0u;
+    static constexpr uint32_t _type_field_pos = 0u;
 
     /**
      * Width of 'type' field, in bits
      */
-    static const uint32_t _type_field_width = 4u;
+    static constexpr uint32_t _type_field_width = 4u;
 
   protected:
     void check_this (void) const;
@@ -148,7 +140,7 @@ public:
     /**
      * Offset of a derived record's fields, in bits
      */
-    static const uint32_t _fields_offset_begin = _type_field_pos + _type_field_width;
+    static constexpr uint32_t _fields_offset_begin = _type_field_pos + _type_field_width;
   };
 
   record_t *get_first (void);
@@ -172,6 +164,8 @@ private:
   void init_free_record (record_t *, size_t, record_t *);
   bool is_record_free (record_t *);
 
+  uint8_t *get_node_data_space (rcs_chunked_list_t::node_t *) const;
+  static size_t get_node_data_space_size (void);
 protected:
   /**
    * First type identifier that can be used for storage-specific record types
@@ -357,22 +351,29 @@ private:
   /**
    * Offset of 'length' field, in bits
    */
-  static const uint32_t _length_field_pos = _fields_offset_begin;
+  static constexpr uint32_t _length_field_pos = _fields_offset_begin;
 
   /**
    * Width of 'length' field, in bits
    */
-  static const uint32_t _length_field_width = 12u;
+  static constexpr uint32_t _length_field_width = 14u - RCS_DYN_STORAGE_LENGTH_UNIT_LOG;
 
   /**
    * Offset of 'previous record' field, in bits
    */
-  static const uint32_t _prev_field_pos = _length_field_pos + _length_field_width;
+  static constexpr uint32_t _prev_field_pos = _length_field_pos + _length_field_width;
 
   /**
    * Width of 'previous record' field, in bits
    */
-  static const uint32_t _prev_field_width = rcs_cpointer_t::bit_field_width;
+  static constexpr uint32_t _prev_field_width = rcs_cpointer_t::bit_field_width;
+
+  /**
+   * Free record should be be placeable at any free space unit of recordset,
+   * and so its size should be less than minimal size of a free space unit
+   * that is RCS_DYN_STORAGE_LENGTH_UNIT bytes.
+   */
+  JERRY_STATIC_ASSERT (_prev_field_pos + _prev_field_width <= RCS_DYN_STORAGE_LENGTH_UNIT * JERRY_BITSINBYTE);
 };
 
 /**


### PR DESCRIPTION
                                                   Benchmark |                              Rss |                             Perf
---- | ---- | ----
                                ./sunspider-1.0.2/3d-cube.js |    136 ->    136 (0.000%) | 1.87167 ->  1.825 (2.494%) | 
                    ./sunspider-1.0.2/access-binary-trees.js |     92 ->     92 (0.000%) |   1.52 -> 1.48833 (2.084%) | 
                        ./sunspider-1.0.2/access-fannkuch.js |     48 ->     48 (0.000%) |  5.025 -> 4.91833 (2.123%) | 
                           ./sunspider-1.0.2/access-nbody.js |     68 ->     68 (0.000%) | 2.44667 ->  2.405 (1.703%) | 
               ./sunspider-1.0.2/bitops-3bit-bits-in-byte.js |     40 ->     40 (0.000%) | 1.55667 ->   1.54 (1.071%) | 
                    ./sunspider-1.0.2/bitops-bits-in-byte.js |     40 ->     40 (0.000%) | 2.02333 -> 2.03833 (-0.741%) | 
                     ./sunspider-1.0.2/bitops-bitwise-and.js |     32 ->     32 (0.000%) |    1.9 -> 1.91167 (-0.614%) | 
                  ./sunspider-1.0.2/controlflow-recursive.js |    216 ->    216 (0.000%) |  1.605 -> 1.55667 (3.011%) | 
                            ./sunspider-1.0.2/crypto-sha1.js |    148 ->    148 (0.000%) | 10.0533 ->   9.63 (4.211%) | 
                      ./sunspider-1.0.2/date-format-xparb.js |    100 ->    100 (0.000%) | 1.45167 -> 1.40333 (3.330%) | 
                            ./sunspider-1.0.2/math-cordic.js |     44 ->     44 (0.000%) | 2.36667 -> 2.26167 (4.437%) | 
                      ./sunspider-1.0.2/math-partial-sums.js |     44 ->     44 (0.000%) | 1.36333 -> 1.36833 (-0.367%) | 
                     ./sunspider-1.0.2/math-spectral-norm.js |     52 ->     52 (0.000%) |  1.575 ->  1.555 (1.270%) | 
                           ./sunspider-1.0.2/string-fasta.js |     56 ->     56 (0.000%) | 7.74667 -> 7.69333 (0.689%) | 
                                              Geometric mean |                               0% |                          1.7774%


Raspbery Pi 2:

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          132->   132 (0.000) |      3.71067-> 3.656 (1.473) | 
                  access-binary-trees.js |           88->    88 (0.000) |       2.736->2.71867 (0.633) | 
                      access-fannkuch.js |           40->    40 (0.000) |      9.89067-> 9.856 (0.350) | 
                         access-nbody.js |           64->    64 (0.000) |        4.632->   4.6 (0.691) | 
             bitops-3bit-bits-in-byte.js |           36->    36 (0.000) |     3.25733->3.23733 (0.614) | 
                  bitops-bits-in-byte.js |           36->    36 (0.000) |    4.41733->4.41867 (-0.030) | 
                   bitops-bitwise-and.js |           32->    32 (0.000) |      4.124->4.18267 (-1.423) | 
                controlflow-recursive.js |          224->   224 (0.000) |    3.20133->3.20267 (-0.042) | 
                    date-format-xparb.js |          100->   100 (0.000) |     2.34667->2.34133 (0.228) | 
                          math-cordic.js |           48->    48 (0.000) |     4.84267->4.80267 (0.826) | 
                    math-partial-sums.js |           40->    40 (0.000) |        2.612-> 2.568 (1.685) | 
                   math-spectral-norm.js |           52->    52 (0.000) |     3.20533->3.16933 (1.123) | 
                         string-fasta.js |           56->    56 (0.000) |      14.9547->14.948 (0.045) | 
                         Geometric mean: |            RSS reduction: 0% |            Speed up: 0.4777% |
