### PR TITLE
Fix parser bug between regex and div operator

### DIFF
--- a/jerry-core/parser/js/lexer.h
+++ b/jerry-core/parser/js/lexer.h
@@ -171,7 +171,7 @@ typedef struct
 
 void lexer_init (const jerry_api_char_t *, size_t, bool);
 
-token lexer_next_token (void);
+token lexer_next_token (bool);
 void lexer_save_token (token);
 token lexer_prev_token (void);
 

--- a/tests/jerry/regexp-literal.js
+++ b/tests/jerry/regexp-literal.js
@@ -65,3 +65,21 @@ try {
 } catch (e) {
 	assert(e instanceof SyntaxError);
 }
+
+try {
+	eval("var x = /aaa/");
+} catch (e) {
+	assert (false);
+}
+
+try {
+	eval("{}/a/g");
+} catch (e) {
+	assert (false);
+}
+
+try {
+	eval("var a, g; +{}/a/g");
+} catch (e) {
+	assert (false);
+}

--- a/tests/jerry/regression-test-issue-563.js
+++ b/tests/jerry/regression-test-issue-563.js
@@ -1,0 +1,32 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+	eval('if (true) /abc/.exec("abc");');
+} catch (e) {
+	assert (false);
+}
+
+try {
+	eval('if (true) {} /abc/.exec("abc");');
+} catch (e) {
+	assert (false);
+}
+
+try {
+	eval('var a\n/abc/.exec("abc");');
+} catch (e) {
+	assert (false);
+}

--- a/tests/jerry/regression-test-issue-652.js
+++ b/tests/jerry/regression-test-issue-652.js
@@ -1,0 +1,32 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+	eval("this / 10");
+} catch (e) {
+	assert (false);
+}
+
+try {
+	eval("var v_0 = 10;\nv_0++ / 1");
+} catch (e) {
+	assert (false);
+}
+
+try {
+	eval("var v_0 = 10;\nif (v_0++ / 1) {\n}");
+} catch (e) {
+	assert (false);
+}

--- a/tests/jerry/regression-test-issue-655.js
+++ b/tests/jerry/regression-test-issue-655.js
@@ -1,0 +1,20 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+	eval("if (true) {}\n/a/;");
+} catch (e) {
+	assert (false);
+}


### PR DESCRIPTION
For Lexer alone, it is hard to find out whether a token that starts with `/` is a division operator or a regex literal. Parser should give its context information to Lexer that it is expecting which. 

In my implementation, Lexer expects division operator by default.
When Parser sees token `/` or `/=` in `parse_primary_expression()`, the token is re-lexed as a regex literal. Seems work good.

This will resolve #652 and #655.