### PR TITLE
Fix: parser bug in parse_switch_statement

### DIFF
--- a/tests/jerry/regression-test-issue-653.js
+++ b/tests/jerry/regression-test-issue-653.js
@@ -1,0 +1,22 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a = "foo", r;
+switch(a) {
+    case true ? "foo" : "bar":
+        r = "OK";
+        break;
+}
+assert(r === "OK");

--- a/tests/jerry/regression-test-issue-654.js
+++ b/tests/jerry/regression-test-issue-654.js
@@ -1,0 +1,19 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+switch (true) {
+    case {"foo": "bar"}:
+        break;
+}


### PR DESCRIPTION
In *switch statement*, when the *expression* that follows `case` contains one or more `:` token 
It turns out issue #653 and #654 have the same problem.

In `parse_switch_statement`, bytecode is generated with two-pass. In second pass, the *expression* is not parsed with `parse_expression` but it just simply waits for a `:` token show. However `parse_expression` would generate unwanted bytecode, so I chose another approach - storing all  starting locations of case/default bodies.

% While working on this patch, I found another bug about *switch statement*. I'll post it as a separated issue.