### PR TITLE
Fix: switch statement jumps to incorrect case body

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -2462,10 +2462,7 @@ parse_switch_statement (void)
   }
   current_token_must_be (TOK_CLOSE_BRACE);
 
-  if (was_default)
-  {
-    dump_default_clause_check_for_rewrite ();
-  }
+  dump_default_clause_check_for_rewrite ();
 
   lexer_seek (start_loc);
   next_token_must_be (TOK_OPEN_BRACE);
@@ -2501,6 +2498,12 @@ parse_switch_statement (void)
     parse_statement_list ();
     skip_newlines ();
   }
+
+  if (!was_default)
+  {
+    rewrite_default_clause ();
+  }
+
   current_token_must_be (TOK_CLOSE_BRACE);
   skip_token ();
 

--- a/tests/jerry/regression-test-issue-667.js
+++ b/tests/jerry/regression-test-issue-667.js
@@ -1,0 +1,23 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+switch (1) {
+  case 0:
+    assert(false);
+    break;
+  case 2:
+    assert(false);
+    break;
+}


### PR DESCRIPTION
The test case in the issue #667,
```javascript
switch (1) {
    case 0:
        assert(false);
        break;
}
```
This code fails because if there is no matching `case` and there is no `default` in switch statement, it does not jump out of the switch statement, and go on to the next opcode.

bytecode for this was:
```
  0:                 meta   12    6  255     // [no 'arguments'] [no 'eval'] 
  1:         reg_var_decl  128  132    0     // var tmp128 .. tmp132;
  2:           assignment  130    1    1     // tmp130 = 1: SMALLINT;
  3:           assignment  131    1    0     // tmp131 = 0: SMALLINT;
  4:     equal_value_type  132  130  131     // tmp132 = tmp130 === tmp131;
  5:     is_true_jmp_down  132    0    1     // if (tmp132) goto 6;
( jmp_down to line 10 is missing here )
  6:               call_n  130    0    1     // 
  7:           assignment  130    0    3     // tmp130 = false: SIMPLE;
  8:                 meta    2  130  255     // tmp130 = assert (tmp130);
  9:             jmp_down    0    1          // goto 10;
 10:                  ret                    // ret;
```

So I changed code to insert `jmp_down` even if there is no `default`.