### PR TITLE
Fix: parse error when no expression follows after 'return', 'break', …

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -2831,6 +2831,11 @@ parse_statement (jsp_label_t *outermost_stmt_label_p) /**< outermost (first) lab
       }
     }
 
+    if (token_is (TOK_CLOSE_BRACE))
+    {
+      lexer_save_token (tok);
+    }
+
     JERRY_ASSERT (label_p != NULL);
 
     jsp_label_add_jump (label_p, is_simply_jumpable, is_break);
@@ -2845,7 +2850,7 @@ parse_statement (jsp_label_t *outermost_stmt_label_p) /**< outermost (first) lab
     }
 
     skip_token ();
-    if (!token_is (TOK_SEMICOLON) && !token_is (TOK_NEWLINE))
+    if (!token_is (TOK_SEMICOLON) && !token_is (TOK_NEWLINE) && !token_is (TOK_CLOSE_BRACE))
     {
       const jsp_operand_t op = parse_expression (true, JSP_EVAL_RET_STORE_NOT_DUMP);
       dump_retval (op);
@@ -2855,6 +2860,11 @@ parse_statement (jsp_label_t *outermost_stmt_label_p) /**< outermost (first) lab
     else
     {
       dump_ret ();
+
+      if (token_is (TOK_CLOSE_BRACE))
+      {
+        lexer_save_token (tok);
+      }
       return;
     }
   }

--- a/tests/jerry/regression-test-issue-669.js
+++ b/tests/jerry/regression-test-issue-669.js
@@ -1,0 +1,21 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function f(){return}
+
+switch (1) {
+  case 1:
+    break}
+
+while (false) {continue}


### PR DESCRIPTION
When no expression follows after keyword 'return', 'break', 'continue' and `}` follows immediately after these keywords, throws an error.

Fix for #669.