### PR TITLE
Use heap allocated buffer instead of char collection in ecma_strings

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -778,8 +778,7 @@ typedef struct
 typedef enum
 {
   ECMA_STRING_CONTAINER_LIT_TABLE, /**< actual data is in literal table */
-  ECMA_STRING_CONTAINER_HEAP_CHUNKS, /**< actual data is on the heap
-                                          in a ecma_collection_chunk_t chain */
+  ECMA_STRING_CONTAINER_STRING_DATA, /**< actual data is on the heap */
   ECMA_STRING_CONTAINER_HEAP_NUMBER, /**< actual data is on the heap as a ecma_number_t */
   ECMA_STRING_CONTAINER_UINT32_IN_DESC, /**< actual data is UInt32-represeneted Number
                                              stored locally in the string's descriptor */
@@ -794,6 +793,18 @@ FIXME (Move to library that should define the type (literal.h /* ? */))
  */
 typedef rcs_record_t *literal_t;
 typedef rcs_cpointer_t lit_cpointer_t;
+
+#define ECMA_STRING_DATA_EXTRA_SIZE (2 * sizeof (uint16_t))
+
+/**
+ * ECMA string data descriptor
+ */
+typedef struct ecma_string_data_t
+{
+  uint16_t size;
+  uint16_t length;
+  lit_utf8_byte_t data;
+} ecma_string_data_t;
 
 /**
  * ECMA string-value descriptor
@@ -822,7 +833,7 @@ typedef struct ecma_string_t
     lit_cpointer_t lit_cp;
 
     /** Compressed pointer to an ecma_collection_header_t */
-    mem_cpointer_t collection_cp : ECMA_POINTER_FIELD_WIDTH;
+    mem_cpointer_t data_cp : ECMA_POINTER_FIELD_WIDTH;
 
     /** Compressed pointer to an ecma_number_t */
     mem_cpointer_t number_cp : ECMA_POINTER_FIELD_WIDTH;


### PR DESCRIPTION
Remove char collection from ecma_strings, and use a heap buffer instead, where we also store string size and length.

Results (measured on rpi2):

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js | 136 -> 136  (0) | 3.728 -> 3.71  (0.4828) | 
                          3d-raytrace.js | 304 -> 264  (13.1579) | 5.918 -> 5.554  (6.1507) | 
                  access-binary-trees.js | 88 -> 92  (-4.545) | 2.72 -> 2.72  (0) |
                      access-fannkuch.js | 52 -> 52  (0) | 10.03 -> 9.94  (0.8973) | 
                         access-nbody.js | 68 -> 68  (0) | 4.65 -> 4.63  (0.4301) | 
             bitops-3bit-bits-in-byte.js | 40 -> 40  (0) | 3.18 -> 3.13  (1.5723) | 
                  bitops-bits-in-byte.js | 40 -> 40  (0) | 4.35 -> 4.36  (-0.23) | 
                   bitops-bitwise-and.js | 36 -> 36  (0) | 4.26 -> 4.26  (0) | 
                controlflow-recursive.js | 224 -> 224  (0) | 3.23 -> 3.17  (1.8576) | 
                           crypto-aes.js | 156 -> 152  (2.5641) | 5.96 -> 5.71  (4.1946) | 
                           crypto-md5.js | 216 -> 212  (1.8519) | 33.57 -> 10.53  (68.6327) | 
                          crypto-sha1.js | 156 -> 152  (2.5641) | 15.1 -> 5.71  (62.1854) | 
                    date-format-xparb.js | 104 -> 96  (7.6923) | 2.03 -> 1.82  (10.3448) | 
                          math-cordic.js | 48 -> 48  (0) | 4.25 -> 4.23  (0.4706) | 
                    math-partial-sums.js | 40 -> 40  (0) | 2.55 -> 2.5  (1.9608) | 
                   math-spectral-norm.js | 52 -> 52  (0) | 3.22 -> 3.18  (1.2422) | 
                        string-base64.js | 192 -> 164  (14.5833) | 235.22 -> 38.6  (83.5898) | 
                         string-fasta.js | 60 -> 60  (0) | 5.54 -> 4.72  (14.8014) | 
                         Geometric mean: |       RSS reduction: 2.2246% |           Speed up: 21.6495% |