### PR TITLE
Fix prop_getters stack manipulation for assignment expression. Fix for  #614

### DIFF
--- a/jerry-core/parser/js/opcodes-dumper.h
+++ b/jerry-core/parser/js/opcodes-dumper.h
@@ -425,7 +425,7 @@ void rewrite_conditional_check (void);
 void dump_jump_to_end_for_rewrite (void);
 void rewrite_jump_to_end (void);
 
-void start_dumping_assignment_expression (void);
+void start_dumping_assignment_expression (jsp_operand_t, locus);
 jsp_operand_t dump_prop_setter_or_variable_assignment_res (jsp_operand_t, jsp_operand_t);
 jsp_operand_t dump_prop_setter_or_addition_res (jsp_operand_t, jsp_operand_t);
 jsp_operand_t dump_prop_setter_or_multiplication_res (jsp_operand_t, jsp_operand_t);

--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -1730,6 +1730,7 @@ static jsp_operand_t
 parse_assignment_expression (bool in_allowed)
 {
   bool is_conditional = false;
+  locus loc_expr = tok.loc;
   jsp_operand_t expr = parse_conditional_expression (in_allowed, &is_conditional);
   if (is_conditional)
   {
@@ -1755,7 +1756,7 @@ parse_assignment_expression (bool in_allowed)
   {
     jsp_early_error_check_for_eval_and_arguments_in_strict_mode (expr, is_strict_mode (), tok.loc);
     skip_newlines ();
-    start_dumping_assignment_expression ();
+    start_dumping_assignment_expression (expr, loc_expr);
     const jsp_operand_t assign_expr = parse_assignment_expression (in_allowed);
 
     if (tt == TOK_EQ)

--- a/tests/jerry/regression-test-issue-614.js
+++ b/tests/jerry/regression-test-issue-614.js
@@ -1,0 +1,26 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+JSON.stringify & (Date = 1);
+
+b = 1;
+this.a = 2;
+this.a
+b = 3;
+assert(b == 3);
+assert(a == 2);
+this.a & (b = 4);
+assert(b == 4);
+assert(a == 2);


### PR DESCRIPTION
Current implementation of Jerry checks whether the last dumped opcode is 'prop_getter' before treating rhs of assignment expression. If it is, it assumes lhs was temporary register operand which is not always true. 

`this.a; b = 1;` is a counter example. Here after parsing lsh of `b = 1`, the last opcode is still 'prop_getter' (result of `this.a`) while in actually the lhs is not temporary register operand and the last opcode is not standing for the lhs. Issue #614 reported it.

This PR is to fix it.