### PR TITLE
Fix ecma_builtin_global_object_decode_uri_helper

### DIFF
--- a/jerry-core/lit/lit-strings.cpp
+++ b/jerry-core/lit/lit-strings.cpp
@@ -223,26 +223,26 @@ lit_is_cesu8_string_valid (const lit_utf8_byte_t *utf8_buf_p, /**< utf-8 string 
 } /* lit_is_cesu8_string_valid */
 
 /**
- * Check if the code unit type is low surrogate
+ * Check if the code point is UTF-16 low surrogate
  *
  * @return true / false
  */
 bool
-lit_is_code_unit_low_surrogate (ecma_char_t code_unit) /**< code unit */
+lit_is_code_point_utf16_low_surrogate (lit_code_point_t code_point) /**< code point */
 {
-  return LIT_UTF16_LOW_SURROGATE_MIN <= code_unit && code_unit <= LIT_UTF16_LOW_SURROGATE_MAX;
-} /* lit_is_code_unit_low_surrogate */
+  return LIT_UTF16_LOW_SURROGATE_MIN <= code_point && code_point <= LIT_UTF16_LOW_SURROGATE_MAX;
+} /* lit_is_code_point_utf16_low_surrogate */
 
 /**
- * Check if the code unit type is high surrogate
+ * Check if the code point is UTF-16 high surrogate
  *
  * @return true / false
  */
 bool
-lit_is_code_unit_high_surrogate (ecma_char_t code_unit) /**< code unit */
+lit_is_code_point_utf16_high_surrogate (lit_code_point_t code_point) /**< code point */
 {
-  return LIT_UTF16_HIGH_SURROGATE_MIN <= code_unit && code_unit <= LIT_UTF16_HIGH_SURROGATE_MAX;
-} /* lit_is_code_unit_high_surrogate */
+  return LIT_UTF16_HIGH_SURROGATE_MIN <= code_point && code_point <= LIT_UTF16_HIGH_SURROGATE_MAX;
+} /* lit_is_code_point_utf16_high_surrogate */
 
 /**
  * Initialize iterator for traversing utf-8 string as a string of code units
@@ -925,8 +925,8 @@ lit_code_point_t
 lit_convert_surrogate_pair_to_code_point (ecma_char_t high_surrogate, /**< high surrogate code point */
                                           ecma_char_t low_surrogate) /**< low surrogate code point */
 {
-  JERRY_ASSERT (lit_is_code_unit_high_surrogate (high_surrogate));
-  JERRY_ASSERT (lit_is_code_unit_low_surrogate (low_surrogate));
+  JERRY_ASSERT (lit_is_code_point_utf16_high_surrogate (high_surrogate));
+  JERRY_ASSERT (lit_is_code_point_utf16_low_surrogate (low_surrogate));
 
   lit_code_point_t code_point;
   code_point = (uint16_t) (high_surrogate - LIT_UTF16_HIGH_SURROGATE_MIN);

--- a/jerry-core/lit/lit-strings.h
+++ b/jerry-core/lit/lit-strings.h
@@ -126,8 +126,8 @@ bool lit_is_utf8_string_valid (const lit_utf8_byte_t *, lit_utf8_size_t);
 bool lit_is_cesu8_string_valid (const lit_utf8_byte_t *, lit_utf8_size_t);
 
 /* checks */
-bool lit_is_code_unit_low_surrogate (ecma_char_t);
-bool lit_is_code_unit_high_surrogate (ecma_char_t);
+bool lit_is_code_point_utf16_low_surrogate (lit_code_point_t);
+bool lit_is_code_point_utf16_high_surrogate (lit_code_point_t);
 
 /* iteration */
 lit_utf8_iterator_t lit_utf8_iterator_create (const lit_utf8_byte_t *, lit_utf8_size_t);

--- a/jerry-core/parser/js/lexer.cpp
+++ b/jerry-core/parser/js/lexer.cpp
@@ -475,8 +475,8 @@ lexer_transform_escape_sequences (const jerry_api_char_t *source_str_p, /**< str
       converted_char = next_char;
     }
 
-    if (lit_is_code_unit_high_surrogate (prev_converted_char)
-        && lit_is_code_unit_low_surrogate (converted_char))
+    if (lit_is_code_point_utf16_high_surrogate (prev_converted_char)
+        && lit_is_code_point_utf16_low_surrogate (converted_char))
     {
       output_str_buf_iter_p -= LIT_UTF8_MAX_BYTES_IN_CODE_UNIT;
 


### PR DESCRIPTION
@zherczeg, @dbatyai, please, check if the changes actually reflect semantics of decodeURI routine defined by ECMA-262 specification. Could you, please, also suggest some formal way to check current implementation on accordance to specification (except running test262 or some other test suite)?

However, the following test262 tests are fixed with the changes:
 - ch15/15.1/15.1.3/15.1.3.1/S15.1.3.1_A2.5_T1
 - ch15/15.1/15.1.3/15.1.3.2/S15.1.3.2_A2.5_T1

Related issue: #692