### PR TITLE
Fix PropertyName not to be resolved as a local variable

### DIFF
--- a/jerry-core/vm/vm-opcodes.inc.h
+++ b/jerry-core/vm/vm-opcodes.inc.h
@@ -298,7 +298,8 @@ VM_OP_3 (reg_var_decl,          REG_VAR_DECL,
          arg_regs_num,          VM_OP_ARG_TYPE_INTEGER_CONST)
 
 VM_OP_3 (meta,                  META,
-         type,                  VM_OP_ARG_TYPE_INTEGER_CONST,
+         type,                  VM_OP_ARG_TYPE_INTEGER_CONST |
+                                VM_OP_ARG_TYPE_TYPE_OF_NEXT,
          data_1,                VM_OP_ARG_TYPE_INTEGER_CONST |
                                 VM_OP_ARG_TYPE_STRING |
                                 VM_OP_ARG_TYPE_VARIABLE,

--- a/tests/jerry/regression-test-issue-703.js
+++ b/tests/jerry/regression-test-issue-703.js
@@ -1,0 +1,26 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function f(a, b) {
+  return {
+    a: a,
+    b: b
+  };
+}
+
+var o = f('1', '2');
+
+assert(o.a == '1');
+assert(o.b == '2');


### PR DESCRIPTION
I was trying to build IoT.js with latest Jerry, but some of IoT.js tests fail. I made an example that causes this error.
```javascript
function f(a, b) {
  return {
    a: a,
    b: b
  };
}
f('1', '2');
```

Byte code for this was:
```
LITERALS:
0x96a704 [  8] f : STRING
0x96a70c [  8] a : STRING
0x96a714 [  8] b : STRING
0x96a71c [  8] 1 : STRING
0x96a724 [  8] 2 : STRING
0x96a72c [ 20]  : EMPTY RECORD
...
  6:             obj_decl  131    0    2     // 
  7:                 meta    3  132  132     // 
  8:                 meta    3  133  133     // tmp131 = {tmp132:tmp132, tmp133:tmp133};
...
```

In the bytecode line 7 and 8, their second arguments must be string literals because **PropertyName** is always a string not an identifier.

Should be just like below:
```
  7:                 meta    3    1  132     // 
  8:                 meta    3    2  133     // tmp131 = {a:tmp132, b:tmp133};
```
