### PR TITLE
Eliminate templates from jrt_read_from_buffer_by_offset and jrt_write_to_buffer_by_offset

### DIFF
--- a/jerry-core/jerry.cpp
+++ b/jerry-core/jerry.cpp
@@ -1608,7 +1608,8 @@ jerry_parse_and_save_snapshot (const jerry_api_char_t* source_p, /**< script sou
   if (!jrt_write_to_buffer_by_offset (buffer_p,
                                       buffer_size,
                                       &buffer_write_offset,
-                                      version))
+                                      &version,
+                                      sizeof (version)))
   {
     return 0;
   }
@@ -1657,7 +1658,7 @@ jerry_parse_and_save_snapshot (const jerry_api_char_t* source_p, /**< script sou
     return 0;
   }
 
-  is_ok = jrt_write_to_buffer_by_offset (buffer_p, buffer_size, &header_offset, header);
+  is_ok = jrt_write_to_buffer_by_offset (buffer_p, buffer_size, &header_offset, &header, sizeof (header));
   JERRY_ASSERT (is_ok && header_offset < buffer_write_offset);
 
   return buffer_write_offset;
@@ -1702,7 +1703,8 @@ jerry_exec_snapshot (const void *snapshot_p, /**< snapshot */
   if (!jrt_read_from_buffer_by_offset (snapshot_data_p,
                                        snapshot_size,
                                        &snapshot_read,
-                                       &version))
+                                       &version,
+                                       sizeof (version)))
   {
     return JERRY_COMPLETION_CODE_INVALID_SNAPSHOT_FORMAT;
   }

--- a/jerry-core/jrt/jrt.cpp
+++ b/jerry-core/jrt/jrt.cpp
@@ -1,0 +1,75 @@
+/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+
+#include "jrt.h"
+
+/**
+ * Read data of specified type from specified buffer
+ *
+ * Note:
+ *      Offset is in-out and is incremented if the read operation completes successfully.
+ *
+ * @return true, if read was successful, i.e. offset + sizeof (data) doesn't exceed buffer size,
+ *         false - otherwise.
+ */
+
+bool __attr_always_inline___
+jrt_read_from_buffer_by_offset (const uint8_t *buffer_p, /**< buffer */
+                                size_t buffer_size, /**< size of buffer */
+                                size_t *in_out_buffer_offset_p, /**< in: offset to read from,
+                                                                 *   out: offset, incremented on sizeof (T) */
+                                void *out_data_p, /**< out: data */
+                                size_t out_data_size) /**< size of the out_data */
+{
+  if (*in_out_buffer_offset_p + out_data_size > buffer_size)
+  {
+    return false;
+  }
+
+  memcpy (out_data_p, buffer_p + *in_out_buffer_offset_p, out_data_size);
+  *in_out_buffer_offset_p += out_data_size;
+
+  return true;
+} /* jrt_read_from_buffer_by_offset */
+
+/**
+ * Write data of specified type to specified buffer
+ *
+ * Note:
+ *      Offset is in-out and is incremented if the write operation completes successfully.
+ *
+ * @return true, if write was successful, i.e. offset + sizeof (data) doesn't exceed buffer size,
+ *         false - otherwise.
+ */
+bool __attr_always_inline___
+jrt_write_to_buffer_by_offset (uint8_t *buffer_p, /**< buffer */
+                               size_t buffer_size, /**< size of buffer */
+                               size_t *in_out_buffer_offset_p, /**< in: offset to read from,
+                                                                *   out: offset, incremented on sizeof (T) */
+                               void *data_p, /**< data */
+                               size_t data_size) /**< size of data */
+{
+  if (*in_out_buffer_offset_p + data_size > buffer_size)
+  {
+    return false;
+  }
+
+  memcpy (buffer_p + *in_out_buffer_offset_p, data_p, data_size);
+  *in_out_buffer_offset_p += data_size;
+
+  return true;
+} /* jrt_write_to_buffer_by_offset */

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -17,7 +17,6 @@
 #define JERRY_GLOBALS_H
 
 #include <stdio.h>
-#include <string.h>
 
 #include "jerry.h"
 #include "jrt-types.h"
@@ -226,60 +225,10 @@ inline void *operator new (size_t, void *where)
   return where;
 } /* operator new */
 
-/**
- * Read data of specified type (T) from specified buffer
- *
- * Note:
- *      Offset is in-out and is incremented if the read operation completes successfully.
- *
- * @return true, if read was successful, i.e. offset + sizeof (T) doesn't exceed buffer size,
- *         false - otherwise.
- */
-template<typename T>
-bool __attr_always_inline___
-jrt_read_from_buffer_by_offset (const uint8_t *buffer_p, /**< buffer */
-                                size_t buffer_size, /**< size of buffer */
-                                size_t *in_out_buffer_offset_p, /**< in: offset to read from,
-                                                                 *   out: offset, incremented on sizeof (T) */
-                                T *out_data_p) /**< out: data */
-{
-  if (*in_out_buffer_offset_p + sizeof (T) > buffer_size)
-  {
-    return false;
-  }
+extern bool
+jrt_read_from_buffer_by_offset (const uint8_t *, size_t, size_t *, void *, size_t);
 
-  memcpy (out_data_p, buffer_p + *in_out_buffer_offset_p, sizeof (T));
-  *in_out_buffer_offset_p += sizeof (T);
-
-  return true;
-} /* jrt_read_from_buffer_by_offset */
-
-/**
- * Write data of specified type (T) to specified buffer
- *
- * Note:
- *      Offset is in-out and is incremented if the write operation completes successfully.
- *
- * @return true, if write was successful, i.e. offset + sizeof (T) doesn't exceed buffer size,
- *         false - otherwise.
- */
-template<typename T>
-bool __attr_always_inline___
-jrt_write_to_buffer_by_offset (uint8_t *buffer_p, /**< buffer */
-                               size_t buffer_size, /**< size of buffer */
-                               size_t *in_out_buffer_offset_p, /**< in: offset to read from,
-                                                                *   out: offset, incremented on sizeof (T) */
-                               T data) /**< data */
-{
-  if (*in_out_buffer_offset_p + sizeof (T) > buffer_size)
-  {
-    return false;
-  }
-
-  memcpy (buffer_p + *in_out_buffer_offset_p, &data, sizeof (T));
-  *in_out_buffer_offset_p += sizeof (T);
-
-  return true;
-} /* jrt_write_to_buffer_by_offset */
+extern bool
+jrt_write_to_buffer_by_offset (uint8_t *, size_t, size_t *, void *, size_t);
 
 #endif /* !JERRY_GLOBALS_H */

--- a/jerry-core/lit/lit-literal-storage.cpp
+++ b/jerry-core/lit/lit-literal-storage.cpp
@@ -232,7 +232,7 @@ lit_charset_record_t::dump_for_snapshot (uint8_t *buffer_p, /**< buffer to dump 
                                          size_t *in_out_buffer_offset_p) /**< in-out: buffer write offset */
 {
   lit_utf8_size_t length = get_length ();
-  if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, length))
+  if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, &length, sizeof (length)))
   {
     return 0;
   }
@@ -246,7 +246,7 @@ lit_charset_record_t::dump_for_snapshot (uint8_t *buffer_p, /**< buffer to dump 
     lit_utf8_byte_t next_byte = it_this.read<lit_utf8_byte_t> ();
     it_this.skip<lit_utf8_byte_t> ();
 
-    if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, next_byte))
+    if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, &next_byte, sizeof (next_byte)))
     {
       return 0;
     }
@@ -269,7 +269,7 @@ lit_number_record_t::dump_for_snapshot (uint8_t *buffer_p, /**< buffer to dump t
   /* dumping as double (not ecma_number_t), because ecma_number_t can be float or double,
    * depending on engine compile-time configuration */
   double num = get_number ();
-  if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, num))
+  if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, &num, sizeof (num)))
   {
     return 0;
   }
@@ -566,7 +566,11 @@ lit_dump_literals_for_snapshot (uint8_t *buffer_p, /**< output snapshot buffer *
   *out_map_num_p = 0;
   *out_lit_table_size_p = 0;
 
-  if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, literals_num))
+  if (!jrt_write_to_buffer_by_offset (buffer_p,
+                                      buffer_size,
+                                      in_out_buffer_offset_p,
+                                      &literals_num,
+                                      sizeof (literals_num)))
   {
     return false;
   }
@@ -594,7 +598,7 @@ lit_dump_literals_for_snapshot (uint8_t *buffer_p, /**< output snapshot buffer *
         continue;
       }
 
-      if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, type))
+      if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, &type, sizeof (type)))
       {
         is_ok = false;
         break;
@@ -677,7 +681,7 @@ lit_dump_literals_for_snapshot (uint8_t *buffer_p, /**< output snapshot buffer *
 
     for (uint32_t i = 0; i < padding_bytes_num; i++)
     {
-      if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, padding))
+      if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, &padding, sizeof (padding)))
       {
         return false;
       }
@@ -721,7 +725,8 @@ lit_load_literals_from_snapshot (const uint8_t *lit_table_p, /**< buffer with li
   if (!jrt_read_from_buffer_by_offset (lit_table_p,
                                        lit_table_size,
                                        &lit_table_read,
-                                       &literals_num))
+                                       &literals_num,
+                                       sizeof (literals_num)))
   {
     return false;
   }
@@ -746,7 +751,8 @@ lit_load_literals_from_snapshot (const uint8_t *lit_table_p, /**< buffer with li
     if (!jrt_read_from_buffer_by_offset (lit_table_p,
                                          lit_table_size,
                                          &lit_table_read,
-                                         &type))
+                                         &type,
+                                         sizeof (type)))
     {
       is_ok = false;
       break;
@@ -760,7 +766,8 @@ lit_load_literals_from_snapshot (const uint8_t *lit_table_p, /**< buffer with li
       if (!jrt_read_from_buffer_by_offset (lit_table_p,
                                            lit_table_size,
                                            &lit_table_read,
-                                           &length)
+                                           &length,
+                                           sizeof (length))
           || (lit_table_read + length > lit_table_size))
       {
         is_ok = false;
@@ -776,7 +783,8 @@ lit_load_literals_from_snapshot (const uint8_t *lit_table_p, /**< buffer with li
       if (!jrt_read_from_buffer_by_offset (lit_table_p,
                                            lit_table_size,
                                            &lit_table_read,
-                                           &id))
+                                           &id,
+                                           sizeof (id)))
       {
         is_ok = false;
         break;
@@ -797,7 +805,8 @@ lit_load_literals_from_snapshot (const uint8_t *lit_table_p, /**< buffer with li
       if (!jrt_read_from_buffer_by_offset (lit_table_p,
                                            lit_table_size,
                                            &lit_table_read,
-                                           &id))
+                                           &id,
+                                           sizeof (id)))
       {
         is_ok = false;
         break;
@@ -818,7 +827,8 @@ lit_load_literals_from_snapshot (const uint8_t *lit_table_p, /**< buffer with li
       if (!jrt_read_from_buffer_by_offset (lit_table_p,
                                            lit_table_size,
                                            &lit_table_read,
-                                           &num))
+                                           &num,
+                                           sizeof (num)))
       {
         is_ok = false;
         break;

--- a/jerry-core/lit/lit-literal-storage.h
+++ b/jerry-core/lit/lit-literal-storage.h
@@ -257,7 +257,7 @@ public:
                               size_t *in_out_buffer_offset_p) const /**< in-out: buffer write offset */
   {
     magic_string_id_t id = get_magic_str_id<magic_string_id_t> ();
-    if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, id))
+    if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, &id, sizeof (id)))
     {
       return 0;
     }

--- a/jerry-core/parser/js/collections/lit-id-hash-table.cpp
+++ b/jerry-core/parser/js/collections/lit-id-hash-table.cpp
@@ -148,7 +148,11 @@ lit_id_hash_table_dump_for_snapshot (uint8_t *buffer_p, /**< buffer to dump to *
   uint32_t idx_num_total = (uint32_t) table_p->current_bucket_pos;
   JERRY_ASSERT (idx_num_total == table_p->current_bucket_pos);
 
-  if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, idx_num_total))
+  if (!jrt_write_to_buffer_by_offset (buffer_p,
+                                      buffer_size,
+                                      in_out_buffer_offset_p,
+                                      &idx_num_total,
+                                      sizeof (idx_num_total)))
   {
     return 0;
   }
@@ -183,7 +187,11 @@ lit_id_hash_table_dump_for_snapshot (uint8_t *buffer_p, /**< buffer to dump to *
       idx_num_in_block = 0;
     }
 
-    if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, idx_num_in_block))
+    if (!jrt_write_to_buffer_by_offset (buffer_p,
+                                        buffer_size,
+                                        in_out_buffer_offset_p,
+                                        &idx_num_in_block,
+                                        sizeof (idx_num_in_block)))
     {
       return 0;
     }
@@ -205,7 +213,7 @@ lit_id_hash_table_dump_for_snapshot (uint8_t *buffer_p, /**< buffer to dump to *
       JERRY_ASSERT (lit_index < literals_num);
 
       uint32_t offset = lit_map_p[lit_index].literal_offset;
-      if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, offset))
+      if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, &offset, sizeof (offset)))
       {
         return 0;
       }
@@ -215,7 +223,11 @@ lit_id_hash_table_dump_for_snapshot (uint8_t *buffer_p, /**< buffer to dump to *
     {
       idx_num_in_block = 0;
 
-      if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, idx_num_in_block))
+      if (!jrt_write_to_buffer_by_offset (buffer_p,
+                                          buffer_size,
+                                          in_out_buffer_offset_p,
+                                          &idx_num_in_block,
+                                          sizeof (idx_num_in_block)))
       {
         return 0;
       }
@@ -263,7 +275,8 @@ lit_id_hash_table_load_from_snapshot (size_t blocks_count, /**< number of byte-c
     if (!jrt_read_from_buffer_by_offset (idx_to_lit_map_p,
                                          idx_to_lit_map_size,
                                          &idx_to_lit_map_offset,
-                                         &idx_num_in_block))
+                                         &idx_num_in_block,
+                                         sizeof (idx_num_in_block)))
     {
       return false;
     }
@@ -287,7 +300,8 @@ lit_id_hash_table_load_from_snapshot (size_t blocks_count, /**< number of byte-c
       if (!jrt_read_from_buffer_by_offset (idx_to_lit_map_p,
                                            idx_to_lit_map_size,
                                            &idx_to_lit_map_offset,
-                                           &lit_offset_from_snapshot))
+                                           &lit_offset_from_snapshot,
+                                           sizeof (lit_offset_from_snapshot)))
       {
         return false;
       }

--- a/jerry-core/parser/js/serializer.cpp
+++ b/jerry-core/parser/js/serializer.cpp
@@ -420,7 +420,8 @@ serializer_load_bytecode_with_idx_map (const uint8_t *bytecode_and_idx_map_p, /*
   if (!jrt_read_from_buffer_by_offset (idx_to_lit_map_p,
                                        idx_to_lit_map_size,
                                        &idx_to_lit_map_offset,
-                                       &idx_num_total))
+                                       &idx_num_total,
+                                       sizeof (idx_num_total)))
   {
     return NULL;
   }


### PR DESCRIPTION
Refactor jrt_read_from_buffer_by_offset and jrt_write_to_buffer_by_offset to eliminate template.

JerryScript-DCO-1.0-Signed-off-by: Roland Takacs rtakacs.u-szeged@partner.samsung.com