### PR TITLE
Use rcs_record_iterator_t::skip(size_t) instead of its template version.

### DIFF
--- a/jerry-core/lit/lit-literal-storage.cpp
+++ b/jerry-core/lit/lit-literal-storage.cpp
@@ -70,7 +70,7 @@ lit_charset_record_t::set_charset (const lit_utf8_byte_t *str, /**< buffer conta
   for (lit_utf8_size_t i = 0; i < get_length (); ++i)
   {
     it.write<lit_utf8_byte_t> (str[i]);
-    it.skip<lit_utf8_byte_t> ();
+    it.skip (sizeof (lit_utf8_byte_t));
   }
 } /* lit_charset_record_t::set_charset */
 
@@ -93,7 +93,7 @@ lit_charset_record_t::get_charset (lit_utf8_byte_t *buff, /**< output buffer */
   for (i = 0; i < len && size > 0; ++i)
   {
     buff[i] = it.read<lit_utf8_byte_t> ();
-    it.skip<lit_utf8_byte_t> ();
+    it.skip (sizeof (lit_utf8_byte_t));
     size -= sizeof (lit_utf8_byte_t);
   }
 
@@ -148,7 +148,7 @@ lit_charset_record_t::compare_utf8 (const lit_utf8_byte_t *str_to_compare_with, 
       return -1;
     }
 
-    it_this.skip<lit_utf8_byte_t> ();
+    it_this.skip (sizeof (lit_utf8_byte_t));
   }
 
   if (i < str_size)
@@ -186,8 +186,8 @@ lit_charset_record_t::is_equal (lit_charset_record_t *rec) /**< charset record t
       return false;
     }
 
-    it_this.skip<lit_utf8_byte_t> ();
-    it_record.skip<lit_utf8_byte_t> ();
+    it_this.skip (sizeof (lit_utf8_byte_t));
+    it_record.skip (sizeof (lit_utf8_byte_t));
   }
 
   return true;
@@ -214,7 +214,7 @@ lit_charset_record_t::is_equal_utf8_string (const lit_utf8_byte_t *str, /**< str
       return false;
     }
 
-    it_this.skip<lit_utf8_byte_t> ();
+    it_this.skip (sizeof (lit_utf8_byte_t));
   }
 
   return get_length () == str_size;
@@ -244,7 +244,7 @@ lit_charset_record_t::dump_for_snapshot (uint8_t *buffer_p, /**< buffer to dump 
   for (lit_utf8_size_t i = 0; i < length; i++)
   {
     lit_utf8_byte_t next_byte = it_this.read<lit_utf8_byte_t> ();
-    it_this.skip<lit_utf8_byte_t> ();
+    it_this.skip (sizeof (lit_utf8_byte_t));
 
     if (!jrt_write_to_buffer_by_offset (buffer_p, buffer_size, in_out_buffer_offset_p, next_byte))
     {
@@ -392,7 +392,7 @@ lit_literal_storage_t::dump ()
         {
           FIXME ("Support proper printing of characters which occupy more than one byte.")
           printf ("%c", it_this.read<lit_utf8_byte_t> ());
-          it_this.skip<lit_utf8_byte_t> ();
+          it_this.skip (sizeof (lit_utf8_byte_t));
         }
 
         printf (" : STRING");
@@ -851,10 +851,6 @@ lit_load_literals_from_snapshot (const uint8_t *lit_table_p, /**< buffer with li
   }
 } /* lit_load_literals_from_snapshot */
 #endif /* JERRY_ENABLE_SNAPSHOT */
-
-template void rcs_record_iterator_t::skip<uint8_t> ();
-template void rcs_record_iterator_t::skip<uint16_t> ();
-template void rcs_record_iterator_t::skip<uint32_t> ();
 
 template void rcs_record_iterator_t::write<uint8_t> (uint8_t);
 template uint8_t rcs_record_iterator_t::read<uint8_t> ();

--- a/jerry-core/rcs/rcs-recordset.h
+++ b/jerry-core/rcs/rcs-recordset.h
@@ -297,14 +297,6 @@ public:
   } /* write */
 
   /**
-   * Increment current position to skip T value in the record.
-   */
-  template<typename T> void skip ()
-  {
-    access (ACCESS_SKIP, NULL, sizeof (T));
-  } /* skip */
-
-  /**
    * Increment current position to skip 'size' bytes.
    */
   void skip (size_t size) /**< number of bytes to skip */

--- a/tests/unit/test-recordset.cpp
+++ b/tests/unit/test-recordset.cpp
@@ -243,9 +243,11 @@ main (int __attr_unused___ argc,
         JERRY_ASSERT (type_one_records[type_one_records_number] != NULL);
 
         rcs_record_iterator_t it (&storage, type_one_records[type_one_records_number]);
-        it.skip<uint32_t> (); // skip header
-        it.skip<uint32_t> (); // skip header
-        for (uint32_t i = 0; i < type_one_record_element_counts[type_one_records_number]; it.skip<uint16_t>(), i++)
+        it.skip (sizeof (uint32_t)); // skip header
+        it.skip (sizeof (uint32_t)); // skip header
+        for (uint32_t i = 0;
+             i < type_one_record_element_counts[type_one_records_number];
+             it.skip (sizeof (uint16_t)), i++)
         {
           uint16_t val = (uint16_t)rand ();
           type_one_record_elements[type_one_records_number][i] = val;
@@ -255,9 +257,11 @@ main (int __attr_unused___ argc,
         JERRY_ASSERT (type_one_records[type_one_records_number] != NULL);
 
         it.reset ();
-        it.skip<uint32_t> (); // skip header
-        it.skip<uint32_t> (); // skip header
-        for (uint32_t i = 0; i < type_one_record_element_counts[type_one_records_number]; it.skip<uint16_t>(), i++)
+        it.skip (sizeof (uint32_t)); // skip header
+        it.skip (sizeof (uint32_t)); // skip header
+        for (uint32_t i = 0;
+            i < type_one_record_element_counts[type_one_records_number];
+            it.skip (sizeof (uint16_t)), i++)
         {
           uint16_t val = type_one_record_elements[type_one_records_number][i];
           JERRY_ASSERT (val == it.read<uint16_t> ());
@@ -287,9 +291,11 @@ main (int __attr_unused___ argc,
         JERRY_ASSERT (index_to_free >= 0 && index_to_free < type_one_records_number);
 
         rcs_record_iterator_t it (&storage, type_one_records[index_to_free]);
-        it.skip<uint32_t> (); // skip header
-        it.skip<uint32_t> (); // skip header
-        for (uint32_t i = 0; i < type_one_record_element_counts[index_to_free]; it.skip<uint16_t>(), i++)
+        it.skip (sizeof (uint32_t)); // skip header
+        it.skip (sizeof (uint32_t)); // skip header
+        for (uint32_t i = 0;
+             i < type_one_record_element_counts[index_to_free];
+             it.skip (sizeof (uint16_t)), i++)
         {
           uint16_t val = type_one_record_elements[index_to_free][i];
           JERRY_ASSERT (it.read <uint16_t> () == val);
@@ -326,9 +332,11 @@ main (int __attr_unused___ argc,
         JERRY_ASSERT (index_to_free >= 0 && index_to_free < type_one_records_number);
 
         rcs_record_iterator_t it (&storage, type_one_records[index_to_free]);
-        it.skip<uint32_t> (); // skip header
-        it.skip<uint32_t> (); // skip header
-        for (uint32_t i = 0; i < type_one_record_element_counts[index_to_free]; it.skip<uint16_t>(), i++)
+        it.skip (sizeof (uint32_t)); // skip header
+        it.skip (sizeof (uint32_t)); // skip header
+        for (uint32_t i = 0;
+             i < type_one_record_element_counts[index_to_free];
+             it.skip (sizeof (uint16_t)), i++)
         {
           uint16_t val = type_one_record_elements[index_to_free][i];
           JERRY_ASSERT (it.read <uint16_t> () == val);


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Roland Takacs rtakacs.u-szeged@partner.samsung.com