### PR TITLE
Add a "Hello JerryScript!" program to the tests

### DIFF
--- a/tests/hello.js
+++ b/tests/hello.js
@@ -1,0 +1,16 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+print ("Hello JerryScript!");


### PR DESCRIPTION
The current code base does not contain any "first JavaScript
program" for those who build JerryScript for Linux console. It
does contain a LED-blinking example -- blinky.js -- but that's
only useful on an developer board where LEDs-to-be-blinked are
available. And the rest of the tests are just that: tests, giving
passed/failed information but nothing eye candy.

This patch adds a simple JS script that can act as a warm welcome
to anyone after the first successful build trying to run something
proving that Jerry works.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu