### PR TITLE
fix a bug in linked_list memory allocation

### DIFF
--- a/jerry-core/parser/js/collections/linked-list.cpp
+++ b/jerry-core/parser/js/collections/linked-list.cpp
@@ -50,12 +50,12 @@ linked_list_block_size (bool is_first_chunk) /**< is it first chunk (chunk, cont
 {
   if (is_first_chunk)
   {
-    return (jsp_mm_recommend_size (sizeof (linked_list_header) + 1u) - sizeof (linked_list_header));
+    return (jsp_mm_recommend_size (sizeof (linked_list_header) + sizeof (linked_list_chunk_header) + 1u)
+            - sizeof (linked_list_header) - sizeof (linked_list_chunk_header));
   }
   else
   {
-    return (jsp_mm_recommend_size (sizeof (linked_list_header) + sizeof (linked_list_chunk_header) + 1u)
-            - sizeof (linked_list_header) - sizeof (linked_list_chunk_header));
+    return (jsp_mm_recommend_size (sizeof (linked_list_chunk_header) + 1u) - sizeof (linked_list_chunk_header));
   }
 } /* linked_list_block_size */
 
@@ -152,7 +152,7 @@ linked_list_switch_to_next_elem (linked_list_header *header_p, /**< list header 
   linked_list_chunk_header *chunk_header_p = *in_out_chunk_header_p;
 
   const size_t element_size = header_p->element_size;
-  const bool is_first_chunk = ((linked_list_chunk_header *) header_p + 1u == chunk_header_p);
+  const bool is_first_chunk = ((linked_list_chunk_header *) (header_p + 1u) == chunk_header_p);
 
   JERRY_ASSERT (raw_elem_ptr_p + element_size
                 <= (uint8_t *) (chunk_header_p + 1u) + linked_list_block_size (is_first_chunk));


### PR DESCRIPTION
The correct heap block for linked_list should be like:
*  first chunk
  
| jsp_mm_header | linked_list_header | linked_list_chunk_header | data |
* non-first chunk

| jsp_mm_header | linked_list_chunk_header | data |

---
However the linked_list_block_size() shows
*  first chunk
 
| jsp_mm_header | linked_list_header | data |

* non-first chunk
 
| jsp_mm_header | linked_list_header | linked_list_chunk_header | data |

 **it is wrong**
it will cause more waste and fragment in mem_heap.


---
After the patch, the performance and rss data are as follows:

in ubuntu14.04 32bit  3.16.0-30-generic, Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz

**data is updated after @ruben-ayrapetyan's fix**

`jzd@jzd32:~/jerryscript$ ./tools/run-perf-test.sh compare_engine/jerry.orig compare_engine/jerry.ll 5 5000 sunspider-1.0.2/`

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          136->   132 (2.941) |        0.352-> 0.352 (0.000) |
                  access-binary-trees.js |           88->    88 (0.000) |        0.164-> 0.164 (0.000) |
                      access-fannkuch.js |           48->    48 (0.000) |       0.916->0.9184 (-0.262) |
             bitops-3bit-bits-in-byte.js |           44->    40 (9.091) |        0.276-> 0.276 (0.000) |
                  bitops-bits-in-byte.js |           40->    40 (0.000) |       0.3616->0.3616 (0.000) |
                   bitops-bitwise-and.js |           40->    40 (0.000) |       0.348->0.3496 (-0.460) |
                controlflow-recursive.js |          244->   240 (1.639) |       0.1536->0.1536 (0.000) |
                           crypto-aes.js |          160->   156 (2.500) |       0.6176-> 0.616 (0.259) |
                           crypto-md5.js |          208->   204 (1.923) |      3.7424->3.7448 (-0.064) |
                          crypto-sha1.js |         144->   148 (-2.778) |       1.616->  1.62 (-0.248) |
                    date-format-tofte.js |          116->   108 (6.897) |        0.396->0.3928 (0.808) |
                    date-format-xparb.js |           96->    96 (0.000) |        0.188-> 0.188 (0.000) |
                          math-cordic.js |           48->    48 (0.000) |       0.3856-> 0.384 (0.415) |
                   math-spectral-norm.js |           48->    44 (8.333) |          0.2->   0.2 (0.000) |
                        string-base64.js |         200->   204 (-2.000) |    28.6832->28.6928 (-0.033) |
                         string-fasta.js |           60->    60 (0.000) |        0.624-> 0.624 (0.000) |
                         Geometric mean: |       RSS reduction: 1.8434% |            Speed up: 0.0264% |

----
the RSS data is coarse and not stable because its minimal unit is 4k. 

We can see the mem-stats data for more details.

```
jzd@jzd32:~/jerryscript$ ./compare_engine/jerry.orig.mem --mem-stats sunspider-1.0.2/3d-cube.js
Heap stats:
  Heap size = 260096 bytes
  Chunk size = 64 bytes
  Allocated chunks count = 0
  Allocated = 0 bytes
  Waste = 0 bytes
  Peak allocated chunks count = 655
  Peak allocated = 41080 bytes
  Peak waste = 4181 bytes

jzd@jzd32:~/jerryscript$ ./compare_engine/jerry.ll.mem --mem-stats sunspider-1.0.2/3d-cube.js
Heap stats:
  Heap size = 260096 bytes
  Chunk size = 64 bytes
  Allocated chunks count = 0
  Allocated = 0 bytes
  Waste = 0 bytes
  Peak allocated chunks count = 646
  Peak allocated = 41080 bytes
  Peak waste = 725 bytes
```
for 3d-cube:
Peak allocated chunks count: 655 -> 646
Peak waste: 4181 -> 725 


```
jzd@jzd32:~/jerryscript$ ./compare_engine/jerry.orig.mem --mem-stats sunspider-1.0.2/access-fannkuch.js
Heap stats:
  Heap size = 260096 bytes
  Chunk size = 64 bytes
  Allocated chunks count = 0
  Allocated = 0 bytes
  Waste = 0 bytes
  Peak allocated chunks count = 104
  Peak allocated = 5967 bytes
  Peak waste = 689 bytes


jzd@jzd32:~/jerryscript$ ./compare_engine/jerry.ll.mem --mem-stats sunspider-1.0.2/access-fannkuch.js
Heap stats:
  Heap size = 260096 bytes
  Chunk size = 64 bytes
  Allocated chunks count = 0
  Allocated = 0 bytes
  Waste = 0 bytes
  Peak allocated chunks count = 99
  Peak allocated = 6099 bytes
  Peak waste = 237 bytes
```
for access-fannkuch.js
 Peak allocated chunks count: 104 -> 99
 Peak waste = 689 -> 237

