### PR TITLE
Fix parse error of parse_switch_statement

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -2447,7 +2447,7 @@ parse_switch_statement (void)
 {
   assert_keyword (KW_SWITCH);
 
-  const jsp_operand_t switch_expr = parse_expression_inside_parens ();
+  const jsp_operand_t switch_expr = dump_assignment_of_lhs_if_literal (parse_expression_inside_parens ());
   token_after_newlines_must_be (TOK_OPEN_BRACE);
 
   start_dumping_case_clauses ();
@@ -2529,7 +2529,6 @@ parse_switch_statement (void)
   }
 
   current_token_must_be (TOK_CLOSE_BRACE);
-  skip_token ();
 
   jsp_label_rewrite_jumps_and_pop (&label,
                                    serializer_get_current_instr_counter ());

--- a/tests/jerry/regression-test-issue-725.js
+++ b/tests/jerry/regression-test-issue-725.js
@@ -1,0 +1,22 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+	eval("switch(foo){} {}");
+	assert(false);
+} catch (e) {
+	assert(e instanceof ReferenceError);
+}
+


### PR DESCRIPTION
Related issue: #725

* Do not eat the last token of switch statement. (so it does not emit a SyntaxError)
* Add dump assignment bytecode if literal (so it emits a ReferenceError)