### PR TITLE
Add support of afl-fuzzer

### DIFF
--- a/build/configs/toolchain_afl_i686.cmake
+++ b/build/configs/toolchain_afl_i686.cmake
@@ -1,0 +1,21 @@
+# Copyright 2015 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeForceCompiler)
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR x86)
+
+CMAKE_FORCE_C_COMPILER(afl-gcc GNU)
+CMAKE_FORCE_CXX_COMPILER(afl-g++ GNU)

--- a/build/configs/toolchain_afl_x86_64.cmake
+++ b/build/configs/toolchain_afl_x86_64.cmake
@@ -1,0 +1,23 @@
+# Copyright 2015 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeForceCompiler)
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+CMAKE_FORCE_C_COMPILER(afl-gcc GNU)
+CMAKE_FORCE_CXX_COMPILER(afl-g++ GNU)
+
+set(FLAGS_COMMON_ARCH -ffixed-rbp)

--- a/jerry-core/jrt/jrt-fatals.cpp
+++ b/jerry-core/jrt/jrt-fatals.cpp
@@ -60,7 +60,9 @@ jerry_fatal (jerry_fatal_code_t code) /**< status code */
   }
 #endif /* !JERRY_NDEBUG */
 
-  if (code != 0 && jerry_is_abort_on_fail ())
+  if (code != 0
+      && code != ERR_OUT_OF_MEMORY
+      && jerry_is_abort_on_fail ())
   {
     abort ();
   }


### PR DESCRIPTION
Related issue: #333, #454

Works only with default libc:
```
$ make debug.linux -j TOOLCHAIN="./build/configs/toolchain_afl.cmake" USE_COMPILER_DEFAULT_LIBC=YES
```
JerryScript-DCO-1.0-Signed-off-by: Ruben Ayrapetyan r.ayrapetyan@samsung.com
JerryScript-DCO-1.0-Signed-off-by: Evgeny Gavrin e.gavrin@samsung.com