### PR TITLE
Update ecma_number_to_uint32 implementation, to improve performance

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -270,6 +270,7 @@ extern int32_t ecma_number_to_int32 (ecma_number_t);
 extern ecma_number_t ecma_int32_to_number (int32_t);
 extern ecma_number_t ecma_uint32_to_number (uint32_t);
 extern lit_utf8_size_t ecma_number_to_utf8_string (ecma_number_t, lit_utf8_byte_t *, ssize_t);
+extern void ecma_number_to_u32 (ecma_number_t, bool*, bool *, uint64_t*);
 
 #endif /* !JERRY_ECMA_HELPERS_H */
 


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Xin Hu Xin.A.Hu@intel.com

binary size is 292k.

Run ./tools/run-perf-test.sh 10 times, 
OS, ubuntu 15.04, 32 bit
CPU, Intel(R) Celeron(R) CPU  N2820  @ 2.13GHz, 2 core

                              Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                                     --------- |                          --- |                         ---- |
                                3d-cube.js |          136->   136 (0.000) |       1.2812->1.2608 (1.592) |                          
              access-binary-trees.js |           92->    92 (0.000) |        0.672-> 0.672 (0.000) |
                   access-fannkuch.js |           52->    52 (0.000) |       3.6228->3.5896 (0.916) |                   
          bitops-3bit-bits-in-byte.js |         40->    44 (-10.000) |       1.0516->0.9552 (9.167) |
                 bitops-bits-in-byte.js |          40->    36 (10.000) |       1.4816-> 1.408 (4.968) |
                 bitops-bitwise-and.js |         40->    44 (-10.000) |       1.4324->1.4164 (1.117) |                 
             controlflow-recursive.js |          244->   244 (0.000) |       0.6308->0.6196 (1.775) |
                             crypto-aes.js |          156->   156 (0.000) |        2.438->2.3564 (3.347) |
                            crypto-md5.js |          212->   208 (1.887) |      12.8976->12.804 (0.726) |
                           crypto-sha1.js |         144->   148 (-2.778) |       5.6252->5.5632 (1.102) |
                   date-format-tofte.js |          116->   116 (0.000) |        1.456->1.4364 (1.346) |
                 date-format-xparb.js |          92->    96 (-4.348) |        0.756-> 0.752 (0.529) |
                           math-cordic.js |           48->    48 (0.000) |       1.5388->1.4888 (3.249) |                  
              math-spectral-norm.js |           48->    48 (0.000) |       0.8436->0.8228 (2.466) |                        
                        string-base64.js |          204->   200 (1.961) |      87.0804->86.672 (0.469) |
                            string-fasta.js |           60->    60 (0.000) |       2.2488->2.2332 (0.694) |
                    
                      Geometric mean: |        RSS reduction: -0.73% |            Speed up: 2.1175% |


/* --------------------------------------------------------------------------------------------------------------------*/

ECMA spec 5.1 sec-9.6
ToUint32: (Unsigned 32 Bit Integer)

posInt = sign(n)*floor(abs(n))
Int32bit = posInt module (2<<32)

Here is my step.
1. extract biased exponent, sign, and fraction from a floating point
2. pack an unsigned 64 bit integer from biased exponent and fraction, that is floor(abs(n))
3. get floor(abs(n)) mod (2<<32)
4. set sign bit

This update is to avoid expensive multiple and divide operation.




