### PR TITLE
Fix lexing number literal

### DIFF
--- a/jerry-core/parser/js/lexer.cpp
+++ b/jerry-core/parser/js/lexer.cpp
@@ -936,7 +936,7 @@ lexer_parse_number (void)
 
       if (c == LIT_CHAR_DOT)
       {
-        if (is_fp)
+        if (is_fp || is_exp)
         {
           /* token is constructed at end of function */
           break;

--- a/tests/jerry/regression-test-issue-745.js
+++ b/tests/jerry/regression-test-issue-745.js
@@ -1,0 +1,22 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval("7E9.");
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+
+assert(7E9.toString() === "7000000000");


### PR DESCRIPTION
Related issue: #745

In number literal, after exponent part, `.` is not part of the literal.