### PR TITLE
Tab removal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,11 +420,11 @@ endif()
     target_include_directories(${TARGET_NAME} SYSTEM PRIVATE ${INCLUDE_EXTERNAL_LIBS_INTERFACE})
     if(("${PLATFORM}" STREQUAL "DARWIN") AND (NOT (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)))
      target_link_libraries(${TARGET_NAME} ${CORE_TARGET_NAME} ${LIBC_TARGET_NAME}
-		                   ${FDLIBM_TARGET_NAME} ${PREFIX_IMPORTED_LIB}libclang_rt.osx)
-	else()
+                           ${FDLIBM_TARGET_NAME} ${PREFIX_IMPORTED_LIB}libclang_rt.osx)
+    else()
      target_link_libraries(${TARGET_NAME} ${CORE_TARGET_NAME} ${LIBC_TARGET_NAME}
-		                   ${FDLIBM_TARGET_NAME} ${PREFIX_IMPORTED_LIB}libgcc ${PREFIX_IMPORTED_LIB}libgcc_eh)
-	endif()
+                           ${FDLIBM_TARGET_NAME} ${PREFIX_IMPORTED_LIB}libgcc ${PREFIX_IMPORTED_LIB}libgcc_eh)
+    endif()
 
     add_cppcheck_target(${TARGET_NAME})
 
@@ -502,7 +502,7 @@ endif()
     if(("${PLATFORM}" STREQUAL "DARWIN") AND (NOT (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)))
       target_link_libraries(${TARGET_NAME} ${CORE_TARGET_NAME} ${LIBC_TARGET_NAME} ${FDLIBM_TARGET_NAME}
                             ${PREFIX_IMPORTED_LIB}libclang_rt.osx)
-	else()
+    else()
       target_link_libraries(${TARGET_NAME} ${CORE_TARGET_NAME} ${LIBC_TARGET_NAME} ${FDLIBM_TARGET_NAME}
                             ${PREFIX_IMPORTED_LIB}libgcc ${PREFIX_IMPORTED_LIB}libgcc_eh)
     endif()

--- a/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-009.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-009.js
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-	var a = new Number(123.5);
+var a = new Number(123.5);
 assert (typeof Object(a) === 'object');

--- a/tests/jerry/N.func-expr-strict.js
+++ b/tests/jerry/N.func-expr-strict.js
@@ -15,5 +15,5 @@
 "use strict";
 
 (function () {
-	var let = 1;
+  var let = 1;
 })();

--- a/tests/jerry/array-prototype-concat.js
+++ b/tests/jerry/array-prototype-concat.js
@@ -18,7 +18,7 @@ var new_arr = array.concat();
 
 assert(new_arr.length === array.length)
 for (i = 0; i < array.length; i++) {
-	assert(array[i] === new_arr[i]);
+  assert(array[i] === new_arr[i]);
 }
 
 var obj = { concat : Array.prototype.concat };
@@ -54,7 +54,7 @@ var result = arr1.concat(arr2, arr3, arr4);
 
 assert(result.length === expected.length)
 for (i = 0; i < result.length; i++) {
-	assert(result[i] === expected[i]);
+  assert(result[i] === expected[i]);
 }
 
 var arr1 = [];
@@ -69,9 +69,9 @@ Object.defineProperty(arr, '0', { 'get' : function () {throw new ReferenceError 
 arr.length = 1;
 
 try {
-	arr.concat();
-	assert(false);
+  arr.concat();
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-every.js
+++ b/tests/jerry/array-prototype-every.js
@@ -16,19 +16,19 @@
 var array = ["foo", [], Infinity, 4];
 
 function f(arg1, arg2, arg3) {
-	assert(arg1 === array[arg2]);
-	assert(arg3 === array);
-	return true;
+  assert(arg1 === array[arg2]);
+  assert(arg3 === array);
+  return true;
 }
 
 assert(array.every(f) === true);
 
 function g(arg1, arg2, arg3) {
-	if (arg1 === 1) {
-		return true;
-	} else {
-		return false;
-	}
+  if (arg1 === 1) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 var arr1 = [1, 1, 1, 1, 1, 2];
@@ -42,11 +42,11 @@ var obj = { every : Array.prototype.every };
 Object.defineProperty(obj, 'length', { 'get' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.every(f);
-	assert(false);
+  obj.every(f);
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to get element
@@ -54,9 +54,9 @@ var obj = { every : Array.prototype.every, length : 1};
 Object.defineProperty(obj, '0', { 'get' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.every(f);
-	assert(false);
+  obj.every(f);
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-filter.js
+++ b/tests/jerry/array-prototype-filter.js
@@ -16,25 +16,25 @@
 var array = ["foo", [], Infinity, 4]
 
 function f(arg1, arg2, arg3) {
-	assert(arg1 === array[arg2]);
-	assert(arg3 === array);
-	return true;
+  assert(arg1 === array[arg2]);
+  assert(arg3 === array);
+  return true;
 }
 
 var filtered = array.filter(f);
 assert(filtered.length === array.length);
 for (i = 0; i < filtered.length; i++) {
-	assert(filtered[i] === array[i]);
+  assert(filtered[i] === array[i]);
 }
 
 var array = [1, 2, 3, 4, 5, 6, 7, 8];
 
 function g (arg1, arg2, arg3) {
-	if (arg2 % 2 === 0) {
-		return true;
-	} else {
-		return false;
-	}
+  if (arg2 % 2 === 0) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 filtered = array.filter(g)
@@ -57,11 +57,11 @@ Object.defineProperty(obj, 'length', { 'get' : function () {throw new ReferenceE
 obj.filter = Array.prototype.filter;
 
 try {
-	obj.filter(f);
-	assert(false);
+  obj.filter(f);
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to get element
@@ -71,9 +71,9 @@ Object.defineProperty(obj, '0', { 'get' : function () {throw new ReferenceError 
 obj.filter = Array.prototype.filter
 
 try {
-	obj.filter(f);
-	assert(false);
+  obj.filter(f);
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-foreach.js
+++ b/tests/jerry/array-prototype-foreach.js
@@ -16,8 +16,8 @@
 var array = ["foo", [], Infinity, 4]
 
 function f(arg1, arg2, arg3) {
-	assert(arg1 === array[arg2]);
-	assert(arg3 === array);
+  assert(arg1 === array[arg2]);
+  assert(arg3 === array);
 }
 
 array.forEach(f);
@@ -28,11 +28,11 @@ Object.defineProperty(obj, 'length', { 'get' : function () {throw new ReferenceE
 obj.forEach = Array.prototype.forEach;
 
 try {
-	obj.forEach(f);
-	assert(false);
+  obj.forEach(f);
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to get element
@@ -42,9 +42,9 @@ Object.defineProperty(obj, '0', { 'get' : function () {throw new ReferenceError 
 obj.forEach = Array.prototype.forEach
 
 try {
-	obj.forEach(f);
-	assert(false);
+  obj.forEach(f);
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-indexof.js
+++ b/tests/jerry/array-prototype-indexof.js
@@ -48,20 +48,20 @@ var arr = [11, 22, 33, 44];
 assert(arr.indexOf(44, 4) === -1);
 
 var fromIndex = {
-	toString: function () {
-		return {};
-	},
+  toString: function () {
+    return {};
+  },
 
-	valueOf: function () {
-		return {};
-	}
+  valueOf: function () {
+    return {};
+  }
 };
 
 try {
-    [0, 1].indexOf(1, fromIndex);
-    assert(false);
+  [0, 1].indexOf(1, fromIndex);
+  assert(false);
 } catch (e) {
-    assert(e instanceof TypeError);
+  assert(e instanceof TypeError);
 }
 
 // Checking behavior when unable to get length
@@ -69,11 +69,11 @@ var obj = { indexOf : Array.prototype.indexOf}
 Object.defineProperty(obj, 'length', { 'get' : function () { throw new ReferenceError ("foo"); } });
 
 try {
-	obj.indexOf("bar");
-	assert(false);
+  obj.indexOf("bar");
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to get element
@@ -81,9 +81,9 @@ var obj = { indexOf : Array.prototype.indexOf, length : 1}
 Object.defineProperty(obj, '0', { 'get' : function () { throw new ReferenceError ("foo"); } });
 
 try {
-	obj.indexOf("bar");
-	assert(false);
+  obj.indexOf("bar");
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-lastindexof.js
+++ b/tests/jerry/array-prototype-lastindexof.js
@@ -50,11 +50,11 @@ var obj = { lastIndexOf : Array.prototype.lastIndexOf}
 Object.defineProperty(obj, 'length', { 'get' : function () { throw new ReferenceError ("foo"); } });
 
 try {
-	obj.lastIndexOf("bar");
-	assert(false);
+  obj.lastIndexOf("bar");
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to get element
@@ -62,9 +62,9 @@ var obj = { lastIndexOf : Array.prototype.lastIndexOf, length : 1}
 Object.defineProperty(obj, '0', { 'get' : function () { throw new ReferenceError ("foo"); } });
 
 try {
-	obj.lastIndexOf("bar");
-	assert(false);
+  obj.lastIndexOf("bar");
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-pop.js
+++ b/tests/jerry/array-prototype-pop.js
@@ -37,11 +37,11 @@ var obj = { pop : Array.prototype.pop };
 Object.defineProperty(obj, 'length', { 'get' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.pop();
-	assert(false);
+  obj.pop();
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to set length
@@ -49,11 +49,11 @@ var obj = { pop : Array.prototype.pop };
 Object.defineProperty(obj, 'length', { 'set' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.pop();
-	assert(false);
+  obj.pop();
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when no length property defined
@@ -67,9 +67,9 @@ var obj = { pop : Array.prototype.pop, length : 1 };
 Object.defineProperty(obj, '0', { 'get' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.pop();
-	assert(false);
+  obj.pop();
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-push.js
+++ b/tests/jerry/array-prototype-push.js
@@ -45,10 +45,10 @@ assert(a.length === 4294967295);
 assert(a[4294967294] === "x");
 
 try {
-	a.push("y");
-	assert(false);
+  a.push("y");
+  assert(false);
 } catch (e) {
-	assert (e instanceof RangeError);
+  assert (e instanceof RangeError);
 }
 assert(a.length === 4294967295)
 
@@ -59,17 +59,17 @@ assert(o.length === 4294967295);
 assert(o[4294967294] === "x");
 
 try {
-	assert(o.push("y") === 4294967296);
+  assert(o.push("y") === 4294967296);
 } catch (e) {
-	assert(false);
+  assert(false);
 }
 assert(o.length === 4294967296);
 assert(o[4294967295] === "y");
 
 try {
-	assert(o.push("z") === 1);
+  assert(o.push("z") === 1);
 } catch (e) {
-	assert(false);
+  assert(false);
 }
 assert(o.length === 1);
 assert(o[0] === "z");

--- a/tests/jerry/array-prototype-reverse.js
+++ b/tests/jerry/array-prototype-reverse.js
@@ -18,7 +18,7 @@ var array = [4, 3, 2, 1, 0]
 array.reverse();
 
 for (i = 0; i < array.length; i++) {
-	assert(array[i] === i);
+  assert(array[i] === i);
 }
 
 // Checking behavior when unable to get length
@@ -26,11 +26,11 @@ var obj = { reverse : Array.prototype.reverse };
 Object.defineProperty(obj, 'length', { 'get' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.reverse();
-	assert(false);
+  obj.reverse();
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to get element
@@ -38,9 +38,9 @@ var obj = { reverse : Array.prototype.reverse, length : 3 };
 Object.defineProperty(obj, '0', { 'get' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.reverse();
-	assert(false);
+  obj.reverse();
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-shift.js
+++ b/tests/jerry/array-prototype-shift.js
@@ -34,7 +34,7 @@ assert(array.shift() === undefined);
 assert(array.length === 0);
 
 var referenceErrorThrower = function () {
-	throw new ReferenceError ("foo");
+  throw new ReferenceError ("foo");
 }
 
 // Checking behavior when unable to get length
@@ -42,11 +42,11 @@ var obj = { shift : Array.prototype.shift };
 Object.defineProperty(obj, 'length', { 'get' : referenceErrorThrower });
 
 try {
-	obj.shift();
-	assert(false);
+  obj.shift();
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to set length
@@ -54,11 +54,11 @@ var obj = { shift : Array.prototype.shift };
 Object.defineProperty(obj, 'length', { 'set' : referenceErrorThrower });
 
 try {
-	obj.shift();
-	assert(false);
+  obj.shift();
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when no length property defined
@@ -72,9 +72,9 @@ var obj = { shift : Array.prototype.shift, length : 1 };
 Object.defineProperty(obj, '0', { 'get' : referenceErrorThrower });
 
 try {
-	obj.shift();
-	assert(false);
+  obj.shift();
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-slice.js
+++ b/tests/jerry/array-prototype-slice.js
@@ -91,11 +91,11 @@ var obj = { slice : Array.prototype.slice };
 Object.defineProperty(obj, 'length', { 'get' : function () { throw new ReferenceError ("foo"); } });
 
 try {
-	obj.slice(1, 2);
-	assert (false);
+  obj.slice(1, 2);
+  assert (false);
 } catch (e) {
-	assert (e.message === "foo");
-	assert (e instanceof ReferenceError);
+  assert (e.message === "foo");
+  assert (e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to get element
@@ -103,9 +103,9 @@ var obj = { length : 1, slice : Array.prototype.slice };
 Object.defineProperty(obj, '0', { 'get' : function () { throw new ReferenceError ("foo"); } });
 
 try {
-	obj.slice(0, 1);
-	assert (false);
+  obj.slice(0, 1);
+  assert (false);
 } catch (e) {
-	assert (e.message === "foo");
-	assert (e instanceof ReferenceError);
+  assert (e.message === "foo");
+  assert (e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-some.js
+++ b/tests/jerry/array-prototype-some.js
@@ -16,19 +16,19 @@
 var array = ["foo", [], Infinity, 4];
 
 function f(arg1, arg2, arg3) {
-	assert(arg1 === array[arg2]);
-	assert(arg3 === array);
-	return false;
+  assert(arg1 === array[arg2]);
+  assert(arg3 === array);
+  return false;
 }
 
 assert(array.some(f) === false);
 
 function g(arg1, arg2, arg3) {
-	if (arg1 === 1) {
-		return true;
-	} else {
-		return false;
-	}
+  if (arg1 === 1) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 var arr1 = [2, 2, 2, 2, 2, 2];
@@ -42,11 +42,11 @@ var obj = { some : Array.prototype.some };
 Object.defineProperty(obj, 'length', { 'get' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.some(f);
-	assert(false);
+  obj.some(f);
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to get element
@@ -54,9 +54,9 @@ var obj = { some : Array.prototype.some, length : 1};
 Object.defineProperty(obj, '0', { 'get' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.some(f);
-	assert(false);
+  obj.some(f);
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-sort.js
+++ b/tests/jerry/array-prototype-sort.js
@@ -29,23 +29,23 @@ var array = [6, 4, 5, 1, 2, 9, 7, 3, 0, 8];
 // Default comparison
 array.sort();
 for (i = 0; i < array.length; i++) {
-	assert(array[i] === i);
+  assert(array[i] === i);
 }
 
 // Using custom comparison function
 function f(arg1, arg2) {
-	if (arg1 < arg2) {
-		return 1;
-	} else if (arg1 > arg2) {
-		return -1;
-	} else {
-		return 0;
-	}
+  if (arg1 < arg2) {
+    return 1;
+  } else if (arg1 > arg2) {
+    return -1;
+  } else {
+    return 0;
+  }
 }
 
 array.sort(f);
 for (i = 0; i < array.length; i++) {
-	assert(array[array.length - i - 1] === i);
+  assert(array[array.length - i - 1] === i);
 }
 
 // Sorting sparse array
@@ -56,18 +56,18 @@ array.sort();
 
 assert(array.length === expected.length);
 for (i = 0; i < array.length; i++) {
-	assert(expected.hasOwnProperty (i) === array.hasOwnProperty (i));
-	assert(array[i] === expected[i]);
+  assert(expected.hasOwnProperty (i) === array.hasOwnProperty (i));
+  assert(array[i] === expected[i]);
 }
 
 // Checking behavior when provided comparefn is not callable
 var obj = {};
 var arr = [];
 try {
-	arr.sort(obj);
-	assert(false);
+  arr.sort(obj);
+  assert(false);
 } catch (e) {
-	assert(e instanceof TypeError);
+  assert(e instanceof TypeError);
 }
 
 // Checking behavior when unable to get length
@@ -75,11 +75,11 @@ var obj = { sort : Array.prototype.sort}
 Object.defineProperty(obj, 'length', { 'get' : function () { throw new ReferenceError ("foo"); } });
 
 try {
-	obj.sort();
-	assert(false);
+  obj.sort();
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to get element
@@ -87,9 +87,9 @@ var obj = { sort : Array.prototype.sort, length : 1}
 Object.defineProperty(obj, '0', { 'get' : function () { throw new ReferenceError ("foo"); } });
 
 try {
-	obj.sort();
-	assert(false);
+  obj.sort();
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-splice.js
+++ b/tests/jerry/array-prototype-splice.js
@@ -15,7 +15,7 @@
 
 function setDefaultValues()
 {
-	return [54, undefined, -127, "sunshine"];
+  return [54, undefined, -127, "sunshine"];
 }
 
 var array = setDefaultValues();
@@ -156,11 +156,11 @@ var obj = {splice : Array.prototype.splice};
 Object.defineProperty(obj, 'length', { 'get' : function () { throw new ReferenceError ("foo"); } });
 
 try {
-	obj.splice(1, 2, "item1", "item2");
-	assert (false);
+  obj.splice(1, 2, "item1", "item2");
+  assert (false);
 } catch (e) {
-	assert (e.message === "foo");
-	assert (e instanceof ReferenceError);
+  assert (e.message === "foo");
+  assert (e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to get element
@@ -168,9 +168,9 @@ var obj = {length : 1, splice : Array.prototype.splice};
 Object.defineProperty(obj, '0', { 'get' : function () { throw new ReferenceError ("foo"); } });
 
 try {
-	obj.splice(0, 1, "item1", "item2");
-	assert (false);
+  obj.splice(0, 1, "item1", "item2");
+  assert (false);
 } catch (e) {
-	assert (e.message === "foo");
-	assert (e instanceof ReferenceError);
+  assert (e.message === "foo");
+  assert (e instanceof ReferenceError);
 }

--- a/tests/jerry/array-prototype-unshift.js
+++ b/tests/jerry/array-prototype-unshift.js
@@ -53,11 +53,11 @@ var obj = { unshift : Array.prototype.unshift };
 Object.defineProperty(obj, 'length', { 'get' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.unshift(1);
-	assert(false)
+  obj.unshift(1);
+  assert(false)
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable to set length
@@ -65,11 +65,11 @@ var obj = { unshift : Array.prototype.unshift };
 Object.defineProperty(obj, 'length', { 'set' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.unshift(2);
-	assert(false)
+  obj.unshift(2);
+  assert(false)
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when unable shift elements
@@ -77,22 +77,22 @@ var obj = { unshift : Array.prototype.unshift, length : 1 };
 Object.defineProperty(obj, '0', { 'get' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.unshift(3);
-	assert(false);
+  obj.unshift(3);
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 var obj = { unshift : Array.prototype.unshift, length : 1 };
 Object.defineProperty(obj, '0', { 'set' : function () {throw new ReferenceError ("foo"); } });
 
 try {
-	obj.unshift(4);
-	assert(false);
+  obj.unshift(4);
+  assert(false);
 } catch (e) {
-	assert(e.message === "foo");
-	assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
 }
 
 // Checking behavior when a property is not defined

--- a/tests/jerry/global-parsefloat.js
+++ b/tests/jerry/global-parsefloat.js
@@ -80,9 +80,9 @@ assert(isNaN(parseFloat(undef)));
 
 var obj = { toString : function () { throw new ReferenceError("foo") } };
 try {
-	parseFloat(obj);
-	assert(false);
+  parseFloat(obj);
+  assert(false);
 } catch (e) {
-	assert(e instanceof ReferenceError);
-	assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
 }

--- a/tests/jerry/global-parseint.js
+++ b/tests/jerry/global-parseint.js
@@ -72,9 +72,9 @@ assert(isNaN(parseInt(undef, arr)));
 
 var obj = { toString : function () { throw new ReferenceError("foo") } };
 try {
-	parseInt(obj);
-	assert(false);
+  parseInt(obj);
+  assert(false);
 } catch (e) {
-	assert(e instanceof ReferenceError);
-	assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
+  assert(e.message === "foo");
 }

--- a/tests/jerry/json-stringify.js
+++ b/tests/jerry/json-stringify.js
@@ -123,7 +123,7 @@ assert (JSON.stringify (to_json_object) === "3");
 function replacer_function (key, value)
 {
   if (typeof(value) == "string")
-	return "FOO";
+    return "FOO";
   return value;
 }
 

--- a/tests/jerry/number-prototype-to-string.js
+++ b/tests/jerry/number-prototype-to-string.js
@@ -89,35 +89,35 @@ var digit_chars = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
                    'u', 'v', 'w', 'x', 'y', 'z'];
 
 for (radix = 2; radix <= 36; radix++) {
-	for (num = 1; num < 100; num++) {
-		var value = num;
-		var str = "";
-		while (value > 0) {
-			str = digit_chars[value % radix] + str;
-			value = Math.floor(value / radix);
-		}
+  for (num = 1; num < 100; num++) {
+    var value = num;
+    var str = "";
+    while (value > 0) {
+      str = digit_chars[value % radix] + str;
+      value = Math.floor(value / radix);
+    }
 
-		assert(str === (num).toString(radix));
-	}
+    assert(str === (num).toString(radix));
+  }
 }
 
 try {
-	assert((123).toString(1));
-	assert(false)
+  assert((123).toString(1));
+  assert(false)
 } catch (e) {
-	assert(e instanceof RangeError);
+  assert(e instanceof RangeError);
 }
 
 try {
-	assert((123).toString(37));
-	assert(false)
+  assert((123).toString(37));
+  assert(false)
 } catch (e) {
-	assert(e instanceof RangeError);
+  assert(e instanceof RangeError);
 }
 
 try {
-	assert((123).toString(Infinity));
-	assert(false)
+  assert((123).toString(Infinity));
+  assert(false)
 } catch (e) {
-	assert(e instanceof RangeError);
+  assert(e instanceof RangeError);
 }

--- a/tests/jerry/regexp-construct.js
+++ b/tests/jerry/regexp-construct.js
@@ -111,24 +111,24 @@ assert (r.ignoreCase === false);
 assert (r.multiline === false);
 
 try {
-	new RegExp (undefined, "ii");
-	assert (false);
+  new RegExp (undefined, "ii");
+  assert (false);
 } catch (e) {
-	assert (e instanceof SyntaxError);
+  assert (e instanceof SyntaxError);
 }
 
 try {
-	new RegExp ("", "gg");
-	assert (false);
+  new RegExp ("", "gg");
+  assert (false);
 } catch (e) {
-	assert (e instanceof SyntaxError);
+  assert (e instanceof SyntaxError);
 }
 
 try {
-	new RegExp (void 0, "mm");
-	assert (false);
+  new RegExp (void 0, "mm");
+  assert (false);
 } catch (e) {
-	assert (e instanceof SyntaxError);
+  assert (e instanceof SyntaxError);
 }
 
 r = new RegExp (undefined, undefined);

--- a/tests/jerry/regexp-literal.js
+++ b/tests/jerry/regexp-literal.js
@@ -28,58 +28,58 @@ t = /\u0000/.exec("\u0000");
 assert (t == "\u0000");
 
 try {
-	eval("/" + String.fromCharCode("0x0000") + "/");
+  eval("/" + String.fromCharCode("0x0000") + "/");
 } catch (e) {
-	assert (false);
+  assert (false);
 }
 
 try {
-	eval("var x = 5\n\n/foo/");
-	assert(false);
+  eval("var x = 5\n\n/foo/");
+  assert(false);
 } catch (e) {
-	assert(e instanceof SyntaxError);
+  assert(e instanceof SyntaxError);
 }
 
 try {
-	eval("var x = 5;\n\n/foo/");
+  eval("var x = 5;\n\n/foo/");
 } catch (e) {
-	assert(false);
+  assert(false);
 }
 
 try {
-	eval("for (;false;/abc/.exec(\"abc\")) {5}");
+  eval("for (;false;/abc/.exec(\"abc\")) {5}");
 } catch (e) {
-	assert(false);
+  assert(false);
 }
 
 try {
-	eval("var a = [] /foo/");
-	assert(false);
+  eval("var a = [] /foo/");
+  assert(false);
 } catch (e) {
-	assert(e instanceof SyntaxError);
+  assert(e instanceof SyntaxError);
 }
 
 try {
-	eval("/");
-	assert(false);
+  eval("/");
+  assert(false);
 } catch (e) {
-	assert(e instanceof SyntaxError);
+  assert(e instanceof SyntaxError);
 }
 
 try {
-	eval("var x = /aaa/");
+  eval("var x = /aaa/");
 } catch (e) {
-	assert (false);
+  assert (false);
 }
 
 try {
-	eval("{}/a/g");
+  eval("{}/a/g");
 } catch (e) {
-	assert (false);
+  assert (false);
 }
 
 try {
-	eval("var a, g; +{}/a/g");
+  eval("var a, g; +{}/a/g");
 } catch (e) {
-	assert (false);
+  assert (false);
 }

--- a/tests/jerry/regexp-routines.js
+++ b/tests/jerry/regexp-routines.js
@@ -19,34 +19,34 @@ r = new RegExp ("a");
 assert (r.exec ("a") == "a");
 assert (r.exec ("b") == null);
 try {
-	r.exec.call({}, "a");
-	assert (false)
+  r.exec.call({}, "a");
+  assert (false)
 }
 catch (e)
 {
-	assert (e instanceof TypeError);
+  assert (e instanceof TypeError);
 }
 
 assert (r.test ("a") == true);
 assert (r.test ("b") == false);
 try {
-	r.test.call({}, "a");
-	assert (false)
+  r.test.call({}, "a");
+  assert (false)
 }
 catch (e)
 {
-	assert (e instanceof TypeError);
+  assert (e instanceof TypeError);
 }
 
 r = new RegExp ("a", "mig");
 assert (r.toString () == "/a/gim");
 try {
-	r.toString.call({}, "a");
-	assert (false)
+  r.toString.call({}, "a");
+  assert (false)
 }
 catch (e)
 {
-	assert (e instanceof TypeError);
+  assert (e instanceof TypeError);
 }
 
 
@@ -71,27 +71,27 @@ var re1 = /foo/gim;
 var re2 = /bar/g;
 
 try {
-	re2.compile("asd", "ggim");
-	assert (false);
+  re2.compile("asd", "ggim");
+  assert (false);
 } catch (e) {
-	assert (e instanceof SyntaxError);
-	assert (re2 == "/bar/g");
+  assert (e instanceof SyntaxError);
+  assert (re2 == "/bar/g");
 }
 
 try {
-	re2.compile("[", undefined);
-	assert (false);
+  re2.compile("[", undefined);
+  assert (false);
 } catch (e) {
-	assert (e instanceof SyntaxError);
-	assert (re2 == "/bar/g");
+  assert (e instanceof SyntaxError);
+  assert (re2 == "/bar/g");
 }
 
 try {
-	re2.compile(re1, "im");
-	assert (false);
+  re2.compile(re1, "im");
+  assert (false);
 } catch (e) {
-	assert (e instanceof TypeError);
-	assert (re2 == "/bar/g");
+  assert (e instanceof TypeError);
+  assert (re2 == "/bar/g");
 }
 
 re2.lastIndex = 2;

--- a/tests/jerry/regression-test-issue-563.js
+++ b/tests/jerry/regression-test-issue-563.js
@@ -14,19 +14,19 @@
 // limitations under the License.
 
 try {
-	eval('if (true) /abc/.exec("abc");');
+  eval('if (true) /abc/.exec("abc");');
 } catch (e) {
-	assert (false);
+  assert (false);
 }
 
 try {
-	eval('if (true) {} /abc/.exec("abc");');
+  eval('if (true) {} /abc/.exec("abc");');
 } catch (e) {
-	assert (false);
+  assert (false);
 }
 
 try {
-	eval('var a\n/abc/.exec("abc");');
+  eval('var a\n/abc/.exec("abc");');
 } catch (e) {
-	assert (false);
+  assert (false);
 }

--- a/tests/jerry/regression-test-issue-652.js
+++ b/tests/jerry/regression-test-issue-652.js
@@ -14,19 +14,19 @@
 // limitations under the License.
 
 try {
-	eval("this / 10");
+  eval("this / 10");
 } catch (e) {
-	assert (false);
+  assert (false);
 }
 
 try {
-	eval("var v_0 = 10;\nv_0++ / 1");
+  eval("var v_0 = 10;\nv_0++ / 1");
 } catch (e) {
-	assert (false);
+  assert (false);
 }
 
 try {
-	eval("var v_0 = 10;\nif (v_0++ / 1) {\n}");
+  eval("var v_0 = 10;\nif (v_0++ / 1) {\n}");
 } catch (e) {
-	assert (false);
+  assert (false);
 }

--- a/tests/jerry/regression-test-issue-655.js
+++ b/tests/jerry/regression-test-issue-655.js
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 try {
-	eval("if (true) {}\n/a/;");
+  eval("if (true) {}\n/a/;");
 } catch (e) {
-	assert (false);
+  assert (false);
 }

--- a/tools/prerequisites.sh
+++ b/tools/prerequisites.sh
@@ -211,11 +211,11 @@ HOST_OS=`uname -s`
 
 if [ "$HOST_OS" == "Darwin" ]
 then
-	SHA256SUM="shasum -a 256"
-	TMP_DIR=`mktemp -d -t jerryscript`
+  SHA256SUM="shasum -a 256"
+  TMP_DIR=`mktemp -d -t jerryscript`
 else
-	SHA256SUM="sha256sum --strict"
-	TMP_DIR=`mktemp -d --tmpdir=./`
+  SHA256SUM="sha256sum --strict"
+  TMP_DIR=`mktemp -d --tmpdir=./`
 fi
 
 if [ "$CLEAN_MODE" == "yes" ]


### PR DESCRIPTION
You can call me names... but tabs are evil...

When I touched CMakeLists.txt last time, I've seen some tabs lurking there. I've made a vow to eliminate them. Then I looked around and found some more. These three patches kill'em all in three parts of the repository: in CMakeLists.txt, in the tools directory, and among the tests.

Side note: there are quite some style issues left over in the tests (number of spaces used for indentation, presence vs absence of space between function names and parameter lists, placement of curly braces, etc) but these patches do not intend to unify them.
