### PR TITLE
Disable LTO by default in Mac OS X build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ project (Jerry CXX C ASM)
 
   option(STRIP_RELEASE_BINARY "Strip symbols from release binaries" ON)
  elseif("${PLATFORM}" STREQUAL "DARWIN")
+  option(ENABLE_LTO            "Enable LTO build" OFF)
+  option(ENABLE_ALL_IN_ONE     "Enable ALL_IN_ONE build" ON)
   set(PLATFORM_EXT "DARWIN")
   set(EXTERNAL_BUILD FALSE)
 

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@
 #   Parallel build of several selected targets started manually is not supported.
 #
 
+export TARGET_NATIVE_SYSTEMS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+
 # Options
  # Valgrind
   VALGRIND ?= OFF
@@ -64,7 +66,11 @@
   endif
 
  # LTO
-  LTO ?= ON
+  ifeq ($(TARGET_NATIVE_SYSTEMS),darwin)
+   LTO ?= OFF
+  else
+   LTO ?= ON
+  endif
 
   ifneq ($(LTO),ON)
    LTO := OFF
@@ -77,7 +83,12 @@
   endif
 
  # All-in-one build
-  ALL_IN_ONE ?= OFF
+  ifeq ($(TARGET_NATIVE_SYSTEMS),darwin)
+   ALL_IN_ONE ?= ON
+  else
+   ALL_IN_ONE ?= OFF
+  endif
+
   ifneq ($(ALL_IN_ONE),ON)
    ALL_IN_ONE := OFF
   endif
@@ -90,8 +101,6 @@
    Q := @
    QLOG := >/dev/null
   endif
-
-export TARGET_NATIVE_SYSTEMS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 # External build configuration
  # Flag, indicating whether to use compiler's default libc (YES / NO)


### PR DESCRIPTION
Because, debugger is not working properly with LTO build in Mac OS X
```
Reading symbols from build/bin/debug.darwin/jerry...
warning: `/tmp/lto.o': can't open to read symbols: No such file or directory.
(no debugging symbols found)...done.
(gdb) _
```
And enable ALL_IN_ONE as default, to minimize the performance degradation by disable LTO.

JerryScript-DCO-1.0-Signed-off-by: Sung-Jae Lee sjlee@mail.com