### PR TITLE
Stacking vargs in pretty-printer rather than using vargs_num and seen…

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -28,6 +28,9 @@
 #include "stack.h"
 #include "jsp-early-error.h"
 #include "vm.h"
+#ifdef JERRY_ENABLE_PRETTY_PRINTER
+#include "pretty-printer.h"
+#endif /* JERRY_ENABLE_PRETTY_PRINTER */
 
 /**
  * Flag, indicating whether result of expression
@@ -3313,6 +3316,10 @@ parser_parse_program (const jerry_api_char_t *source_p, /**< source code buffer 
   dumper_init ();
   jsp_early_error_init ();
 
+#ifdef JERRY_ENABLE_PRETTY_PRINTER
+  pp_init ();
+#endif /* JERRY_ENABLE_PRETTY_PRINTER */
+
   STACK_INIT (scopes);
   STACK_PUSH (scopes, scopes_tree_init (NULL, scope_type));
   serializer_set_scope (STACK_TOP (scopes));
@@ -3368,6 +3375,10 @@ parser_parse_program (const jerry_api_char_t *source_p, /**< source code buffer 
     jsp_early_error_free ();
 
     *out_bytecode_data_p = serializer_merge_scopes_into_bytecode ();
+
+#ifdef JERRY_ENABLE_PRETTY_PRINTER
+    pp_free ();
+#endif /* JERRY_ENABLE_PRETTY_PRINTER */
 
     dumper_free ();
 

--- a/jerry-core/vm/pretty-printer.h
+++ b/jerry-core/vm/pretty-printer.h
@@ -23,6 +23,8 @@
 #include "scopes-tree.h"
 
 void pp_op_meta (const bytecode_data_header_t *, vm_instr_counter_t, op_meta, bool);
+void pp_init (void);
+void pp_free (void);
 #endif // JERRY_ENABLE_PRETTY_PRINTER
 
 #endif // PRETTY_PRINTER


### PR DESCRIPTION
…_vargs

Related issue: #680

JerryScript-DCO-1.0-Signed-off-by: Hanjoung Lee hanjoung.lee@samsung.com

`pretty-printer` was not working well when vargs are nested. Currently this is handled with two integer variables `vargs_num` and `seen_vargs`, but they must be stacked. stack was implemented with `array_list`.

an example that emits an assert error in issue #680. 

Here's another case that does not emit an error but does not print either.
```javascript
print(foo(1, 2));
```
As-is:
```
 13:               call_n  131    1    1     // 
 14:               call_n  131    0    2     // 
 15:           assignment  131    1    1     // tmp131 = 1: SMALLINT;
 16:                 meta    2  131  255     // 
 17:           assignment  131    1    2     // tmp131 = 2: SMALLINT;
 18:                 meta    2  131  255     // tmp131 = foo (tmp131, tmp131);
 19:                 meta    2  131  255     //  [nothing printed]
```

After patch:
```
 19:                 meta    2  131  255     // tmp131 = print (tmp131);
```
