### PR TITLE
Fix Failed JSON stringify with NaN

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
@@ -1348,7 +1348,7 @@ ecma_builtin_json_str (ecma_string_t *key_p, /**< property key*/
       ecma_number_t num_value_p = *ecma_get_number_from_value (my_val);
 
       /* 9.a */
-      if (!ecma_number_is_infinity (num_value_p))
+      if (!ecma_number_is_nan (num_value_p) && !ecma_number_is_infinity (num_value_p))
       {
         ret_value = ecma_op_to_string (my_val);
         JERRY_ASSERT (ecma_is_completion_value_normal (ret_value));

--- a/tests/jerry/regression-test-issue-741.js
+++ b/tests/jerry/regression-test-issue-741.js
@@ -1,0 +1,25 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a = JSON.stringify (b=+'�');
+
+assert(a === "null");
+
+var b = JSON.stringify (b=-'�0001');
+
+assert(b === "null");
+
+var c = JSON.stringify (b=+'�');
+
+assert(c === "null");


### PR DESCRIPTION
http://www.ecma-international.org/ecma-262/5.1/#sec-15.12.3
Depending to Note4, NaN is reprensented as the String null
#741

JerryScript-DCO-1.0-Signed-off-by: pius.lee pius.lee@samsung.com