### PR TITLE
Fix Unittests build fails when LTO is disabled

### DIFF
--- a/tests/unit/test-api.cpp
+++ b/tests/unit/test-api.cpp
@@ -737,38 +737,3 @@ main (void)
 
   return 0;
 }
-
-/**
- * Provide log message to filestream implementation for the engine.
- */
-int jerry_port_logmsg (FILE* stream, const char* format, ...)
-{
-  va_list args;
-  int count;
-  va_start (args, format);
-  count = vfprintf (stream, format, args);
-  va_end (args);
-  return count;
-}
-
-/**
- * Provide error message to console implementation for the engine.
- */
-int jerry_port_errormsg (const char* format, ...)
-{
-  va_list args;
-  int count;
-  va_start (args, format);
-  count = vfprintf (stderr, format, args);
-  va_end (args);
-  return count;
-}
-
-
-/**
- * Provide output character to console implementation for the engine.
- */
-int jerry_port_putchar (int c)
-{
-  return putchar (c);
-}

--- a/tests/unit/test-common.h
+++ b/tests/unit/test-common.h
@@ -22,8 +22,10 @@
 #include <setjmp.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <string.h>
 #include <sys/time.h>
+
 
 /**
  * Verify that unit tests are built with all debug checks enabled
@@ -59,5 +61,39 @@ do \
  \
   srand (seed); \
 } while (0)
+
+/**
+ * Provide log message to filestream implementation for the engine.
+ */
+int jerry_port_logmsg (FILE* stream, const char* format, ...)
+{
+  va_list args;
+  int count;
+  va_start (args, format);
+  count = vfprintf (stream, format, args);
+  va_end (args);
+  return count;
+}
+
+/**
+ * Provide error message to console implementation for the engine.
+ */
+int jerry_port_errormsg (const char* format, ...)
+{
+  va_list args;
+  int count;
+  va_start (args, format);
+  count = vfprintf (stderr, format, args);
+  va_end (args);
+  return count;
+}
+
+/**
+ * Provide output character to console implementation for the engine.
+ */
+int jerry_port_putchar (int c)
+{
+  return putchar (c);
+}
 
 #endif /* TEST_COMMON_H */

--- a/tests/unit/test-date-helpers.cpp
+++ b/tests/unit/test-date-helpers.cpp
@@ -18,6 +18,8 @@
 #include "ecma-globals.h"
 #include "ecma-helpers.h"
 
+#include "test-common.h"
+
 #define MS_PER_DAY ((ecma_number_t) 86400000)
 #define MS_PER_YEAR ((ecma_number_t) 365 * MS_PER_DAY)
 #define START_OF_GREGORIAN_CALENDAR ((ecma_number_t) (-1970 * MS_PER_YEAR \

--- a/tests/unit/test-parser.cpp
+++ b/tests/unit/test-parser.cpp
@@ -147,11 +147,3 @@ main (int __attr_unused___ argc,
 
   return 0;
 } /* main */
-
-/**
- * Provide output character to console implementation for the engine.
- */
-int jerry_port_putchar (int c)
-{
-  return putchar (c);
-}


### PR DESCRIPTION
Related issue: #774

JerryScript-DCO-1.0-Signed-off-by: SaeHie Park saehie.park@samsung.com