### PR TITLE
ecma_get_chars_collection_length optimization

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-string.cpp
+++ b/jerry-core/ecma/base/ecma-helpers-string.cpp
@@ -143,7 +143,7 @@ ecma_get_chars_collection_length (const ecma_collection_header_t *header_p) /**<
     if (skip_bytes == 0)
     {
       skip_bytes = lit_get_unicode_char_size_by_utf8_first_byte (*cur_char_buf_iter_p);
-      length += (skip_bytes == 4) ? 2 : 1;
+      length++;
       skip_bytes--;
     }
     else


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Xin Hu Xin.A.Hu@intel.com


Run ./tools/run-perf-test.sh 10 times, 
OS, ubuntu 15.04, 32 bit
CPU, Intel(R) Celeron(R) CPU N2820 @ 2.13GHz, 2 core


                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          120->   120 (0.000) |     1.09333->1.07244 (1.911) |
                  access-binary-trees.js |           88->    88 (0.000) |         0.66->  0.66 (0.000) |
                      access-fannkuch.js |           44->    44 (0.000) |     3.51333->3.42444 (2.530) |
             bitops-3bit-bits-in-byte.js |          36->    32 (11.111) |   0.910667->0.907111 (0.390) |
                  bitops-bits-in-byte.js |         32->    36 (-12.500) |      1.196->1.20889 (-1.078) |
                   bitops-bitwise-and.js |         36->    40 (-11.111) |        1.28->1.24178 (2.986) |
                controlflow-recursive.js |          244->   244 (0.000) |  0.559111->0.565333 (-1.113) |
                           crypto-aes.js |          128->   128 (0.000) |     2.31422->2.24133 (3.150) |
                           crypto-md5.js |          192->   192 (0.000) |     12.3387->11.2867 (8.526) |
                          crypto-sha1.js |          140->   136 (2.857) |     5.52133->5.08933 (7.824) |
                    date-format-xparb.js |           76->    76 (0.000) |      0.64->0.640889 (-0.139) |
                          math-cordic.js |           44->    44 (0.000) |        1.32->1.29867 (1.616) |
                   math-spectral-norm.js |           44->    44 (0.000) |   0.792889->0.788444 (0.561) |
                        string-base64.js |          168->   168 (0.000) |     97.4484->91.0982 (6.516) |
                         string-fasta.js |           56->    56 (0.000) |     2.27244->2.19333 (3.481) |
                         Geometric mean: |        RSS reduction: -0.51% |            Speed up: 2.5229% |
Mon Dec 28 11:29:47 EST 2015


lit_get_unicode_char_size_by_utf8_first_byte()  does not return 4, 
it is not necessary to check (skip_bytes == 4).