### PR TITLE
Use CESU-8 lookup table to improve lit_get_unicode_char_size_by_utf8_…

### DIFF
--- a/jerry-core/lit/lit-strings.cpp
+++ b/jerry-core/lit/lit-strings.cpp
@@ -757,6 +757,15 @@ lit_utf8_string_code_unit_at (const lit_utf8_byte_t *utf8_buf_p, /**< utf-8 stri
   return code_unit;
 } /* lit_utf8_string_code_unit_at */
 
+/* CESU-8 number of bytes occupied lookup table */
+const __attribute__ ((aligned (CESU_8_TABLE_MEM_ALIGNMENT))) lit_utf8_byte_t table[]
+{
+  1, 1, 1, 1, 1, 1, 1, 1,
+  0, 0, 0, 0,
+  2, 2,
+  3, 0
+};
+
 /**
  * Get CESU-8 encoded size of character
  *
@@ -765,19 +774,14 @@ lit_utf8_string_code_unit_at (const lit_utf8_byte_t *utf8_buf_p, /**< utf-8 stri
 lit_utf8_size_t
 lit_get_unicode_char_size_by_utf8_first_byte (const lit_utf8_byte_t first_byte) /**< buffer with characters */
 {
-  if ((first_byte & LIT_UTF8_1_BYTE_MASK) == LIT_UTF8_1_BYTE_MARKER)
-  {
-    return 1;
-  }
-  else if ((first_byte & LIT_UTF8_2_BYTE_MASK) == LIT_UTF8_2_BYTE_MARKER)
-  {
-    return 2;
-  }
-  else
-  {
-    JERRY_ASSERT ((first_byte & LIT_UTF8_3_BYTE_MASK) == LIT_UTF8_3_BYTE_MARKER);
-    return 3;
-  }
+  JERRY_ASSERT (((first_byte >> 4) == 0 ||
+    (first_byte >> 4) == 1 || (first_byte >> 4) == 2 ||
+    (first_byte >> 4) == 3 || (first_byte >> 4) == 4 ||
+    (first_byte >> 4) == 5 || (first_byte >> 4) == 6 ||
+    (first_byte >> 4) == 7 || (first_byte >> 4) == 12 ||
+    (first_byte >> 4) == 13 || (first_byte >> 4) == 14));
+
+  return table[first_byte >> 4];
 } /* lit_get_unicode_char_size_by_utf8_first_byte */
 
 /**

--- a/jerry-core/lit/lit-strings.h
+++ b/jerry-core/lit/lit-strings.h
@@ -157,6 +157,7 @@ lit_string_hash_t lit_utf8_string_calc_hash (const lit_utf8_byte_t *, lit_utf8_s
 lit_string_hash_t lit_utf8_string_hash_combine (lit_string_hash_t, const lit_utf8_byte_t *, lit_utf8_size_t);
 
 /* code unit access */
+#define  CESU_8_TABLE_MEM_ALIGNMENT  16
 ecma_char_t lit_utf8_string_code_unit_at (const lit_utf8_byte_t *, lit_utf8_size_t, ecma_length_t);
 lit_utf8_size_t lit_get_unicode_char_size_by_utf8_first_byte (lit_utf8_byte_t);
 


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Xin Hu Xin.A.Hu@intel.com

Run ./tools/run-perf-test.sh 10 times, 
OS, ubuntu 15.04, 32 bit
CPU, Intel(R) Celeron(R) CPU N2820 @ 2.13GHz, 2 core


                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better)
                               --------- |                          --- |                         ----
                              3d-cube.js |          116->   116 (0.000) |       1.092->1.08089 (1.017)
                  access-binary-trees.js |           88->    88 (0.000) |   0.660444->0.659556 (0.134)
                      access-fannkuch.js |           44->    44 (0.000) |       3.512->3.50133 (0.304)
             bitops-3bit-bits-in-byte.js |          36->    32 (11.111) |  0.910667->0.916889 (-0.683)
                  bitops-bits-in-byte.js |         32->    36 (-12.500) |    1.19689->1.20578 (-0.743)
                   bitops-bitwise-and.js |           36->    36 (0.000) |     1.27956->1.27111 (0.660)
                controlflow-recursive.js |          244->   244 (0.000) |      0.56->0.570667 (-1.905)
                           crypto-aes.js |         128->   132 (-3.125) |     2.31289->2.22622 (3.747)
                           crypto-md5.js |          192->   192 (0.000) |    12.3418->10.3098 (16.464)
                          crypto-sha1.js |          140->   140 (0.000) |    5.52311->4.67778 (15.305)
                    date-format-xparb.js |           76->    76 (0.000) |   0.640444->0.629333 (1.735)
                          math-cordic.js |           44->    40 (9.091) |     1.32267->1.29422 (2.151)
                   math-spectral-norm.js |           44->    44 (0.000) |      0.796->0.780444 (1.954)
                        string-base64.js |         168->   172 (-2.381) |     97.4924->89.3093 (8.394) |
                         string-fasta.js |          52->    56 (-7.692) |     2.27644->2.14844 (5.623) |
                         Geometric mean: |       RSS reduction: -0.221% |            Speed up: 3.7729% |
Tue Dec 29 06:36:58 EST 2015

In lit_get_unicode_char_size_by_utf8_first_byte(), use a lookup table to get the cesu-8 length.
Then there is no if/else branch in lit_get_unicode_char_size_by_utf8_first_byte(),
and it gets chance to be inlined.
This lookup table is pretty small, which should not affect memory a lot.
