### PR TITLE
Use bit vector to store CESU-8 lookup table,

### DIFF
--- a/jerry-core/lit/lit-strings.cpp
+++ b/jerry-core/lit/lit-strings.cpp
@@ -762,7 +762,7 @@ lit_utf8_string_code_unit_at (const lit_utf8_byte_t *utf8_buf_p, /**< utf-8 stri
  *
  * @return number of bytes occupied in CESU-8
  */
-lit_utf8_size_t
+lit_utf8_size_t __attr_always_inline___
 lit_get_unicode_char_size_by_utf8_first_byte (const lit_utf8_byte_t first_byte) /**< buffer with characters */
 {
   if ((first_byte & LIT_UTF8_1_BYTE_MASK) == LIT_UTF8_1_BYTE_MARKER)


### PR DESCRIPTION

JerryScript-DCO-1.0-Signed-off-by: Xin Hu Xin.A.Hu@intel.com

Run ./tools/run-perf-test.sh 10 times, 
OS, ubuntu 15.04, 32 bit
CPU, Intel(R) Celeron(R) CPU N2820 @ 2.13GHz, 2 core

                                Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          120->   120 (0.000) |       1.092->1.08178 (0.936) |
                  access-binary-trees.js |           92->    88 (4.348) |  0.660444->0.660889 (-0.067) |
                      access-fannkuch.js |           44->    44 (0.000) |    3.51244->3.54133 (-0.823) |
             bitops-3bit-bits-in-byte.js |          36->    32 (11.111) |  0.910222->0.920444 (-1.123) |
                  bitops-bits-in-byte.js |          36->    32 (11.111) |    1.19556->1.22444 (-2.416) |
                   bitops-bitwise-and.js |          40->    36 (10.000) |     1.27956->1.24711 (2.536) |
                controlflow-recursive.js |          244->   244 (0.000) |        0.56-> 0.576 (-2.857) |
                           crypto-aes.js |          128->   128 (0.000) |     2.31156->2.25244 (2.558) |
                           crypto-md5.js |          196->   192 (2.041) |     12.3347-> 9.312 (24.506) |
                          crypto-sha1.js |          140->   136 (2.857) |     5.51956-> 4.296 (22.168) |
                    date-format-xparb.js |           80->    76 (5.000) |      0.64->0.644444 (-0.694) |
                          math-cordic.js |           44->    44 (0.000) |        1.32-> 1.332 (-0.909) |
                   math-spectral-norm.js |           44->    44 (0.000) |  0.793333->0.796444 (-0.392) |
                        string-base64.js |          172->   168 (2.326) |    97.4058->82.5538 (15.248) |
                         string-fasta.js |           56->    56 (0.000) |     2.27156->2.17556 (4.226) |
                         Geometric mean: |       RSS reduction: 3.3416% |            Speed up: 4.6192% |
Wed Dec 30 20:40:51 EST 2015


Another one for lit_get_unicode_char_size_by_utf8_first_byte.

Use bit vector to store the USEC-8 length table. 
Since the value is 0,1,2,3, we can use two bits to represent one table item.
The whole set is 16*2 = 32 bit, that is just using one uint32 to store the USEC-8 table.
This way squeeze 12 bytes comparing to uint8 table version.
The average performance seems fine. crypto-md5 , crypto-sh1.js and string-base64.js are really good, but several others are not that good comparing to  https://github.com/Samsung/jerryscript/pull/793
Hard to say which one is better.




