### PR TITLE
Optimize lit_charset_record_get_length

### DIFF
--- a/jerry-core/lit/lit-literal.cpp
+++ b/jerry-core/lit/lit-literal.cpp
@@ -628,7 +628,7 @@ lit_charset_literal_get_length (lit_literal_t lit) /**< literal */
     rcs_iterator_skip (&it_ctx, bytes_to_skip);
 
     i += bytes_to_skip;
-    length += (bytes_to_skip > LIT_UTF8_MAX_BYTES_IN_CODE_UNIT) ? 2 : 1;
+    length++;
   }
 
 #ifndef JERRY_NDEBUG


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Xin Hu Xin.A.Hu@intel.com

Run ./tools/run-perf-test.sh 10 times, 
OS, ubuntu 15.04, 32 bit
CPU, Intel(R) Celeron(R) CPU N2820 @ 2.13GHz, 2 core


                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          116->   116 (0.000) |     1.09467->1.08089 (1.259) |
                  access-binary-trees.js |           88->    88 (0.000) |   0.661778->0.660889 (0.134) |
                      access-fannkuch.js |           48->    48 (0.000) |     3.51689->3.47556 (1.175) |
             bitops-3bit-bits-in-byte.js |         32->    36 (-12.500) |     0.912444-> 0.912 (0.049) |
                  bitops-bits-in-byte.js |           32->    32 (0.000) |    1.19822->1.21778 (-1.632) |
                   bitops-bitwise-and.js |          40->    36 (10.000) |     1.28222->1.24844 (2.634) |
                controlflow-recursive.js |          244->   244 (0.000) |  0.560444->0.564889 (-0.793) |
                           crypto-aes.js |          128->   128 (0.000) |     2.31511->2.23956 (3.263) |
                           crypto-md5.js |          192->   192 (0.000) |    12.3533->12.3538 (-0.004) |
                          crypto-sha1.js |          140->   140 (0.000) |      5.52933->  5.52 (0.169) |
                    date-format-xparb.js |           76->    76 (0.000) |   0.641778->0.639556 (0.346) |
                          math-cordic.js |           44->    44 (0.000) |     1.32178->1.29778 (1.816) |
                   math-spectral-norm.js |           44->    44 (0.000) |    0.792889-> 0.796 (-0.392) |
                        string-base64.js |          172->   172 (0.000) |     97.4516->97.3449 (0.110) |
                         string-fasta.js |          52->    56 (-7.692) |     2.27911->2.24444 (1.521) |
                         Geometric mean: |       RSS reduction: -0.579% |            Speed up: 0.6516% |
Thu Dec 31 09:03:59 EST 2015

bytes_to_skip will be 1, 2 or 3, it will not be larger than LIT_UTF8_MAX_BYTES_IN_CODE_UNIT (3)
It is redundant to check (bytes_to_skip > LIT_UTF8_MAX_BYTES_IN_CODE_UNIT).

