### PR TITLE
Fix handling of property accessors in loop condition expressions and in argument of `with` statement

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  * Copyright 2015 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -4828,6 +4828,9 @@ jsp_parse_source_element_list (jsp_ctx_t *ctx_p,
       {
         parse_expression_inside_parens_end (ctx_p);
 
+        dump_get_value_if_ref (ctx_p, substate_p, true);
+        dump_get_value_for_state_if_const (ctx_p, substate_p);
+
         const jsp_operand_t cond = substate_p->u.expression.operand;
 
         JSP_FINISH_SUBEXPR ();
@@ -4855,6 +4858,9 @@ jsp_parse_source_element_list (jsp_ctx_t *ctx_p,
       if (is_subexpr_end)
       {
         parse_expression_inside_parens_end (ctx_p);
+
+        dump_get_value_if_ref (ctx_p, substate_p, true);
+        dump_get_value_for_state_if_const (ctx_p, substate_p);
 
         const jsp_operand_t cond = substate_p->u.expression.operand;
 
@@ -4958,7 +4964,11 @@ jsp_parse_source_element_list (jsp_ctx_t *ctx_p,
     {
       if (is_subexpr_end)
       {
+        dump_get_value_if_ref (ctx_p, substate_p, true);
+        dump_get_value_for_state_if_const (ctx_p, substate_p);
+
         jsp_operand_t cond = substate_p->u.expression.operand;
+
         JSP_FINISH_SUBEXPR ();
 
         dump_continue_iterations_check (ctx_p, state_p->u.statement.u.iterational.u.loop_for.next_iter_tgt_pos, cond);
@@ -5385,6 +5395,10 @@ jsp_parse_source_element_list (jsp_ctx_t *ctx_p,
       if (is_subexpr_end)
       {
         parse_expression_inside_parens_end (ctx_p);
+
+        dump_get_value_if_ref (ctx_p, substate_p, true);
+        dump_get_value_for_state_if_const (ctx_p, substate_p);
+
         const jsp_operand_t expr = substate_p->u.expression.operand;
 
         JSP_FINISH_SUBEXPR ();

--- a/tests/jerry/for.js
+++ b/tests/jerry/for.js
@@ -76,3 +76,9 @@ var i = {x: 0};
 }
 
 assert (s === '01');
+
+// 7.
+a = [];
+for (; a[0]; ) {
+  assert (false);
+}

--- a/tests/jerry/regression-test-issue-798.js
+++ b/tests/jerry/regression-test-issue-798.js
@@ -1,0 +1,38 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a = {}, b = 0;
+
+while (a[b]) {
+  assert (false);
+}
+
+for ( ; a[b]; ) {
+  assert (false);
+}
+
+var flag = false;
+do
+{
+  assert (!flag);
+  flag = true;
+} while (a[b]);
+
+a = { };
+a.b = { c : 1 };
+
+with (a.b)
+{
+  assert (c === 1);
+}


### PR DESCRIPTION
Related issue: #798 