### PR TITLE
Improve algorithm of collecting empty pools

### DIFF
--- a/tests/benchmarks/jerry/fill-array-with-numbers-3-times-5000-elements.js
+++ b/tests/benchmarks/jerry/fill-array-with-numbers-3-times-5000-elements.js
@@ -1,0 +1,23 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+for (i = 0; i < 3; i++)
+{
+  a = [];
+
+  for (j = 0; j < 5000; j++)
+  {
+    a[j] = j;
+  }
+}

--- a/tests/unit/test-poolman.cpp
+++ b/tests/unit/test-poolman.cpp
@@ -31,6 +31,7 @@ const uint32_t test_iters = 1024;
 const uint32_t test_max_sub_iters = 1024;
 
 uint8_t *ptrs[test_max_sub_iters];
+uint8_t data[test_max_sub_iters][MEM_POOL_CHUNK_SIZE];
 
 int
 main (int __attr_unused___ argc,
@@ -51,7 +52,12 @@ main (int __attr_unused___ argc,
 
       if (ptrs[j] != NULL)
       {
-        memset (ptrs[j], 0, MEM_POOL_CHUNK_SIZE);
+        for (size_t k = 0; k < MEM_POOL_CHUNK_SIZE; k++)
+        {
+          ptrs[j][k] = (uint8_t) (rand () % 256);
+        }
+
+        memcpy (data[j], ptrs[j], MEM_POOL_CHUNK_SIZE);
       }
     }
 
@@ -59,12 +65,14 @@ main (int __attr_unused___ argc,
 
     for (size_t j = 0; j < subiters; j++)
     {
+      if (rand () % 256 == 0)
+      {
+        mem_pools_collect_empty ();
+      }
+
       if (ptrs[j] != NULL)
       {
-        for (size_t k = 0; k < MEM_POOL_CHUNK_SIZE; k++)
-        {
-          JERRY_ASSERT (((uint8_t*) ptrs[j])[k] == 0);
-        }
+        JERRY_ASSERT (!memcmp (data[j], ptrs[j], MEM_POOL_CHUNK_SIZE));
 
         mem_pools_free (ptrs[j]);
       }


### PR DESCRIPTION
                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          112->   112 (0.000) |        2.992-> 2.976 (0.535) | 
                  access-binary-trees.js |           84->    84 (0.000) |      1.84267-> 1.832 (0.579) | 
                      access-fannkuch.js |           40->    40 (0.000) |     8.87467->8.75733 (1.322) | 
                         access-nbody.js |           48->    48 (0.000) |    4.19333->4.19867 (-0.127) | 
             bitops-3bit-bits-in-byte.js |           32->    32 (0.000) |     2.28267->2.27467 (0.350) | 
                  bitops-bits-in-byte.js |           32->    32 (0.000) |      3.04533-> 3.028 (0.569) | 
                   bitops-bitwise-and.js |           32->    32 (0.000) |        3.456-> 3.456 (0.000) | 
                controlflow-recursive.js |          220->   220 (0.000) |      1.57467-> 1.556 (1.186) | 
                          crypto-sha1.js |          132->   132 (0.000) |     11.1653->11.1573 (0.072) | 
                          math-cordic.js |           40->    40 (0.000) |        3.292-> 3.288 (0.121) | 
                    math-partial-sums.js |           32->    32 (0.000) |     1.92533->1.92267 (0.138) | 
                   math-spectral-norm.js |           40->    40 (0.000) |    2.06933->2.08267 (-0.645) | 
                         string-fasta.js |           48->    48 (0.000) |      5.37867-> 5.348 (0.570) | 
                         Geometric mean: |            RSS reduction: 0% |            Speed up: 0.3606% |

<br/>
Extended set of benchmarks

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          112->   112 (0.000) |        2.996-> 2.968 (0.935) | 
                  access-binary-trees.js |           84->    84 (0.000) |       1.852->1.83067 (1.152) | 
                      access-fannkuch.js |           40->    40 (0.000) |        8.92->8.76533 (1.734) | 
                         access-nbody.js |           48->    48 (0.000) |     4.19333-> 4.212 (-0.445) | 
             bitops-3bit-bits-in-byte.js |           32->    32 (0.000) |     2.28267->2.27867 (0.175) | 
                  bitops-bits-in-byte.js |           32->    32 (0.000) |     3.09067->3.03467 (1.812) | 
                   bitops-bitwise-and.js |           32->    32 (0.000) |      3.448->3.44933 (-0.039) | 
                   bitops-nsieve-bits.js |          156->   156 (0.000) |      27.9547->27.804 (0.539) | 
                controlflow-recursive.js |          220->   220 (0.000) |     1.57067->1.54667 (1.528) | 
                           crypto-aes.js |          124->   124 (0.000) |     5.20933->  5.22 (-0.205) | 
                           crypto-md5.js |          184->   184 (0.000) |      24.304->24.2187 (0.351) | 
                          crypto-sha1.js |          132->   132 (0.000) |      11.192->11.1507 (0.369) | 
                    date-format-tofte.js |           72->    72 (0.000) |     3.22933->3.20267 (0.826) | 
                    date-format-xparb.js |           72->    72 (0.000) |      1.66133-> 1.644 (1.043) | 
                          math-cordic.js |           40->    40 (0.000) |     3.28933->3.28133 (0.243) | 
                    math-partial-sums.js |           32->    32 (0.000) |    1.91867->1.92533 (-0.347) | 
                   math-spectral-norm.js |           40->    40 (0.000) |     2.10933->2.07867 (1.454) | 
                         string-fasta.js |           48->    48 (0.000) |     5.39333->5.34533 (0.890) | 
                         Geometric mean: |            RSS reduction: 0% |            Speed up: 0.6698% |

<br/>
Microbenchmark:
```js
for (i = 0; i < 3; i++)
{
  a = [];

  for (j = 0; j < 5000; j++)
  {
    a[j] = j;
  }
}
```

4.6152 -> 4.492 (2.7%)