### PR TITLE
refactor rcs_chunked_list and remove its c++ features

### DIFF
--- a/jerry-core/lit/lit-literal.cpp
+++ b/jerry-core/lit/lit-literal.cpp
@@ -29,7 +29,7 @@ lit_init ()
 {
   JERRY_ASSERT (rcs_get_node_data_space_size () % RCS_DYN_STORAGE_LENGTH_UNIT == 0);
 
-  rcs_lit_storage.init ();
+  rcs_chunked_list_init (&rcs_lit_storage);
 
   lit_magic_strings_init ();
   lit_magic_strings_ex_init ();
@@ -41,8 +41,8 @@ lit_init ()
 void
 lit_finalize ()
 {
-  rcs_lit_storage.cleanup ();
-  rcs_lit_storage.free ();
+  rcs_chunked_list_cleanup (&rcs_lit_storage);
+  rcs_chunked_list_free (&rcs_lit_storage);
 } /* lit_finalize */
 
 /**

--- a/jerry-core/rcs/rcs-allocator.h
+++ b/jerry-core/rcs/rcs-allocator.h
@@ -22,7 +22,7 @@
 extern void rcs_check_record_alignment (rcs_record_t *);
 extern void rcs_free_record (rcs_record_set_t *, rcs_record_t *);
 extern size_t rcs_get_node_data_space_size (void);
-extern uint8_t *rcs_get_node_data_space (rcs_record_set_t *, rcs_chunked_list_t::node_t *);
+extern uint8_t *rcs_get_node_data_space (rcs_record_set_t *, rcs_chunked_list_node_t *);
 extern rcs_record_t *rcs_alloc_record (rcs_record_set_t *, rcs_record_type_t, size_t);
 
 #endif /* !RCS_ALLOCATOR_H */

--- a/jerry-core/rcs/rcs-chunked-list.cpp
+++ b/jerry-core/rcs/rcs-chunked-list.cpp
@@ -15,318 +15,93 @@
 
 #include "rcs-chunked-list.h"
 
-/**
- * Constructor
- */
-void
-rcs_chunked_list_t::init (void)
-{
-  head_p = NULL;
-  tail_p = NULL;
-} /* rcs_chunked_list_t::init */
 
-/**
- * Destructor
- */
-void
-rcs_chunked_list_t::free (void)
-{
-  JERRY_ASSERT (head_p == NULL);
-  JERRY_ASSERT (tail_p == NULL);
-} /* rcs_chunked_list_t::free */
-
-void
-rcs_chunked_list_t::cleanup (void)
-{
-  while (head_p)
-  {
-    remove (head_p);
-  }
-} /* rcs_chunked_list_t::cleanup */
-
-/**
- * Get first node of the list
- *
- * @return pointer to the first node
- */
-rcs_chunked_list_t::node_t*
-rcs_chunked_list_t::get_first (void)
-const
-{
-  return head_p;
-} /* rcs_chunked_list_t::get_first */
-
-/**
- * Get last node of the list
- *
- * @return pointer to the last node
- */
-rcs_chunked_list_t::node_t*
-rcs_chunked_list_t::get_last (void)
-const
-{
-  return tail_p;
-} /* rcs_chunked_list_t::get_last */
-
-/**
- * Get node, previous to specified
- *
- * @return pointer to previous node
- */
-rcs_chunked_list_t::node_t*
-rcs_chunked_list_t::get_prev (rcs_chunked_list_t::node_t *node_p) /**< node to get previous for */
-const
-{
-  JERRY_ASSERT (node_p != NULL);
-
-  return MEM_CP_GET_POINTER (node_t, node_p->prev_cp);
-} /* rcs_chunked_list_t::get_prev */
-
-/**
- * Get node, next to specified
- *
- * @return pointer to next node
- */
-rcs_chunked_list_t::node_t*
-rcs_chunked_list_t::get_next (rcs_chunked_list_t::node_t *node_p) /**< node to get next for */
-const
-{
-  JERRY_ASSERT (node_p != NULL);
-
-  return MEM_CP_GET_POINTER (node_t, node_p->next_cp);
-} /* rcs_chunked_list_t::get_next */
-
-/**
- * Append new node to end of the list
- *
- * @return pointer to the new node
- */
-rcs_chunked_list_t::node_t*
-rcs_chunked_list_t::append_new (void)
-{
-  assert_list_is_correct ();
-
-  node_t *node_p = (node_t*) mem_heap_alloc_chunked_block (MEM_HEAP_ALLOC_LONG_TERM);
-
-  set_prev (node_p, tail_p);
-  set_next (node_p, NULL);
-
-  if (head_p == NULL)
-  {
-    JERRY_ASSERT (tail_p == NULL);
-
-    head_p = node_p;
-    tail_p = node_p;
-  }
-  else
-  {
-    JERRY_ASSERT (tail_p != NULL);
-
-    set_next (tail_p, node_p);
-
-    tail_p = node_p;
-  }
-
-  assert_node_is_correct (node_p);
-
-  return node_p;
-} /* rcs_chunked_list_t::append_new */
-
-/**
- * Insert new node after the specified node
- *
- * @return pointer to the new node
- */
-rcs_chunked_list_t::node_t*
-rcs_chunked_list_t::insert_new (rcs_chunked_list_t::node_t* after_p) /**< the node to insert the new node after */
-{
-  assert_list_is_correct ();
-
-  node_t *node_p = (node_t*) mem_heap_alloc_chunked_block (MEM_HEAP_ALLOC_LONG_TERM);
-
-  JERRY_ASSERT (head_p != NULL);
-  JERRY_ASSERT (tail_p != NULL);
-  assert_node_is_correct (after_p);
-
-  set_next (after_p, node_p);
-  if (tail_p == after_p)
-  {
-    tail_p = node_p;
-  }
-
-  set_prev (node_p, after_p);
-  set_next (node_p, NULL);
-
-  assert_node_is_correct (node_p);
-
-  return node_p;
-} /* rcs_chunked_list_t::insert_new */
-
-/**
- * Remove specified node
- */
-void
-rcs_chunked_list_t::remove (rcs_chunked_list_t::node_t* node_p) /**< node to remove */
-{
-  JERRY_ASSERT (head_p != NULL);
-  JERRY_ASSERT (tail_p != NULL);
-
-  assert_node_is_correct (node_p);
-
-  node_t *prev_node_p, *next_node_p;
-  prev_node_p = get_prev (node_p);
-  next_node_p = get_next (node_p);
-
-  if (prev_node_p == NULL)
-  {
-    JERRY_ASSERT (head_p == node_p);
-    head_p = next_node_p;
-  }
-  else
-  {
-    set_next (prev_node_p, next_node_p);
-  }
-
-  if (next_node_p == NULL)
-  {
-    JERRY_ASSERT (tail_p == node_p);
-    tail_p = prev_node_p;
-  }
-  else
-  {
-    set_prev (next_node_p, prev_node_p);
-  }
-
-  mem_heap_free_block (node_p);
-
-  assert_list_is_correct ();
-} /* rcs_chunked_list_t::remove */
-
-/**
- * Find node containing space, pointed by specified pointer
- *
- * @return pointer to the node that contains the pointed area
- */
-rcs_chunked_list_t::node_t*
-rcs_chunked_list_t::get_node_from_pointer (void* ptr) /**< the pointer value */
-const
-{
-  node_t *node_p = (node_t*) mem_heap_get_chunked_block_start (ptr);
-
-  assert_node_is_correct (node_p);
-
-  return node_p;
-} /* rcs_chunked_list_t::get_node_from_pointer */
-
-/**
- * Get the node's data space
- *
- * @return pointer to beginning of the node's data space
- */
-uint8_t *
-rcs_chunked_list_t::get_node_data_space (rcs_chunked_list_t::node_t *node_p) /**< the node */
-const
-{
-  assert_node_is_correct (node_p);
-
-  return (uint8_t *) (node_p + 1);
-} /* rcs_chunked_list_t::get_node_data_space */
-
-/**
- * Get size of a node's data space
- *
- * @return size
- */
-size_t
-rcs_chunked_list_t::get_node_data_space_size (void)
-{
-  return rcs_chunked_list_t::get_node_size () - sizeof (node_t);
-} /* rcs_chunked_list_t::get_node_data_space_size */
 
 /**
  * Set previous node for the specified node
  */
-void
-rcs_chunked_list_t::set_prev (rcs_chunked_list_t::node_t *node_p, /**< node to set previous for */
-                              rcs_chunked_list_t::node_t *prev_node_p) /**< the previous node */
+static void
+rcs_chunked_list_set_prev (rcs_chunked_list_node_t *node_p, /**< node to set previous for */
+                           rcs_chunked_list_node_t *prev_node_p) /**< the previous node */
 {
   JERRY_ASSERT (node_p != NULL);
 
   MEM_CP_SET_POINTER (node_p->prev_cp, prev_node_p);
-} /* rcs_chunked_list_t::set_prev */
+} /* rcs_chunked_list_set_prev */
 
 /**
  * Set next node for the specified node
  */
-void
-rcs_chunked_list_t::set_next (rcs_chunked_list_t::node_t *node_p, /**< node to set next for */
-                              rcs_chunked_list_t::node_t *next_node_p) /**< the next node */
+static void
+rcs_chunked_list_set_next (rcs_chunked_list_node_t *node_p, /**< node to set next for */
+                           rcs_chunked_list_node_t *next_node_p) /**< the next node */
 {
   JERRY_ASSERT (node_p != NULL);
 
   MEM_CP_SET_POINTER (node_p->next_cp, next_node_p);
-} /* rcs_chunked_list_t::set_next */
+} /* rcs_chunked_list_set_next */
 
 /**
  * Get size of the node
  *
  * @return size of node, including header and data space
  */
-size_t
-rcs_chunked_list_t::get_node_size (void)
+static size_t
+rcs_chunked_list_get_node_size (void)
 {
-  size_t size = mem_heap_recommend_allocation_size (sizeof (node_t) + 1u);
+  size_t size = mem_heap_recommend_allocation_size (sizeof (rcs_chunked_list_node_t) + 1u);
 
-  JERRY_ASSERT (size != 0 && size >= sizeof (node_t));
+  JERRY_ASSERT (size != 0 && size >= sizeof (rcs_chunked_list_node_t));
 
   return size;
-} /* rcs_chunked_list_t::get_node_size */
+} /* rcs_chunked_list_get_node_size */
 
 /**
  * Assert that the list state is correct
  */
-void
-rcs_chunked_list_t::assert_list_is_correct (void)
-const
+static void
+rcs_assert_chunked_list_is_correct (rcs_chunked_list_t *cl_p) /**< the chunked_list */
 {
 #ifndef JERRY_DISABLE_HEAVY_DEBUG
-  for (node_t *node_iter_p = get_first ();
+  for (rcs_chunked_list_node_t *node_iter_p = rcs_chunked_list_get_first (cl_p);
        node_iter_p != NULL;
-       node_iter_p = get_next (node_iter_p))
+       node_iter_p = rcs_chunked_list_get_next (node_iter_p))
   {
-    node_t *prev_node_p = get_prev (node_iter_p);
-    node_t *next_node_p = get_next (node_iter_p);
+    rcs_chunked_list_node_t *prev_node_p = rcs_chunked_list_get_prev (node_iter_p);
+    rcs_chunked_list_node_t *next_node_p = rcs_chunked_list_get_next (node_iter_p);
 
-    JERRY_ASSERT ((node_iter_p == head_p
+    JERRY_ASSERT ((node_iter_p == cl_p->head_p
                    && prev_node_p == NULL)
-                  || (node_iter_p != head_p
+                  || (node_iter_p != cl_p->head_p
                       && prev_node_p != NULL
-                      && get_next (prev_node_p) == node_iter_p));
-    JERRY_ASSERT ((node_iter_p == tail_p
+                      && rcs_chunked_list_get_next (prev_node_p) == node_iter_p));
+    JERRY_ASSERT ((node_iter_p == cl_p->tail_p
                    && next_node_p == NULL)
-                  || (node_iter_p != tail_p
+                  || (node_iter_p != cl_p->tail_p
                       && next_node_p != NULL
-                      && get_prev (next_node_p) == node_iter_p));
+                      && rcs_chunked_list_get_prev (next_node_p) == node_iter_p));
   }
+#else
+  (void) cl_p;
 #endif /* !JERRY_DISABLE_HEAVY_DEBUG */
-} /* rcs_chunked_list_t::assert_list_is_correct */
+} /* rcs_assert_chunked_list_is_correct */
 
 /**
  * Assert that state of specified node is correct
  */
-void
-rcs_chunked_list_t::assert_node_is_correct (const rcs_chunked_list_t::node_t* node_p) /**< the node */
-const
+static void
+rcs_assert_chunked_list_node_is_correct (rcs_chunked_list_t *cl_p, /**< the chunked_list */
+                                     rcs_chunked_list_node_t *node_p) /**< the node */
 {
 #ifndef JERRY_DISABLE_HEAVY_DEBUG
   JERRY_ASSERT (node_p != NULL);
 
-  assert_list_is_correct ();
+  rcs_assert_chunked_list_is_correct (cl_p);
 
   bool is_in_list = false;
-  for (node_t *node_iter_p = get_first ();
+  for (rcs_chunked_list_node_t *node_iter_p = rcs_chunked_list_get_first (cl_p);
        node_iter_p != NULL;
-       node_iter_p = get_next (node_iter_p))
+       node_iter_p = rcs_chunked_list_get_next (node_iter_p))
   {
     if (node_iter_p == node_p)
     {
@@ -339,5 +114,227 @@ const
   JERRY_ASSERT (is_in_list);
 #else /* !JERRY_DISABLE_HEAVY_DEBUG */
   (void) node_p;
+  (void) cl_p;
 #endif /* JERRY_DISABLE_HEAVY_DEBUG */
-} /* rcs_chunked_list_t::assert_node_is_correct */
+} /* rcs_assert_chunked_list_node_is_correct */
+
+
+/**
+ * Initializarion
+ */
+void
+rcs_chunked_list_init (rcs_chunked_list_t *cl_p) /**< the chunked_list */
+{
+  cl_p->head_p = NULL;
+  cl_p->tail_p = NULL;
+} /* rcs_chunked_list_init */
+
+/**
+ * Free
+ */
+void
+rcs_chunked_list_free (rcs_chunked_list_t *cl_p) /**< the chunked_list */
+{
+  JERRY_ASSERT (cl_p->head_p == NULL);
+  JERRY_ASSERT (cl_p->tail_p == NULL);
+} /* rcs_chunked_list_free */
+
+void
+rcs_chunked_list_cleanup (rcs_chunked_list_t *cl_p) /**< the chunked_list */
+{
+  while (cl_p->head_p)
+  {
+    rcs_chunked_list_remove (cl_p, cl_p->head_p);
+  }
+} /* rcs_chunked_list_cleanup */
+
+
+
+/**
+ * Get first node of the list
+ *
+ * @return pointer to the first node
+ */
+rcs_chunked_list_node_t*
+rcs_chunked_list_get_first (rcs_chunked_list_t *cl_p) /**< the chunked_list */
+{
+  return cl_p->head_p;
+} /* rcs_chunked_list_get_first */
+
+
+/**
+ * Get last node of the list
+ *
+ * @return pointer to the last node
+ */
+rcs_chunked_list_node_t*
+rcs_chunked_list_get_last (rcs_chunked_list_t *cl_p) /**< the chunked_list */
+{
+  return cl_p->tail_p;
+} /* rcs_chunked_list_get_last */
+
+/**
+ * Get node, previous to specified
+ *
+ * @return pointer to previous node
+ */
+rcs_chunked_list_node_t*
+rcs_chunked_list_get_prev (rcs_chunked_list_node_t *node_p) /**< the node in the chunked_list */
+{
+  JERRY_ASSERT (node_p != NULL);
+  return MEM_CP_GET_POINTER (rcs_chunked_list_node_t, node_p->prev_cp);
+} /* rcs_chunked_list_get_prev */
+
+
+/**
+ * Get node, next to specified
+ *
+ * @return pointer to next node
+ */
+rcs_chunked_list_node_t*
+rcs_chunked_list_get_next (rcs_chunked_list_node_t *node_p) /**< the node in the chunked_list */
+{
+  JERRY_ASSERT (node_p != NULL);
+  return MEM_CP_GET_POINTER (rcs_chunked_list_node_t, node_p->next_cp);
+} /* rcs_chunked_list_get_next */
+
+/**
+ * Append new node to end of the list
+ *
+ * @return pointer to the new node
+ */
+rcs_chunked_list_node_t*
+rcs_chunked_list_append_new (rcs_chunked_list_t *cl_p) /**< the chunked_list */
+{
+  rcs_assert_chunked_list_is_correct (cl_p);
+  rcs_chunked_list_node_t *node_p =
+  (rcs_chunked_list_node_t*) mem_heap_alloc_chunked_block (MEM_HEAP_ALLOC_LONG_TERM);
+  rcs_chunked_list_set_prev (node_p, cl_p->tail_p);
+  rcs_chunked_list_set_next (node_p, NULL);
+
+  if (cl_p->head_p == NULL)
+  {
+    JERRY_ASSERT (cl_p->tail_p == NULL);
+    cl_p->head_p = node_p;
+    cl_p->tail_p = node_p;
+  }
+  else
+  {
+    JERRY_ASSERT (cl_p->tail_p != NULL);
+    rcs_chunked_list_set_next (cl_p->tail_p, node_p);
+    cl_p->tail_p = node_p;
+  }
+  rcs_assert_chunked_list_node_is_correct (cl_p, node_p);
+
+  return node_p;
+} /* rcs_chunked_list_append_new */
+
+/**
+ * Insert new node after the specified node
+ *
+ * @return pointer to the new node
+ */
+rcs_chunked_list_node_t*
+rcs_chunked_list_insert_new (rcs_chunked_list_t *cl_p, /**< the chunked_list */
+                             rcs_chunked_list_node_t *after_p) /**< the node to insert the new node after */
+{
+  rcs_assert_chunked_list_is_correct (cl_p);
+  rcs_chunked_list_node_t *node_p =
+  (rcs_chunked_list_node_t*) mem_heap_alloc_chunked_block (MEM_HEAP_ALLOC_LONG_TERM);
+  JERRY_ASSERT (cl_p->head_p != NULL);
+  JERRY_ASSERT (cl_p->tail_p != NULL);
+  rcs_assert_chunked_list_node_is_correct (cl_p, after_p);
+
+  rcs_chunked_list_set_next (after_p, node_p);
+  if (cl_p->tail_p == after_p)
+  {
+    cl_p->tail_p = node_p;
+  }
+  rcs_chunked_list_set_prev (node_p, after_p);
+  rcs_chunked_list_set_next (node_p, NULL);
+
+  rcs_assert_chunked_list_node_is_correct (cl_p, node_p);
+  return node_p;
+} /* rcs_chunked_list_insert_new */
+
+/**
+ * Remove specified node
+ */
+void
+rcs_chunked_list_remove (rcs_chunked_list_t *cl_p, /**< the chunked_list */
+                         rcs_chunked_list_node_t *node_p) /**< the node to remove */
+{
+  JERRY_ASSERT (cl_p->head_p != NULL);
+  JERRY_ASSERT (cl_p->tail_p != NULL);
+
+  rcs_assert_chunked_list_node_is_correct (cl_p, node_p);
+  rcs_chunked_list_node_t *prev_node_p, *next_node_p;
+  prev_node_p = rcs_chunked_list_get_prev (node_p);
+  next_node_p = rcs_chunked_list_get_next (node_p);
+
+  if (prev_node_p == NULL)
+  {
+    JERRY_ASSERT (cl_p->head_p == node_p);
+    cl_p->head_p = next_node_p;
+  }
+  else
+  {
+    rcs_chunked_list_set_next (prev_node_p, next_node_p);
+  }
+
+  if (next_node_p == NULL)
+  {
+    JERRY_ASSERT (cl_p->tail_p == node_p);
+    cl_p->tail_p = prev_node_p;
+  }
+  else
+  {
+    rcs_chunked_list_set_prev (next_node_p, prev_node_p);
+  }
+
+  mem_heap_free_block (node_p);
+
+  rcs_assert_chunked_list_is_correct (cl_p);
+} /* rcs_chunked_list_remove */
+
+/**
+ * Find node containing space, pointed by specified pointer
+ *
+ * @return pointer to the node that contains the pointed area
+ */
+rcs_chunked_list_node_t*
+rcs_chunked_list_get_node_from_pointer (rcs_chunked_list_t *cl_p, /**< the chunked_list */
+                                        void* ptr) /**< the pointer value */
+{
+  rcs_chunked_list_node_t *node_p = (rcs_chunked_list_node_t*) mem_heap_get_chunked_block_start (ptr);
+
+  rcs_assert_chunked_list_node_is_correct (cl_p, node_p);
+
+  return node_p;
+} /* rcs_chunked_list_get_node_from_pointer */
+
+/**
+ * Get the node's data space
+ *
+ * @return pointer to beginning of the node's data space
+ */
+uint8_t *
+rcs_chunked_list_get_node_data_space (rcs_chunked_list_t *cl_p, /**< the chunked_list */
+                                      rcs_chunked_list_node_t *node_p) /**< the node */
+{
+  rcs_assert_chunked_list_node_is_correct (cl_p, node_p);
+
+  return (uint8_t *) (node_p + 1);
+} /* rcs_chunked_list_get_node_data_space */
+
+/**
+ * Get size of a node's data space
+ *
+ * @return size
+ */
+size_t
+rcs_chunked_list_get_node_data_space_size (void)
+{
+  return rcs_chunked_list_get_node_size () - sizeof (rcs_chunked_list_node_t);
+} /* rcs_chunked_list_get_node_data_space_size */
+

--- a/jerry-core/rcs/rcs-chunked-list.h
+++ b/jerry-core/rcs/rcs-chunked-list.h
@@ -29,67 +29,36 @@
  */
 
 /**
- * Chunked list
- *
- * Note:
- *      Each node exactly fits size of one memory heap's chunk
- */
-class rcs_chunked_list_t
+  * List node
+  */
+typedef struct
 {
-public:
-  /**
-   * Constructor of chunked list
-   */
-  rcs_chunked_list_t ()
-  {
-    head_p = tail_p = NULL;
-  } /* rcs_chunked_list_t */
-
-  /**
-   * List node
-   */
-  typedef struct
-  {
-    mem_cpointer_t prev_cp; /**< prev list's node */
-    mem_cpointer_t next_cp; /**< next list's node */
-  } node_t;
-
-  void init (void);
-  void cleanup (void);
-  void free (void);
-
-  node_t *get_first (void) const;
-  node_t *get_last (void) const;
-
-  node_t *get_prev (node_t *) const;
-  node_t *get_next (node_t *) const;
-
-  node_t *append_new (void);
-  node_t *insert_new (node_t *);
-
-  void remove (node_t *);
-
-  node_t *get_node_from_pointer (void *) const;
-  uint8_t *get_node_data_space (node_t *) const;
-
-  static size_t get_node_data_space_size (void);
-
-private:
-  void set_prev (node_t *, node_t *);
-  void set_next (node_t *, node_t *);
-
-  static size_t get_node_size (void);
-
-  void assert_list_is_correct (void) const;
-  void assert_node_is_correct (const node_t *) const;
-
-  node_t *head_p; /**< head node of list */
-  node_t *tail_p; /**< tail node of list */
-};
+  mem_cpointer_t prev_cp; /**< prev list's node */
+  mem_cpointer_t next_cp; /**< next list's node */
+} rcs_chunked_list_node_t;
 
 /**
- * @}
- * @}
+ * Chunked list
  */
+typedef struct
+{
+  rcs_chunked_list_node_t *head_p; /**< head node of list */
+  rcs_chunked_list_node_t *tail_p; /**< tail node of list */
+} rcs_chunked_list_t;
+
+extern void rcs_chunked_list_init (rcs_chunked_list_t *);
+extern void rcs_chunked_list_free (rcs_chunked_list_t *);
+extern void rcs_chunked_list_cleanup (rcs_chunked_list_t *);
+extern rcs_chunked_list_node_t *rcs_chunked_list_get_first (rcs_chunked_list_t *);
+extern rcs_chunked_list_node_t *rcs_chunked_list_get_last (rcs_chunked_list_t *);
+extern rcs_chunked_list_node_t *rcs_chunked_list_get_prev (rcs_chunked_list_node_t *);
+extern rcs_chunked_list_node_t *rcs_chunked_list_get_next (rcs_chunked_list_node_t *);
+extern rcs_chunked_list_node_t *rcs_chunked_list_append_new (rcs_chunked_list_t *);
+extern rcs_chunked_list_node_t *rcs_chunked_list_insert_new (rcs_chunked_list_t *, rcs_chunked_list_node_t *);
+extern void rcs_chunked_list_remove (rcs_chunked_list_t *, rcs_chunked_list_node_t *);
+extern rcs_chunked_list_node_t *rcs_chunked_list_get_node_from_pointer (rcs_chunked_list_t *, void *);
+extern uint8_t *rcs_chunked_list_get_node_data_space (rcs_chunked_list_t *, rcs_chunked_list_node_t *);
+extern size_t rcs_chunked_list_get_node_data_space_size (void);
+
 
 #endif /* RCS_CHUNKED_LIST_H */

--- a/jerry-core/rcs/rcs-iterator.cpp
+++ b/jerry-core/rcs/rcs-iterator.cpp
@@ -65,7 +65,8 @@ rcs_iterator_access (rcs_iterator_t *ctx_p, /**< iterator context */
 
   JERRY_ASSERT (!rcs_iterator_finished (ctx_p));
 
-  rcs_chunked_list_t::node_t *current_node_p = ctx_p->recordset_p->get_node_from_pointer (ctx_p->current_pos_p);
+  rcs_chunked_list_node_t *current_node_p =
+  rcs_chunked_list_get_node_from_pointer (ctx_p->recordset_p, ctx_p->current_pos_p);
   uint8_t *current_node_data_space_p = rcs_get_node_data_space (ctx_p->recordset_p, current_node_p);
   size_t left_in_node = node_data_space_size - (size_t) (ctx_p->current_pos_p - current_node_data_space_p);
 
@@ -95,7 +96,7 @@ rcs_iterator_access (rcs_iterator_t *ctx_p, /**< iterator context */
       }
       else if (ctx_p->current_offset + size < record_size)
       {
-        current_node_p = ctx_p->recordset_p->get_next (current_node_p);
+        current_node_p = rcs_chunked_list_get_next (current_node_p);
         JERRY_ASSERT (current_node_p);
         ctx_p->current_pos_p = rcs_get_node_data_space (ctx_p->recordset_p, current_node_p);
       }
@@ -119,7 +120,7 @@ rcs_iterator_access (rcs_iterator_t *ctx_p, /**< iterator context */
       memcpy (ctx_p->current_pos_p, data, first_chunk_size);
     }
 
-    rcs_chunked_list_t::node_t *next_node_p = ctx_p->recordset_p->get_next (current_node_p);
+    rcs_chunked_list_node_t *next_node_p = rcs_chunked_list_get_next (current_node_p);
     JERRY_ASSERT (next_node_p != NULL);
     uint8_t *next_node_data_space_p = rcs_get_node_data_space (ctx_p->recordset_p, next_node_p);
 

--- a/jerry-core/rcs/rcs-records.cpp
+++ b/jerry-core/rcs/rcs-records.cpp
@@ -492,7 +492,7 @@ rcs_record_get_charset (rcs_record_set_t *rec_set_p, /**< recordset */
 rcs_record_t *
 rcs_record_get_first (rcs_record_set_t *rec_set_p) /**< recordset */
 {
-  rcs_chunked_list_t::node_t *first_node_p = rec_set_p->get_first ();
+  rcs_chunked_list_node_t *first_node_p = rcs_chunked_list_get_first (rec_set_p);
 
   if (first_node_p == NULL)
   {
@@ -511,7 +511,7 @@ rcs_record_t *
 rcs_record_get_next (rcs_record_set_t *rec_set_p, /**< recordset */
                      rcs_record_t *rec_p) /**< record */
 {
-  rcs_chunked_list_t::node_t *node_p = rec_set_p->get_node_from_pointer (rec_p);
+  rcs_chunked_list_node_t *node_p = rcs_chunked_list_get_node_from_pointer (rec_set_p, rec_p);
 
   const uint8_t *data_space_begin_p = rcs_get_node_data_space (rec_set_p, node_p);
   const size_t data_space_size = rcs_get_node_data_space_size ();
@@ -527,7 +527,7 @@ rcs_record_get_next (rcs_record_set_t *rec_set_p, /**< recordset */
     return (rcs_record_t *) (record_start_p + record_size);
   }
 
-  node_p = rec_set_p->get_next (node_p);
+  node_p = rcs_chunked_list_get_next (node_p);
   JERRY_ASSERT (node_p != NULL || record_size == node_size_left);
 
   size_t record_size_left = record_size - node_size_left;
@@ -535,7 +535,7 @@ rcs_record_get_next (rcs_record_set_t *rec_set_p, /**< recordset */
   {
     JERRY_ASSERT (node_p != NULL);
 
-    node_p = rec_set_p->get_next (node_p);
+    node_p = rcs_chunked_list_get_next (node_p);
     record_size_left -= data_space_size;
   }
 

--- a/tests/unit/test-literal-storage.cpp
+++ b/tests/unit/test-literal-storage.cpp
@@ -133,7 +133,7 @@ main (int __attr_unused___ argc,
     // Check empty string exists
     JERRY_ASSERT (lit_find_literal_by_utf8_string (NULL, 0));
 
-    rcs_lit_storage.cleanup ();
+    rcs_chunked_list_cleanup (&rcs_lit_storage);
     JERRY_ASSERT (rcs_record_get_first (&rcs_lit_storage) == NULL);
   }
 


### PR DESCRIPTION
remove rcs_chunked_list 's c++ features. All the functionality remain the same

It can pass the make precommit.

in x86 machine (32bit)
`size -A release_jerry` output

section|master|patch
---|---|---
.note.gnu.build-id|36|36
.text|253351|1253191
.rodata|13564|13596
.eh_frame|26464|26036
.init_array|4|0
.data|1096|1096
.bss|2363776|2363776
.comment|41|41
Total|2658332|2657772