### PR TITLE
Refactor opcodes-dumper to not use C++ features.

### DIFF
--- a/jerry-core/parser/js/jsp-early-error.cpp
+++ b/jerry-core/parser/js/jsp-early-error.cpp
@@ -116,8 +116,8 @@ jsp_early_error_start_checking_of_prop_names (void)
 void
 jsp_early_error_add_prop_name (jsp_operand_t op, prop_type pt)
 {
-  JERRY_ASSERT (op.is_string_lit_operand ());
-  STACK_PUSH (props, create_prop_literal (lit_get_literal_by_cp (op.get_literal ()), pt));
+  JERRY_ASSERT (jsp_is_string_lit_operand (op));
+  STACK_PUSH (props, create_prop_literal (lit_get_literal_by_cp (jsp_operand_get_literal (op)), pt));
 }
 
 void
@@ -210,14 +210,14 @@ jsp_early_error_check_for_eval_and_arguments_in_strict_mode (jsp_operand_t op, b
   {
     lit_cpointer_t lit_cp;
 
-    if (op.is_string_lit_operand ()
-        || op.is_number_lit_operand ())
+    if (jsp_is_string_lit_operand (op)
+        || jsp_is_number_lit_operand (op))
     {
-      lit_cp = op.get_literal ();
+      lit_cp = jsp_operand_get_literal (op);
     }
-    else if (op.is_identifier_operand ())
+    else if (jsp_is_identifier_operand (op))
     {
-      lit_cp = op.get_identifier_name ();
+      lit_cp = jsp_operand_get_identifier_name (op);
     }
     else
     {

--- a/jerry-core/parser/js/opcodes-dumper.h
+++ b/jerry-core/parser/js/opcodes-dumper.h
@@ -25,510 +25,33 @@
 #include "scopes-tree.h"
 
 /**
+ * Operand types
+ */
+typedef enum __attr_packed___
+{
+  JSP_OPERAND_TYPE_EMPTY, /**< empty operand */
+  JSP_OPERAND_TYPE_STRING_LITERAL, /**< operand contains string literal value */
+  JSP_OPERAND_TYPE_NUMBER_LITERAL, /**< operand contains number literal value */
+  JSP_OPERAND_TYPE_REGEXP_LITERAL, /**< operand contains regexp literal value */
+  JSP_OPERAND_TYPE_SIMPLE_VALUE, /**< operand contains a simple ecma value */
+  JSP_OPERAND_TYPE_SMALLINT, /**< operand contains small integer value (less than 256) */
+  JSP_OPERAND_TYPE_IDENTIFIER, /**< Identifier reference */
+  JSP_OPERAND_TYPE_THIS_BINDING, /**< ThisBinding operand */
+  JSP_OPERAND_TYPE_TMP, /**< operand contains byte-code register index */
+  JSP_OPERAND_TYPE_IDX_CONST, /**< operand contains an integer constant that fits vm_idx_t */
+  JSP_OPERAND_TYPE_UNKNOWN, /**< operand, representing unknown value that would be rewritten later */
+  JSP_OPERAND_TYPE_UNINITIALIZED /**< uninitialized operand
+                                  *
+                                  *   Note:
+                                  *      For use only in assertions to check that operands
+                                  *      are initialized before actual usage */
+} jsp_operand_type_t;
+
+/**
  * Operand (descriptor of value or reference in context of parser)
  */
-class jsp_operand_t
+typedef struct
 {
-public:
-  enum type_t : uint8_t
-  {
-    EMPTY, /**< empty operand */
-    STRING_LITERAL, /**< operand contains string literal value */
-    NUMBER_LITERAL, /**< operand contains number literal value */
-    REGEXP_LITERAL, /**< operand contains regexp literal value */
-    SIMPLE_VALUE, /**< operand contains a simple ecma value */
-    SMALLINT, /**< operand contains small integer value (less than 256) */
-    IDENTIFIER, /**< Identifier reference */
-    THIS_BINDING, /**< ThisBinding operand */
-    TMP, /**< operand contains byte-code register index */
-    IDX_CONST, /**< operand contains an integer constant that fits vm_idx_t */
-    UNKNOWN, /**< operand, representing unknown value that would be rewritten later */
-    UNINITIALIZED /**< uninitialized operand
-                   *
-                   *   Note:
-                   *      For use only in assertions to check that operands
-                   *      are initialized before actual usage */
-  };
-
-  /**
-   * Construct operand template
-   */
-  jsp_operand_t (void)
-  {
-#ifndef JERRY_NDEBUG
-    _type = jsp_operand_t::UNINITIALIZED;
-#endif /* !JERRY_NDEBUG */
-  } /* jsp_operand_t */
-
-  /**
-   * Construct empty operand
-   *
-   * @return constructed operand
-   */
-  static jsp_operand_t
-  make_empty_operand (void)
-  {
-    jsp_operand_t ret;
-
-    ret._type = jsp_operand_t::EMPTY;
-
-    return ret;
-  } /* make_empty_operand */
-
-  /**
-   * Construct ThisBinding operand
-   *
-   * @return constructed operand
-   */
-  static jsp_operand_t
-  make_this_operand (void)
-  {
-    jsp_operand_t ret;
-
-    ret._type = jsp_operand_t::THIS_BINDING;
-
-    return ret;
-  } /* make_this_operand */
-
-  /**
-   * Construct unknown operand
-   *
-   * @return constructed operand
-   */
-  static jsp_operand_t
-  make_unknown_operand (void)
-  {
-    jsp_operand_t ret;
-
-    ret._type = jsp_operand_t::UNKNOWN;
-
-    return ret;
-  } /* make_unknown_operand */
-
-  /**
-   * Construct idx-constant operand
-   *
-   * @return constructed operand
-   */
-  static jsp_operand_t
-  make_idx_const_operand (vm_idx_t cnst) /**< integer in vm_idx_t range */
-  {
-    jsp_operand_t ret;
-
-    ret._type = jsp_operand_t::IDX_CONST;
-    ret._data.idx_const = cnst;
-
-    return ret;
-  } /* make_idx_const_operand */
-
-  /**
-   * Construct small integer operand
-   *
-   * @return constructed operand
-   */
-  static jsp_operand_t
-  make_smallint_operand (uint8_t integer_value) /**< small integer value */
-  {
-    jsp_operand_t ret;
-
-    ret._type = jsp_operand_t::SMALLINT;
-    ret._data.smallint_value = integer_value;
-
-    return ret;
-  } /* make_smallint_operand */
-
-  /**
-   * Construct simple ecma value operand
-   *
-   * @return constructed operand
-   */
-  static jsp_operand_t
-  make_simple_value_operand (ecma_simple_value_t simple_value) /**< simple ecma value */
-  {
-    jsp_operand_t ret;
-
-    ret._type = jsp_operand_t::SIMPLE_VALUE;
-    ret._data.simple_value = simple_value;
-
-    return ret;
-  } /* make_simple_value_operand */
-
-  /**
-   * Construct string literal operand
-   *
-   * @return constructed operand
-   */
-  static jsp_operand_t
-  make_string_lit_operand (lit_cpointer_t lit_id) /**< literal identifier */
-  {
-    JERRY_ASSERT (lit_id.packed_value != NOT_A_LITERAL.packed_value);
-
-#ifndef JERRY_NDEBUG
-    lit_literal_t lit = lit_get_literal_by_cp (lit_id);
-
-    JERRY_ASSERT (RCS_RECORD_IS_CHARSET (lit)
-                  || RCS_RECORD_IS_MAGIC_STR (lit)
-                  || RCS_RECORD_IS_MAGIC_STR_EX (lit));
-#endif /* !JERRY_NDEBUG */
-
-    jsp_operand_t ret;
-
-    ret._type = jsp_operand_t::STRING_LITERAL;
-    ret._data.lit_id = lit_id;
-
-    return ret;
-  } /* make_string_lit_operand */
-
-  /**
-   * Construct RegExp literal operand
-   *
-   * @return constructed operand
-   */
-  static jsp_operand_t
-  make_regexp_lit_operand (lit_cpointer_t lit_id) /**< literal identifier */
-  {
-    JERRY_ASSERT (lit_id.packed_value != NOT_A_LITERAL.packed_value);
-
-#ifndef JERRY_NDEBUG
-    lit_literal_t lit = lit_get_literal_by_cp (lit_id);
-
-    JERRY_ASSERT (RCS_RECORD_IS_CHARSET (lit)
-                  || RCS_RECORD_IS_MAGIC_STR (lit)
-                  || RCS_RECORD_IS_MAGIC_STR_EX (lit));
-#endif /* !JERRY_NDEBUG */
-
-    jsp_operand_t ret;
-
-    ret._type = jsp_operand_t::REGEXP_LITERAL;
-    ret._data.lit_id = lit_id;
-
-    return ret;
-  } /* make_regexp_lit_operand */
-
-  /**
-   * Construct number literal operand
-   *
-   * @return constructed operand
-   */
-  static jsp_operand_t
-  make_number_lit_operand (lit_cpointer_t lit_id) /**< literal identifier */
-  {
-    JERRY_ASSERT (lit_id.packed_value != NOT_A_LITERAL.packed_value);
-
-#ifndef JERRY_NDEBUG
-    lit_literal_t lit = lit_get_literal_by_cp (lit_id);
-
-    JERRY_ASSERT (RCS_RECORD_IS_NUMBER (lit));
-#endif /* !JERRY_NDEBUG */
-
-    jsp_operand_t ret;
-
-    ret._type = jsp_operand_t::NUMBER_LITERAL;
-    ret._data.lit_id = lit_id;
-
-    return ret;
-  } /* make_number_lit_operand */
-
-  /**
-   * Construct identifier reference operand
-   *
-   * @return constructed operand
-   */
-  static jsp_operand_t
-  make_identifier_operand (lit_cpointer_t lit_id) /**< literal identifier */
-  {
-    JERRY_ASSERT (lit_id.packed_value != NOT_A_LITERAL.packed_value);
-
-    jsp_operand_t ret;
-
-    ret._type = jsp_operand_t::IDENTIFIER;
-    ret._data.identifier = lit_id;
-
-    return ret;
-  } /* make_identifier_operand */
-
-  /**
-   * Construct register operand
-   *
-   * @return constructed operand
-   */
-  static jsp_operand_t
-  make_reg_operand (vm_idx_t reg_index) /**< register index */
-  {
-    /*
-     * The following check currently leads to 'comparison is always true
-     * due to limited range of data type' warning, so it is turned off.
-     *
-     * If VM_IDX_GENERAL_VALUE_FIRST is changed to value greater than 0,
-     * the check should be restored.
-     */
-    // JERRY_ASSERT (reg_index >= VM_IDX_GENERAL_VALUE_FIRST);
-    static_assert (VM_IDX_GENERAL_VALUE_FIRST == 0, "See comment above");
-
-    JERRY_ASSERT (reg_index <= VM_IDX_GENERAL_VALUE_LAST);
-
-    jsp_operand_t ret;
-
-    ret._type = jsp_operand_t::TMP;
-    ret._data.uid = reg_index;
-
-    return ret;
-  } /* make_reg_operand */
-
-  /**
-   * Is it empty operand?
-   *
-   * @return true / false
-   */
-  bool
-  is_empty_operand (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    return (_type == jsp_operand_t::EMPTY);
-  } /* is_empty_operand */
-
-  /**
-   * Is it ThisBinding operand?
-   *
-   * @return true / false
-   */
-  bool
-  is_this_operand (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    return (_type == jsp_operand_t::THIS_BINDING);
-  } /* is_this_operand */
-
-  /**
-   * Is it unknown operand?
-   *
-   * @return true / false
-   */
-  bool
-  is_unknown_operand (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    return (_type == jsp_operand_t::UNKNOWN);
-  } /* is_unknown_operand */
-
-  /**
-   * Is it idx-constant operand?
-   *
-   * @return true / false
-   */
-  bool
-  is_idx_const_operand (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    return (_type == jsp_operand_t::IDX_CONST);
-  } /* is_idx_const_operand */
-
-  /**
-   * Is it byte-code register operand?
-   *
-   * @return true / false
-   */
-  bool
-  is_register_operand (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    return (_type == jsp_operand_t::TMP);
-  } /* is_register_operand */
-
-  /**
-   * Is it simple ecma value operand?
-   *
-   * @return true / false
-   */
-  bool
-  is_simple_value_operand (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    return (_type == jsp_operand_t::SIMPLE_VALUE);
-  } /* is_simple_value_operand */
-
-  /**
-   * Is it small integer operand?
-   *
-   * @return true / false
-   */
-  bool
-  is_smallint_operand (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    return (_type == jsp_operand_t::SMALLINT);
-  } /* is_smallint_operand */
-
-  /**
-   * Is it number literal operand?
-   *
-   * @return true / false
-   */
-  bool
-  is_number_lit_operand (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    return (_type == jsp_operand_t::NUMBER_LITERAL);
-  } /* is_number_lit_operand */
-
-  /**
-   * Is it string literal operand?
-   *
-   * @return true / false
-   */
-  bool
-  is_string_lit_operand (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    return (_type == jsp_operand_t::STRING_LITERAL);
-  } /* is_string_lit_operand */
-
-  /**
-   * Is it RegExp literal operand?
-   *
-   * @return true / false
-   */
-  bool
-  is_regexp_lit_operand (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    return (_type == jsp_operand_t::REGEXP_LITERAL);
-  } /* is_regexp_lit_operand */
-
-  /**
-   * Is it identifier reference operand?
-   *
-   * @return true / false
-   */
-  bool is_identifier_operand (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    return (_type == jsp_operand_t::IDENTIFIER);
-  } /* is_identifier_operand */
-
-  /**
-   * Get string literal - name of Identifier reference
-   *
-   * @return literal identifier
-   */
-  lit_cpointer_t get_identifier_name (void) const
-  {
-    JERRY_ASSERT (is_identifier_operand ());
-
-    return (_data.identifier);
-  } /* get_identifier_name */
-
-  /**
-   * Get idx for operand
-   *
-   * @return VM_IDX_REWRITE_LITERAL_UID (for jsp_operand_t::LITERAL),
-   *         or register index (for jsp_operand_t::TMP).
-   */
-  vm_idx_t
-  get_idx (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    if (_type == jsp_operand_t::TMP)
-    {
-      return _data.uid;
-    }
-    else if (_type == jsp_operand_t::STRING_LITERAL
-             || _type == jsp_operand_t::NUMBER_LITERAL)
-    {
-      return VM_IDX_REWRITE_LITERAL_UID;
-    }
-    else if (_type == jsp_operand_t::THIS_BINDING)
-    {
-      return VM_REG_SPECIAL_THIS_BINDING;
-    }
-    else
-    {
-      JERRY_ASSERT (_type == jsp_operand_t::EMPTY);
-
-      return VM_IDX_EMPTY;
-    }
-  } /* get_idx */
-
-  /**
-   * Get literal from operand
-   *
-   * @return literal identifier (for jsp_operand_t::LITERAL),
-   *         or NOT_A_LITERAL (for jsp_operand_t::TMP).
-   */
-  lit_cpointer_t
-  get_literal (void) const
-  {
-    JERRY_ASSERT (_type != jsp_operand_t::UNINITIALIZED);
-
-    if (_type == jsp_operand_t::TMP)
-    {
-      return NOT_A_LITERAL;
-    }
-    else if (_type == jsp_operand_t::STRING_LITERAL
-             || _type == jsp_operand_t::NUMBER_LITERAL
-             || _type == jsp_operand_t::REGEXP_LITERAL)
-    {
-      return _data.lit_id;
-    }
-    else
-    {
-      JERRY_ASSERT (_type == jsp_operand_t::EMPTY);
-
-      return NOT_A_LITERAL;
-    }
-  } /* get_literal */
-
-  /**
-   * Get constant from idx-constant operand
-   *
-   * @return an integer
-   */
-  vm_idx_t
-  get_idx_const (void) const
-  {
-    JERRY_ASSERT (is_idx_const_operand ());
-
-    return _data.idx_const;
-  } /* get_idx_const */
-
-  /**
-   * Get small integer constant from operand
-   *
-   * @return an integer
-   */
-  uint8_t
-  get_smallint_value (void) const
-  {
-    JERRY_ASSERT (is_smallint_operand ());
-
-    return _data.smallint_value;
-  } /* get_smallint_value */
-
-  /**
-   * Get simple value from operand
-   *
-   * @return a simple ecma value
-   */
-  ecma_simple_value_t
-  get_simple_value (void) const
-  {
-    JERRY_ASSERT (is_simple_value_operand ());
-
-    return (ecma_simple_value_t) _data.simple_value;
-  } /* get_simple_value */
-private:
   union
   {
     vm_idx_t idx_const; /**< idx constant value (for jsp_operand_t::IDX_CONST) */
@@ -537,12 +60,44 @@ private:
     lit_cpointer_t identifier; /**< Identifier reference (is_value_based_ref flag not set) */
     uint8_t smallint_value; /**< small integer value */
     uint8_t simple_value; /**< simple ecma value */
-  } _data;
+  } data;
 
-  type_t _type; /**< type of operand */
-};
+  jsp_operand_type_t type; /**< type of operand */
+} jsp_operand_t;
 
-static_assert (sizeof (jsp_operand_t) == 4, "");
+extern jsp_operand_t jsp_make_uninitialized_operand (void);
+extern jsp_operand_t jsp_make_empty_operand (void);
+extern jsp_operand_t jsp_make_this_operand (void);
+extern jsp_operand_t jsp_make_unknown_operand (void);
+extern jsp_operand_t jsp_make_idx_const_operand (vm_idx_t);
+extern jsp_operand_t jsp_make_smallint_operand (uint8_t);
+extern jsp_operand_t jsp_make_simple_value_operand (ecma_simple_value_t);
+extern jsp_operand_t jsp_make_string_lit_operand (lit_cpointer_t);
+extern jsp_operand_t jsp_make_regexp_lit_operand (lit_cpointer_t);
+extern jsp_operand_t jsp_make_number_lit_operand (lit_cpointer_t);
+extern jsp_operand_t jsp_make_identifier_operand (lit_cpointer_t);
+extern jsp_operand_t jsp_make_reg_operand (vm_idx_t);
+
+extern bool jsp_is_empty_operand (jsp_operand_t);
+extern bool jsp_is_this_operand (jsp_operand_t);
+extern bool jsp_is_unknown_operand (jsp_operand_t);
+extern bool jsp_is_idx_const_operand (jsp_operand_t);
+extern bool jsp_is_register_operand (jsp_operand_t);
+extern bool jsp_is_simple_value_operand (jsp_operand_t);
+extern bool jsp_is_smallint_operand (jsp_operand_t);
+extern bool jsp_is_number_lit_operand (jsp_operand_t);
+extern bool jsp_is_string_lit_operand (jsp_operand_t);
+extern bool jsp_is_regexp_lit_operand (jsp_operand_t);
+extern bool jsp_is_identifier_operand (jsp_operand_t);
+
+extern lit_cpointer_t jsp_operand_get_identifier_name (jsp_operand_t);
+extern lit_cpointer_t jsp_operand_get_literal (jsp_operand_t);
+extern vm_idx_t jsp_operand_get_idx (jsp_operand_t);
+extern vm_idx_t jsp_operand_get_idx_const (jsp_operand_t);
+extern ecma_simple_value_t jsp_operand_get_simple_value (jsp_operand_t);
+extern uint8_t jsp_operand_get_smallint_value (jsp_operand_t);
+
+JERRY_STATIC_ASSERT (sizeof (jsp_operand_t) == 4);
 
 typedef enum __attr_packed___
 {
@@ -554,89 +109,91 @@ typedef enum __attr_packed___
   VARG_CALL_EXPR
 } varg_list_type;
 
-jsp_operand_t empty_operand (void);
-jsp_operand_t tmp_operand (void);
-bool operand_is_empty (jsp_operand_t);
+extern jsp_operand_t empty_operand (void);
+extern jsp_operand_t tmp_operand (void);
+extern bool operand_is_empty (jsp_operand_t);
 
-void dumper_init (jsp_ctx_t *, bool);
+extern void dumper_init (jsp_ctx_t *, bool);
 
-vm_instr_counter_t dumper_get_current_instr_counter (jsp_ctx_t *);
+extern vm_instr_counter_t dumper_get_current_instr_counter (jsp_ctx_t *);
 
-void dumper_start_move_of_vars_to_regs (jsp_ctx_t *);
-bool dumper_start_move_of_args_to_regs (jsp_ctx_t *, uint32_t args_num);
-bool dumper_try_replace_identifier_name_with_reg (jsp_ctx_t *, bytecode_data_header_t *, op_meta *);
-void dumper_alloc_reg_for_unused_arg (jsp_ctx_t *);
+extern void dumper_start_move_of_vars_to_regs (jsp_ctx_t *);
+extern bool dumper_start_move_of_args_to_regs (jsp_ctx_t *, uint32_t args_num);
+extern bool dumper_try_replace_identifier_name_with_reg (jsp_ctx_t *, bytecode_data_header_t *, op_meta *);
+extern void dumper_alloc_reg_for_unused_arg (jsp_ctx_t *);
 
-void dumper_new_statement (jsp_ctx_t *);
-void dumper_save_reg_alloc_ctx (jsp_ctx_t *, vm_idx_t *, vm_idx_t *);
-void dumper_restore_reg_alloc_ctx (jsp_ctx_t *, vm_idx_t, vm_idx_t, bool);
-vm_idx_t dumper_save_reg_alloc_counter (jsp_ctx_t *);
-void dumper_restore_reg_alloc_counter (jsp_ctx_t *, vm_idx_t);
+extern void dumper_new_statement (jsp_ctx_t *);
+extern void dumper_save_reg_alloc_ctx (jsp_ctx_t *, vm_idx_t *, vm_idx_t *);
+extern void dumper_restore_reg_alloc_ctx (jsp_ctx_t *, vm_idx_t, vm_idx_t, bool);
+extern vm_idx_t dumper_save_reg_alloc_counter (jsp_ctx_t *);
+extern void dumper_restore_reg_alloc_counter (jsp_ctx_t *, vm_idx_t);
 
 extern bool dumper_is_eval_literal (jsp_operand_t);
 
-void dump_variable_assignment (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
+extern void dump_variable_assignment (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
 
-vm_instr_counter_t dump_varg_header_for_rewrite (jsp_ctx_t *, varg_list_type, jsp_operand_t, jsp_operand_t);
-void rewrite_varg_header_set_args_count (jsp_ctx_t *, size_t, vm_instr_counter_t);
-void dump_call_additional_info (jsp_ctx_t *, opcode_call_flags_t, jsp_operand_t);
-void dump_varg (jsp_ctx_t *, jsp_operand_t);
+extern vm_instr_counter_t dump_varg_header_for_rewrite (jsp_ctx_t *, varg_list_type, jsp_operand_t, jsp_operand_t);
+extern void rewrite_varg_header_set_args_count (jsp_ctx_t *, size_t, vm_instr_counter_t);
+extern void dump_call_additional_info (jsp_ctx_t *, opcode_call_flags_t, jsp_operand_t);
+extern void dump_varg (jsp_ctx_t *, jsp_operand_t);
 
-void dump_prop_name_and_value (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
-void dump_prop_getter_decl (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
-void dump_prop_setter_decl (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
-void dump_prop_getter (jsp_ctx_t *, jsp_operand_t, jsp_operand_t, jsp_operand_t);
-void dump_prop_setter (jsp_ctx_t *, jsp_operand_t, jsp_operand_t, jsp_operand_t);
+extern void dump_prop_name_and_value (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
+extern void dump_prop_getter_decl (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
+extern void dump_prop_setter_decl (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
+extern void dump_prop_getter (jsp_ctx_t *, jsp_operand_t, jsp_operand_t, jsp_operand_t);
+extern void dump_prop_setter (jsp_ctx_t *, jsp_operand_t, jsp_operand_t, jsp_operand_t);
 
-vm_instr_counter_t dump_conditional_check_for_rewrite (jsp_ctx_t *, jsp_operand_t);
-void rewrite_conditional_check (jsp_ctx_t *, vm_instr_counter_t);
-vm_instr_counter_t dump_jump_to_end_for_rewrite (jsp_ctx_t *);
-void rewrite_jump_to_end (jsp_ctx_t *, vm_instr_counter_t);
+extern vm_instr_counter_t dump_conditional_check_for_rewrite (jsp_ctx_t *, jsp_operand_t);
+extern void rewrite_conditional_check (jsp_ctx_t *, vm_instr_counter_t);
+extern vm_instr_counter_t dump_jump_to_end_for_rewrite (jsp_ctx_t *);
+extern void rewrite_jump_to_end (jsp_ctx_t *, vm_instr_counter_t);
 
-vm_instr_counter_t dumper_set_next_iteration_target (jsp_ctx_t *);
-vm_instr_counter_t dump_simple_or_nested_jump_for_rewrite (jsp_ctx_t *,
+extern vm_instr_counter_t dumper_set_next_iteration_target (jsp_ctx_t *);
+extern vm_instr_counter_t dump_simple_or_nested_jump_for_rewrite (jsp_ctx_t *,
                                                            bool,
                                                            bool,
                                                            bool,
                                                            jsp_operand_t,
                                                            vm_instr_counter_t);
-vm_instr_counter_t rewrite_simple_or_nested_jump_and_get_next (jsp_ctx_t *, vm_instr_counter_t, vm_instr_counter_t);
-void dump_continue_iterations_check (jsp_ctx_t *, vm_instr_counter_t, jsp_operand_t);
+extern vm_instr_counter_t rewrite_simple_or_nested_jump_and_get_next (jsp_ctx_t *,
+                                                                      vm_instr_counter_t,
+                                                                      vm_instr_counter_t);
+extern void dump_continue_iterations_check (jsp_ctx_t *, vm_instr_counter_t, jsp_operand_t);
 
-void dump_delete (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
-void dump_delete_prop (jsp_ctx_t *, jsp_operand_t, jsp_operand_t, jsp_operand_t);
+extern void dump_delete (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
+extern void dump_delete_prop (jsp_ctx_t *, jsp_operand_t, jsp_operand_t, jsp_operand_t);
 
-void dump_typeof (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
+extern void dump_typeof (jsp_ctx_t *, jsp_operand_t, jsp_operand_t);
 
-void dump_unary_op (jsp_ctx_t *, vm_op_t, jsp_operand_t, jsp_operand_t);
-void dump_binary_op (jsp_ctx_t *, vm_op_t, jsp_operand_t, jsp_operand_t, jsp_operand_t);
+extern void dump_unary_op (jsp_ctx_t *, vm_op_t, jsp_operand_t, jsp_operand_t);
+extern void dump_binary_op (jsp_ctx_t *, vm_op_t, jsp_operand_t, jsp_operand_t, jsp_operand_t);
 
-vm_instr_counter_t dump_with_for_rewrite (jsp_ctx_t *, jsp_operand_t);
-void rewrite_with (jsp_ctx_t *, vm_instr_counter_t);
-void dump_with_end (jsp_ctx_t *);
+extern vm_instr_counter_t dump_with_for_rewrite (jsp_ctx_t *, jsp_operand_t);
+extern void rewrite_with (jsp_ctx_t *, vm_instr_counter_t);
+extern void dump_with_end (jsp_ctx_t *);
 
-vm_instr_counter_t dump_for_in_for_rewrite (jsp_ctx_t *, jsp_operand_t);
-void rewrite_for_in (jsp_ctx_t *, vm_instr_counter_t);
-void dump_for_in_end (jsp_ctx_t *);
+extern vm_instr_counter_t dump_for_in_for_rewrite (jsp_ctx_t *, jsp_operand_t);
+extern void rewrite_for_in (jsp_ctx_t *, vm_instr_counter_t);
+extern void dump_for_in_end (jsp_ctx_t *);
 
-vm_instr_counter_t dump_try_for_rewrite (jsp_ctx_t *);
-vm_instr_counter_t dump_catch_for_rewrite (jsp_ctx_t *, jsp_operand_t);
-vm_instr_counter_t dump_finally_for_rewrite (jsp_ctx_t *);
-void rewrite_try (jsp_ctx_t *, vm_instr_counter_t);
-void rewrite_catch (jsp_ctx_t *, vm_instr_counter_t);
-void rewrite_finally (jsp_ctx_t *, vm_instr_counter_t);
-void dump_end_try_catch_finally (jsp_ctx_t *);
-void dump_throw (jsp_ctx_t *, jsp_operand_t);
+extern vm_instr_counter_t dump_try_for_rewrite (jsp_ctx_t *);
+extern vm_instr_counter_t dump_catch_for_rewrite (jsp_ctx_t *, jsp_operand_t);
+extern vm_instr_counter_t dump_finally_for_rewrite (jsp_ctx_t *);
+extern void rewrite_try (jsp_ctx_t *, vm_instr_counter_t);
+extern void rewrite_catch (jsp_ctx_t *, vm_instr_counter_t);
+extern void rewrite_finally (jsp_ctx_t *, vm_instr_counter_t);
+extern void dump_end_try_catch_finally (jsp_ctx_t *);
+extern void dump_throw (jsp_ctx_t *, jsp_operand_t);
 
-void dump_variable_declaration (jsp_ctx_t *, lit_cpointer_t);
+extern void dump_variable_declaration (jsp_ctx_t *, lit_cpointer_t);
 
-vm_instr_counter_t dump_reg_var_decl_for_rewrite (jsp_ctx_t *);
-void rewrite_reg_var_decl (jsp_ctx_t *, vm_instr_counter_t);
+extern vm_instr_counter_t dump_reg_var_decl_for_rewrite (jsp_ctx_t *);
+extern void rewrite_reg_var_decl (jsp_ctx_t *, vm_instr_counter_t);
 
-void dump_ret (jsp_ctx_t *);
-void dump_retval (jsp_ctx_t *, jsp_operand_t);
+extern void dump_ret (jsp_ctx_t *);
+extern void dump_retval (jsp_ctx_t *, jsp_operand_t);
 
-op_meta dumper_get_op_meta (jsp_ctx_t *, vm_instr_counter_t);
-void dumper_rewrite_op_meta (jsp_ctx_t *, vm_instr_counter_t, op_meta);
+extern op_meta dumper_get_op_meta (jsp_ctx_t *, vm_instr_counter_t);
+extern void dumper_rewrite_op_meta (jsp_ctx_t *, vm_instr_counter_t, op_meta);
 
-#endif /* OPCODES_DUMPER_H */
+#endif /* !OPCODES_DUMPER_H */


### PR DESCRIPTION
Measurement results:
<pre>
testing board:  rpi2
master revision: 18d0d8c
</pre>

section            |size (master)|size (patch) |
-------------------|-------------|-------------|
.note.gnu.build-id | 36          | 36          |
.text              | 190892      | 190100      |
.rodata            | 8292        | 8324        |
.ARM.exidx         | 8           | 8           |
.init_array        | 4           | 4           |
.data              | 1096        | 1096        |
.bss               | 2363784     | 2363784     |
.comment           | 40          | 40          |
.ARM.attributes    | 47          | 47          |
Total              | 2564199     | 2563439     |

Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          112->   112 (0.000) |        2.966-> 2.954 (0.405) | 
                  access-binary-trees.js |           84->    84 (0.000) |       1.811-> 1.823 (-0.663) | 
                      access-fannkuch.js |           40->    40 (0.000) |        9.309-> 8.814 (5.317) | 
                         access-nbody.js |           48->    44 (8.333) |        4.204-> 4.133 (1.689) | 
             bitops-3bit-bits-in-byte.js |         32->    36 (-12.500) |        2.272-> 2.252 (0.880) | 
                  bitops-bits-in-byte.js |           32->    32 (0.000) |        3.046->  3.02 (0.854) | 
                   bitops-bitwise-and.js |         32->    36 (-12.500) |        3.464-> 3.434 (0.866) | 
                controlflow-recursive.js |         220->   228 (-3.636) |        1.56-> 1.587 (-1.731) | 
                           crypto-aes.js |         128->   132 (-3.125) |        5.211-> 5.163 (0.921) | 
                           crypto-md5.js |         184->   192 (-4.348) |        21.95->21.725 (1.025) | 
                          crypto-sha1.js |          132->   132 (0.000) |       10.248->10.192 (0.546) | 
                    date-format-tofte.js |          72->    76 (-5.556) |       3.182-> 3.185 (-0.094) | 
                    date-format-xparb.js |           72->    72 (0.000) |       1.642-> 1.656 (-0.853) | 
                          math-cordic.js |           40->    40 (0.000) |       3.326-> 3.335 (-0.271) | 
                    math-partial-sums.js |         32->    36 (-12.500) |        1.957-> 1.938 (0.971) | 
                   math-spectral-norm.js |         40->    44 (-10.000) |       2.051-> 2.066 (-0.731) | 
                         string-fasta.js |           48->    48 (0.000) |        5.353-> 5.322 (0.579) | 
                         Geometric mean: |       RSS reduction: -3.135% |            Speed up: 0.5821% |