### PR TITLE
ecma_compare_ecma_strings_longpath performance improvement

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-string.cpp
+++ b/jerry-core/ecma/base/ecma-helpers-string.cpp
@@ -1043,29 +1043,34 @@ ecma_compare_ecma_strings_longpath (const ecma_string_t *string1_p, /* ecma-stri
 {
   if (string1_p->container == string2_p->container)
   {
-    if (string1_p->container == ECMA_STRING_CONTAINER_LIT_TABLE)
+    switch ((ecma_string_container_t) string1_p->container)
     {
-      JERRY_ASSERT (string1_p->u.lit_cp.packed_value != string2_p->u.lit_cp.packed_value);
-
-      return false;
-    }
-    else if (string1_p->container == ECMA_STRING_CONTAINER_MAGIC_STRING)
-    {
-      JERRY_ASSERT (string1_p->u.magic_string_id != string2_p->u.magic_string_id);
-
-      return false;
-    }
-    else if (string1_p->container == ECMA_STRING_CONTAINER_MAGIC_STRING_EX)
-    {
-      JERRY_ASSERT (string1_p->u.magic_string_ex_id != string2_p->u.magic_string_ex_id);
-
-      return false;
-    }
-    else if (string1_p->container == ECMA_STRING_CONTAINER_UINT32_IN_DESC)
-    {
-      JERRY_ASSERT (string1_p->u.uint32_number != string2_p->u.uint32_number);
-
-      return false;
+      case ECMA_STRING_CONTAINER_LIT_TABLE:
+      {
+        JERRY_ASSERT (string1_p->u.lit_cp.packed_value != string2_p->u.lit_cp.packed_value);
+        return false;
+      }
+      case ECMA_STRING_CONTAINER_MAGIC_STRING:
+      {
+        JERRY_ASSERT (string1_p->u.magic_string_id != string2_p->u.magic_string_id);
+        return false;
+      }
+      case ECMA_STRING_CONTAINER_MAGIC_STRING_EX:
+      {
+        JERRY_ASSERT (string1_p->u.magic_string_ex_id != string2_p->u.magic_string_ex_id);
+        return false;
+      }
+      case ECMA_STRING_CONTAINER_UINT32_IN_DESC:
+      {
+        JERRY_ASSERT (string1_p->u.uint32_number != string2_p->u.uint32_number);
+        return false;
+      }
+      default:
+      {
+        JERRY_ASSERT (string1_p->container == ECMA_STRING_CONTAINER_HEAP_NUMBER
+                      || string1_p->container == ECMA_STRING_CONTAINER_HEAP_CHUNKS);
+        break;
+      }
     }
   }
 
@@ -1111,29 +1116,10 @@ ecma_compare_ecma_strings_longpath (const ecma_string_t *string1_p, /* ecma-stri
 
         return ecma_compare_chars_collection (chars_collection1_p, chars_collection2_p);
       }
-      case ECMA_STRING_CONTAINER_LIT_TABLE:
+      default:
       {
-        JERRY_ASSERT (string1_p->u.lit_cp.packed_value != string2_p->u.lit_cp.packed_value);
-
-        return false;
-      }
-      case ECMA_STRING_CONTAINER_MAGIC_STRING:
-      {
-        JERRY_ASSERT (string1_p->u.magic_string_id != string2_p->u.magic_string_id);
-
-        return false;
-      }
-      case ECMA_STRING_CONTAINER_MAGIC_STRING_EX:
-      {
-        JERRY_ASSERT (string1_p->u.magic_string_ex_id != string2_p->u.magic_string_ex_id);
-
-        return false;
-      }
-      case ECMA_STRING_CONTAINER_UINT32_IN_DESC:
-      {
-        JERRY_ASSERT (string1_p->u.uint32_number != string2_p->u.uint32_number);
-
-        return false;
+        JERRY_ASSERT (false);
+        break;
       }
     }
   }


### PR DESCRIPTION


JerryScript-DCO-1.0-Signed-off-by: Xin Hu Xin.A.Hu@intel.com

Run ./tools/run-perf-test.sh 10 times, 
OS, ubuntu 15.04, 32 bit
CPU, Intel(R) Celeron(R) CPU N2820 @ 2.13GHz, 2 core

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |         116->   120 (-3.448) |      1.09733-> 1.056 (3.766) |3d-morph.js | <FAILED>3d-raytrace.js | <FAILED>
                  access-binary-trees.js |          84->    88 (-4.762) |        0.656-> 0.652 (0.610) |
                      access-fannkuch.js |          44->    48 (-9.091) |     3.54333->3.44267 (2.841) |access-nbody.js | <FAILED>access-nsieve.js | <FAILED>
             bitops-3bit-bits-in-byte.js |           32->    32 (0.000) |        0.908->   0.9 (0.881) |
                  bitops-bits-in-byte.js |          36->    32 (11.111) |     1.24067->1.22067 (1.612) |
                   bitops-bitwise-and.js |           36->    36 (0.000) |     1.24133-> 1.266 (-1.987) |
                   bitops-nsieve-bits.js |         156->   160 (-2.564) |     10.0293->9.97467 (0.545) |
                controlflow-recursive.js |          244->   244 (0.000) |       0.58->0.569333 (1.839) |
                           crypto-aes.js |          132->   132 (0.000) |      2.11733-> 2.068 (2.330) |
                           crypto-md5.js |          192->   192 (0.000) |     10.5987->10.5987 (0.000) |
                          crypto-sha1.js |          140->   136 (2.857) |      4.81333->   4.8 (0.277) |
                    date-format-tofte.js |           80->    80 (0.000) |      1.21667-> 1.182 (2.850) |
                    date-format-xparb.js |           76->    76 (0.000) |  0.633333->0.635333 (-0.316) |
                          math-cordic.js |           44->    44 (0.000) |        1.324-> 1.292 (2.417) |math-partial-sums.js | <FAILED>
                   math-spectral-norm.js |           44->    40 (9.091) |        0.792->  0.78 (1.515) |regexp-dna.js | <FAILED>
                         string-fasta.js |           56->    56 (0.000) |     2.18267->2.14533 (1.711) |string-tagcloud.js | <FAILED>string-unpack-code.js | <FAILED>string-validate-input.js | <FAILED>
                         Geometric mean: |       RSS reduction: 0.3079% |            Speed up: 1.3154% |
Tue Jan 19 07:45:02 EST 2016



Raspberry Pi 2, Run ./tools/run-perf-test.sh 5 times

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          112->   112 (0.000) |        3.01->2.96333 (1.550) |3d-morph.js | <FAILED>3d-raytrace.js | <FAILED>
                  access-binary-trees.js |           84->    84 (0.000) |     1.84333->1.81667 (1.446) |
                      access-fannkuch.js |           40->    40 (0.000) |         9.02->  9.02 (0.000) |
                         access-nbody.js |           48->    48 (0.000) |     4.28333->4.18333 (2.335) |access-nsieve.js | <FAILED>
             bitops-3bit-bits-in-byte.js |           32->    32 (0.000) |     2.24667->  2.25 (-0.148) |
                  bitops-bits-in-byte.js |           32->    32 (0.000) |        3.03->3.02667 (0.110) |
                   bitops-bitwise-and.js |           32->    32 (0.000) |     3.49667->3.44667 (1.430) |
                   bitops-nsieve-bits.js |          156->   156 (0.000) |     27.8333-> 28.02 (-0.671) |
                controlflow-recursive.js |          220->   220 (0.000) |     1.55667->1.53667 (1.285) |
                           crypto-aes.js |          128->   128 (0.000) |         5.23->  5.22 (0.191) |
                           crypto-md5.js |          184->   184 (0.000) |       24.36->24.3133 (0.192) |
                          crypto-sha1.js |          132->   132 (0.000) |        11.19-> 11.15 (0.357) |
                    date-format-tofte.js |           72->    72 (0.000) |     3.22333->3.17667 (1.448) |
                    date-format-xparb.js |           72->    72 (0.000) |      1.65667->  1.64 (1.006) |
                          math-cordic.js |           40->    40 (0.000) |     3.32667->3.28333 (1.303) |
                    math-partial-sums.js |           32->    32 (0.000) |         1.98->  1.94 (2.020) |
                   math-spectral-norm.js |           40->    40 (0.000) |      2.10333->  2.06 (2.060) |regexp-dna.js | <FAILED>
                         string-fasta.js |           48->    48 (0.000) |         5.36->  5.32 (0.746) |string-tagcloud.js | <FAILED>string-unpack-code.js | <FAILED>string-validate-input.js | <FAILED>
                         Geometric mean: |            RSS reduction: 0% |            Speed up: 0.9291% |
Tue 19 Jan 12:42:58 UTC 2016




