### PR TITLE
ecma_string_get_size performance improvement

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-string.cpp
+++ b/jerry-core/ecma/base/ecma-helpers-string.cpp
@@ -1385,70 +1385,67 @@ ecma_string_get_length (const ecma_string_t *string_p) /**< ecma-string */
 lit_utf8_size_t
 ecma_string_get_size (const ecma_string_t *string_p) /**< ecma-string */
 {
-  ecma_string_container_t container = (ecma_string_container_t) string_p->container;
-
-  if (container == ECMA_STRING_CONTAINER_LIT_TABLE)
+  switch ((ecma_string_container_t) string_p->container)
   {
-    lit_literal_t lit = lit_get_literal_by_cp (string_p->u.lit_cp);
-    JERRY_ASSERT (RCS_RECORD_IS_CHARSET (lit));
-
-    return lit_charset_literal_get_size (lit);
-  }
-  else if (container == ECMA_STRING_CONTAINER_MAGIC_STRING)
-  {
-    return lit_get_magic_string_size (string_p->u.magic_string_id);
-  }
-  else if (container == ECMA_STRING_CONTAINER_MAGIC_STRING_EX)
-  {
-    return lit_get_magic_string_ex_size (string_p->u.magic_string_ex_id);
-  }
-  else if (container == ECMA_STRING_CONTAINER_UINT32_IN_DESC)
-  {
-    const uint32_t uint32_number = string_p->u.uint32_number;
-    const int32_t max_uint32_len = 10;
-    const uint32_t nums_with_ascending_length[max_uint32_len] =
+    case ECMA_STRING_CONTAINER_LIT_TABLE:
     {
-      1u,
-      10u,
-      100u,
-      1000u,
-      10000u,
-      100000u,
-      1000000u,
-      10000000u,
-      100000000u,
-      1000000000u
-    };
+      lit_literal_t lit = lit_get_literal_by_cp (string_p->u.lit_cp);
+      JERRY_ASSERT (RCS_RECORD_IS_CHARSET (lit));
 
-    int32_t size = 1;
-
-    while (size < max_uint32_len
-           && uint32_number >= nums_with_ascending_length[size])
-    {
-      size++;
+      return lit_charset_literal_get_size (lit);
     }
+    case ECMA_STRING_CONTAINER_MAGIC_STRING:
+    {
+      return lit_get_magic_string_size (string_p->u.magic_string_id);
+    }
+    case ECMA_STRING_CONTAINER_MAGIC_STRING_EX:
+    {
+      return lit_get_magic_string_ex_size (string_p->u.magic_string_ex_id);
+    }
+    case ECMA_STRING_CONTAINER_UINT32_IN_DESC:
+    {
+      const uint32_t uint32_number = string_p->u.uint32_number;
+      const int32_t max_uint32_len = 10;
+      const uint32_t nums_with_ascending_length[max_uint32_len] =
+      {
+        1u,
+        10u,
+        100u,
+        1000u,
+        10000u,
+        100000u,
+        1000000u,
+        10000000u,
+        100000000u,
+        1000000000u
+      };
 
-    return (lit_utf8_size_t) size;
-  }
-  else if (container == ECMA_STRING_CONTAINER_HEAP_NUMBER)
-  {
-    const ecma_number_t *num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
+      int32_t size = 1;
+      while (size < max_uint32_len
+              && uint32_number >= nums_with_ascending_length[size])
+      {
+        size++;
+      }
+      return (lit_utf8_size_t) size;
+    }
+    case ECMA_STRING_CONTAINER_HEAP_NUMBER:
+    {
+      const ecma_number_t *num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
                                                             string_p->u.number_cp);
+      lit_utf8_byte_t buffer[ECMA_MAX_CHARS_IN_STRINGIFIED_NUMBER];
 
-    lit_utf8_byte_t buffer[ECMA_MAX_CHARS_IN_STRINGIFIED_NUMBER];
+      return ecma_number_to_utf8_string (*num_p,
+                buffer,
+                sizeof (buffer));
+    }
+    default:
+    {
+      JERRY_ASSERT ((ecma_string_container_t)string_p->container == ECMA_STRING_CONTAINER_HEAP_CHUNKS);
+      const ecma_collection_header_t *collection_header_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_header_t,
+            string_p->u.collection_cp);
 
-    return ecma_number_to_utf8_string (*num_p,
-                                       buffer,
-                                       sizeof (buffer));
-  }
-  else
-  {
-    JERRY_ASSERT (container == ECMA_STRING_CONTAINER_HEAP_CHUNKS);
-
-    const ecma_collection_header_t *collection_header_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_header_t,
-                                                                                     string_p->u.collection_cp);
-
-    return collection_header_p->unit_number;
+      return collection_header_p->unit_number;
+    }
   }
 } /* ecma_string_get_size */
 


### PR DESCRIPTION

JerryScript-DCO-1.0-Signed-off-by: Xin Hu Xin.A.Hu@intel.com

Run ./tools/run-perf-test.sh 10 times, 
OS, ubuntu 15.04, 32 bit
CPU, Intel(R) Celeron(R) CPU N2820 @ 2.13GHz, 2 core

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          116->   116 (0.000) |        1.096-> 1.068 (2.555) |3d-morph.js | <FAILED>3d-raytrace.js | <FAILED>
                  access-binary-trees.js |           88->    88 (0.000) |     0.657333-> 0.652 (0.811) |
                      access-fannkuch.js |           48->    44 (8.333) |      3.54667->   3.5 (1.316) |access-nbody.js | <FAILED>access-nsieve.js | <FAILED>
             bitops-3bit-bits-in-byte.js |           36->    36 (0.000) |   0.907333->0.898667 (0.955) |
                  bitops-bits-in-byte.js |          36->    32 (11.111) |     1.24333->1.18933 (4.343) |
                   bitops-bitwise-and.js |         36->    40 (-11.111) |     1.24533->1.24067 (0.374) |
                   bitops-nsieve-bits.js |          160->   156 (2.500) |      10.0247->10.002 (0.226) |
                controlflow-recursive.js |          244->   244 (0.000) |   0.579333->0.571333 (1.381) |
                           crypto-aes.js |          132->   132 (0.000) |        2.12->2.09933 (0.975) |
                           crypto-md5.js |          192->   192 (0.000) |     10.5947->10.602 (-0.069) |
                          crypto-sha1.js |          140->   140 (0.000) |     4.81133->4.80467 (0.138) |
                    date-format-tofte.js |           80->    80 (0.000) |       1.214->1.18867 (2.087) |
                    date-format-xparb.js |           76->    76 (0.000) |     0.634667-> 0.632 (0.420) |
                          math-cordic.js |           44->    40 (9.091) |        1.324-> 1.296 (2.115) |math-partial-sums.js | <FAILED>
                   math-spectral-norm.js |           44->    44 (0.000) |      0.792->0.787333 (0.589) |regexp-dna.js | <FAILED>
                         string-fasta.js |          52->    56 (-7.692) |     2.18467->2.14667 (1.739) |string-tagcloud.js | <FAILED>string-unpack-code.js | <FAILED>string-validate-input.js | <FAILED>
                         Geometric mean: |       RSS reduction: 0.9081% |            Speed up: 1.2534% |
Tue Jan 19 09:16:40 EST 2016

Raspberry Pi 2



                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          112->   112 (0.000) |     3.00667->2.93333 (2.439) |3d-morph.js | <FAILED>3d-raytrace.js | <FAILED>
                  access-binary-trees.js |           84->    84 (0.000) |      1.83667->  1.79 (2.541) |
                      access-fannkuch.js |           40->    40 (0.000) |      9.01333->  8.83 (2.034) |
                         access-nbody.js |           48->    48 (0.000) |         4.28->  4.13 (3.505) |access-nsieve.js | <FAILED>
             bitops-3bit-bits-in-byte.js |           32->    32 (0.000) |     2.25333->2.23333 (0.888) |
                  bitops-bits-in-byte.js |           32->    32 (0.000) |     3.02667->2.99333 (1.101) |
                   bitops-bitwise-and.js |           32->    32 (0.000) |     3.49333->3.47667 (0.477) |
                   bitops-nsieve-bits.js |          156->   156 (0.000) |        27.85-> 27.75 (0.359) |
                controlflow-recursive.js |          220->   220 (0.000) |     1.56667->1.51667 (3.192) |
                           crypto-aes.js |          128->   128 (0.000) |        5.23->5.14667 (1.593) |
                           crypto-md5.js |          184->   184 (0.000) |      24.31->24.3167 (-0.028) |
                          crypto-sha1.js |          132->   132 (0.000) |     11.1867->11.1767 (0.089) |
                    date-format-tofte.js |           72->    72 (0.000) |     3.22333->3.17333 (1.551) |
                    date-format-xparb.js |           72->    72 (0.000) |        1.65->1.61667 (2.020) |
                          math-cordic.js |           40->    40 (0.000) |     3.32667->3.27333 (1.603) |
                    math-partial-sums.js |           32->    32 (0.000) |     1.96333->1.89333 (3.565) |
                   math-spectral-norm.js |           40->    40 (0.000) |         2.09->  2.05 (1.914) |regexp-dna.js | <FAILED>
                         string-fasta.js |           48->    48 (0.000) |     5.36333->5.29667 (1.243) |string-tagcloud.js | <FAILED>string-unpack-code.js | <FAILEstring-validate-input.js | <FAILED>
                         Geometric mean: |            RSS reduction: 0% |            Speed up: 1.6773% |
Tue 19 Jan 14:15:18 UTC 2016

