### PR TITLE
Add ToBoolean api call

### DIFF
--- a/jerry-core/jerry-api.h
+++ b/jerry-core/jerry-api.h
@@ -384,6 +384,9 @@ size_t jerry_parse_and_save_snapshot (const jerry_api_char_t *, size_t, bool, ui
 extern EXTERN_C
 jerry_completion_code_t jerry_exec_snapshot (const void *, size_t, bool, jerry_api_value_t *);
 
+extern EXTERN_C
+bool jerry_api_value_to_boolean (const jerry_api_value_t *);
+
 /**
  * @}
  */

--- a/jerry-core/jerry.cpp
+++ b/jerry-core/jerry.cpp
@@ -2105,3 +2105,23 @@ jerry_exec_snapshot (const void *snapshot_p, /**< snapshot */
   return JERRY_COMPLETION_CODE_INVALID_SNAPSHOT_VERSION;
 #endif /* !JERRY_ENABLE_SNAPSHOT */
 } /* jerry_exec_snapshot */
+
+
+/**
+ * Call the ToBoolean ecma builtin operation on the api value.
+ *
+ * @return true or false depending on the ToBoolean operaion.
+ */
+bool jerry_api_value_to_boolean (const jerry_api_value_t *in_value_p) /** < input value */
+{
+  jerry_assert_api_available ();
+
+  ecma_value_t in_value;
+  jerry_api_convert_api_value_to_ecma_value (&in_value, in_value_p);
+
+  ecma_completion_value_t bool_completion_value = ecma_op_to_boolean (in_value);
+
+  ecma_free_value (in_value, true);
+
+  return ecma_is_completion_value_normal_true (bool_completion_value);
+} /* jerry_api_value_to_boolean */

--- a/main-darwin.cpp
+++ b/main-darwin.cpp
@@ -123,9 +123,7 @@ assert_handler (const jerry_api_object_t *function_obj_p __attr_unused___, /** <
                 const jerry_api_value_t args_p[], /** < function arguments */
                 const jerry_api_length_t args_cnt) /** < number of function arguments */
 {
-  if (args_cnt == 1
-      && args_p[0].type == JERRY_API_DATA_TYPE_BOOLEAN
-      && args_p[0].v_bool == true)
+  if (args_cnt == 1 &&  && jerry_api_value_to_boolean (&args_p[0]))
   {
     return true;
   }

--- a/main-linux.cpp
+++ b/main-linux.cpp
@@ -176,9 +176,7 @@ assert_handler (const jerry_api_object_t *function_obj_p __attr_unused___, /** <
                 const jerry_api_value_t args_p[], /** < function arguments */
                 const jerry_api_length_t args_cnt) /** < number of function arguments */
 {
-  if (args_cnt == 1
-      && args_p[0].type == JERRY_API_DATA_TYPE_BOOLEAN
-      && args_p[0].v_bool == true)
+  if (args_cnt == 1 && jerry_api_value_to_boolean (&args_p[0]))
   {
     return true;
   }


### PR DESCRIPTION
Implement a way to convert the api values to boolean values
according to the ECMA standard. Also use this method for the
assert implementation.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com