### PR TITLE
Cache magic string lengths

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-string.cpp
+++ b/jerry-core/ecma/base/ecma-helpers-string.cpp
@@ -1318,9 +1318,7 @@ ecma_string_get_length (const ecma_string_t *string_p) /**< ecma-string */
   }
   else if (container == ECMA_STRING_CONTAINER_MAGIC_STRING)
   {
-    TODO ("Cache magic string lengths")
-    return lit_utf8_string_length (lit_get_magic_string_utf8 (string_p->u.magic_string_id),
-                                   lit_get_magic_string_size (string_p->u.magic_string_id));
+    return lit_get_magic_string_length (string_p->u.magic_string_id);
   }
   else if (container == ECMA_STRING_CONTAINER_MAGIC_STRING_EX)
   {

--- a/jerry-core/lit/lit-magic-strings.cpp
+++ b/jerry-core/lit/lit-magic-strings.cpp
@@ -18,9 +18,14 @@
 #include "lit-strings.h"
 
 /**
- * Lengths of magic strings
+ * Sizes of magic strings
  */
 static lit_utf8_size_t lit_magic_string_sizes[LIT_MAGIC_STRING__COUNT];
+
+/**
+ * Lengths of magic strings
+ */
+static lit_utf8_size_t lit_magic_string_lengths[LIT_MAGIC_STRING__COUNT];
 
 /**
  * External magic strings data array, count and lengths
@@ -53,7 +58,8 @@ lit_magic_strings_init (void)
        id = (lit_magic_string_id_t) (id + 1))
   {
     lit_magic_string_sizes[id] = lit_zt_utf8_string_size (lit_get_magic_string_utf8 (id));
-
+    lit_magic_string_lengths[id] = lit_utf8_string_length (lit_get_magic_string_utf8 (id),
+                                                           lit_magic_string_sizes[id]);
 #ifndef JERRY_NDEBUG
     ecma_magic_string_max_length = JERRY_MAX (ecma_magic_string_max_length, lit_magic_string_sizes[id]);
 
@@ -115,6 +121,18 @@ lit_utf8_size_t
 lit_get_magic_string_size (lit_magic_string_id_t id) /**< magic string id */
 {
   return lit_magic_string_sizes[id];
+} /* lit_get_magic_string_size */
+
+
+/**
+ * Get length of specified magic string
+ *
+ * @return length in bytes
+ */
+lit_utf8_size_t
+lit_get_magic_string_length (lit_magic_string_id_t id) /**< magic string id */
+{
+  return lit_magic_string_lengths[id];
 } /* lit_get_magic_string_size */
 
 /**

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -48,6 +48,7 @@ extern uint32_t lit_get_magic_string_ex_count (void);
 
 extern const lit_utf8_byte_t *lit_get_magic_string_utf8 (lit_magic_string_id_t);
 extern lit_utf8_size_t lit_get_magic_string_size (lit_magic_string_id_t);
+extern lit_utf8_size_t lit_get_magic_string_length (lit_magic_string_id_t);
 
 extern const lit_utf8_byte_t *lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t);
 extern lit_utf8_size_t lit_get_magic_string_ex_size (lit_magic_string_ex_id_t);


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Xin Hu Xin.A.Hu@intel.com

Run ./tools/run-perf-test.sh 10 times, 
OS, ubuntu 15.04, 32 bit
CPU, Intel(R) Celeron(R) CPU N2820 @ 2.13GHz, 2 core

                              Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          120->   116 (3.333) |       1.096->1.07511 (1.906) |3d-morph.js | <FAILED>3d-raytrace.js | <FAILED>
                  access-binary-trees.js |           88->    88 (0.000) |   0.655556->0.655111 (0.068) |
                      access-fannkuch.js |           44->    40 (9.091) |     3.54489->3.51467 (0.853) |access-nbody.js | <FAILED>access-nsieve.js | <FAILED>
             bitops-3bit-bits-in-byte.js |         36->    40 (-11.111) |  0.906222->0.921333 (-1.667) |
                  bitops-bits-in-byte.js |           36->    36 (0.000) |     1.24089->1.21733 (1.899) |
                   bitops-bitwise-and.js |         36->    40 (-11.111) |     1.24311->1.21022 (2.646) |
                   bitops-nsieve-bits.js |          160->   156 (2.500) |      10.0227->10.008 (0.147) |
                controlflow-recursive.js |         244->   248 (-1.639) |       0.58->0.561333 (3.218) |
                           crypto-aes.js |         132->   136 (-3.030) |     2.11733->2.08622 (1.469) |
                           crypto-md5.js |          192->   192 (0.000) |     10.6076->10.6071 (0.005) |
                          crypto-sha1.js |          140->   136 (2.857) |    4.81244->4.81778 (-0.111) |
                    date-format-tofte.js |           80->    80 (0.000) |     1.21467->1.20711 (0.622) |
                    date-format-xparb.js |          76->    80 (-5.263) |  0.634222->0.637333 (-0.491) |
                          math-cordic.js |           44->    40 (9.091) |     1.32356->1.31867 (0.369) |math-partial-sums.js | <FAILED>
                   math-spectral-norm.js |          44->    48 (-9.091) |     0.792->0.803111 (-1.403) |regexp-dna.js | <FAILED>
                         string-fasta.js |           52->    48 (7.692) |     2.18711->2.17689 (0.467) |string-tagcloud.js | <FAILED>string-unpack-code.js | <FAILED>string-validate-input.js | <FAILED>
                         Geometric mean: |       RSS reduction: -0.227% |            Speed up: 0.6333% |
Wed Jan 20 11:54:13 EST 2016






Raspberry Pi 2, Run ./tools/run-perf-test.sh 6 times

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          112->   112 (0.000) |      3.00333->  2.97 (1.110) |3d-morph.js | <FAILED>3d-raytrace.js | <FAILED>
                  access-binary-trees.js |           84->    80 (4.762) |         1.84->  1.81 (1.630) |
                      access-fannkuch.js |          40->    36 (10.000) |         9.02->  8.82 (2.217) |
                         access-nbody.js |           48->    48 (0.000) |     4.28333->4.16667 (2.724) |access-nsieve.js | <FAILED>
             bitops-3bit-bits-in-byte.js |           32->    32 (0.000) |        2.25->2.24667 (0.148) |
                  bitops-bits-in-byte.js |           32->    32 (0.000) |     3.03667->3.00667 (0.988) |
                   bitops-bitwise-and.js |           32->    32 (0.000) |      3.48667->  3.41 (2.199) |
                   bitops-nsieve-bits.js |          156->   152 (2.564) |      27.8533-> 27.76 (0.335) |
                controlflow-recursive.js |          220->   220 (0.000) |     1.56667->1.56667 (0.000) |
                           crypto-aes.js |          128->   128 (0.000) |      5.23667->  5.17 (1.273) |
                           crypto-md5.js |          184->   184 (0.000) |      24.2733-> 24.26 (0.055) |
                          crypto-sha1.js |          132->   128 (3.030) |    11.1567->11.1667 (-0.090) |
                    date-format-tofte.js |           72->    72 (0.000) |        3.22->3.18667 (1.035) |
                    date-format-xparb.js |          72->    76 (-5.556) |     1.65667->1.64333 (0.805) |
                          math-cordic.js |          40->    36 (10.000) |      3.32667->  3.29 (1.102) |
                    math-partial-sums.js |           32->    32 (0.000) |        1.96->1.90667 (2.721) |
                   math-spectral-norm.js |           40->    40 (0.000) |         2.1->2.08333 (0.794) |regexp-dna.js | <FAILED>
                         string-fasta.js |           48->    44 (8.333) |         5.36->  5.31 (0.933) |string-tagcloud.js | <FAILED>string-unpack-code.js | <FAILED>string-validate-input.js | <FAILED>
                         Geometric mean: |       RSS reduction: 1.9213% |            Speed up: 1.1137% |
Wed 20 Jan 15:51:31 UTC 2016
