### PR TITLE
Fix build break on OSX: Invalid type comparision.

### DIFF
--- a/jerry-core/parser/js/bc/bytecode-data.cpp
+++ b/jerry-core/parser/js/bc/bytecode-data.cpp
@@ -785,7 +785,7 @@ bc_load_bytecode_data (const uint8_t *snapshot_data_p, /**< buffer with instruct
       next_to_handle_list_p->next_header_cp = MEM_CP_NULL;
       next_to_handle_list_p = bc_header_list_iter_p;
 
-      if (next_to_handle_list_p == MEM_CP_NULL)
+      if (next_to_handle_list_p == NULL)
       {
         break;
       }


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Sung-Jae Lee sjlee@mail.com