### PR TITLE
Replace uint32_t magic string lengths with uint8_t

### DIFF
--- a/jerry-core/lit/lit-globals.h
+++ b/jerry-core/lit/lit-globals.h
@@ -115,6 +115,11 @@ typedef uint8_t lit_utf8_byte_t;
 typedef uint32_t lit_utf8_size_t;
 
 /**
+ * Size of a magic string in bytes
+ */
+typedef uint8_t lit_magic_size_t;
+
+/**
  * Unicode code point
  */
 typedef uint32_t lit_code_point_t;

--- a/jerry-core/lit/lit-magic-strings.cpp
+++ b/jerry-core/lit/lit-magic-strings.cpp
@@ -20,7 +20,7 @@
 /**
  * Lengths of magic strings
  */
-static lit_utf8_size_t lit_magic_string_sizes[LIT_MAGIC_STRING__COUNT];
+static lit_magic_size_t lit_magic_string_sizes[LIT_MAGIC_STRING__COUNT];
 
 /**
  * External magic strings data array, count and lengths
@@ -52,7 +52,7 @@ lit_magic_strings_init (void)
        id < LIT_MAGIC_STRING__COUNT;
        id = (lit_magic_string_id_t) (id + 1))
   {
-    lit_magic_string_sizes[id] = lit_zt_utf8_string_size (lit_get_magic_string_utf8 (id));
+    lit_magic_string_sizes[id] = (lit_magic_size_t) lit_zt_utf8_string_size (lit_get_magic_string_utf8 (id));
 
 #ifndef JERRY_NDEBUG
     ecma_magic_string_max_length = JERRY_MAX (ecma_magic_string_max_length, lit_magic_string_sizes[id]);


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Xin Hu Xin.A.Hu@intel.com

LIT_MAGIC_STRING_LENGTH_LIMIT is 32, u8 is enough to store magic string lengths.


OS, ubuntu 15.04, 32 bit
CPU, Intel(R) Celeron(R) CPU N2820 @ 2.13GHz, 2 core

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          116->   112 (3.448) |      1.07133-> 1.066 (0.498) |3d-morph.js | <FAILED>3d-raytrace.js | <FAILED>
                  access-binary-trees.js |           84->    84 (0.000) |        0.652-> 0.648 (0.613) |
                      access-fannkuch.js |           44->    40 (9.091) |     3.45867->  3.46 (-0.038) |access-nbody.js | <FAILED>access-nsieve.js | <FAILED>
             bitops-3bit-bits-in-byte.js |           36->    36 (0.000) |     0.902->0.907333 (-0.591) |
                  bitops-bits-in-byte.js |         32->    36 (-12.500) |    1.17667->1.18533 (-0.736) |
                   bitops-bitwise-and.js |          40->    28 (30.000) |    1.22133->1.23267 (-0.928) |
                   bitops-nsieve-bits.js |          160->   160 (0.000) |     10.0273->9.98533 (0.419) |
                controlflow-recursive.js |          244->   240 (1.639) |    0.552667-> 0.568 (-2.774) |
                           crypto-aes.js |          132->   132 (0.000) |       2.066->  2.07 (-0.194) |
                           crypto-md5.js |          192->   188 (2.083) |    10.5913->10.5973 (-0.057) |
                          crypto-sha1.js |          140->   136 (2.857) |    4.80267->4.80333 (-0.014) |
                    date-format-tofte.js |           80->    80 (0.000) |     1.18933->1.17533 (1.177) |
                    date-format-xparb.js |           80->    76 (5.000) |     0.638667-> 0.636 (0.418) |
                          math-cordic.js |           44->    44 (0.000) |      1.284->1.28733 (-0.259) |math-partial-sums.js | <FAILED>
                   math-spectral-norm.js |           44->    44 (0.000) |   0.791333->0.783333 (1.011) |regexp-dna.js | <FAILED>
                         string-fasta.js |          56->    48 (14.286) |     2.15267->2.14867 (0.186) |string-tagcloud.js | <FAILED>string-unpack-code.js | <FAILED>string-validate-input.js | <FAILED>
                         Geometric mean: |       RSS reduction: 3.9289% |            Speed up: -0.075% |
Wed Jan 27 05:05:13 EST 2016


Raspberry Pi 2

                               Benchmark |         RSS<br>(+ is better) |        Perf<br>(+ is better) |
                               --------- |                          --- |                         ---- |
                              3d-cube.js |          112->   108 (3.571) |       3.005->2.98167 (0.776) |3d-morph.js | <FAILED>3d-raytrace.js | <FAILED>
                  access-binary-trees.js |           84->    80 (4.762) |     1.84333->1.81167 (1.718) |
                      access-fannkuch.js |          40->    36 (10.000) |         9.03-> 8.985 (0.498) |
                         access-nbody.js |           48->    48 (0.000) |     4.28167->4.20167 (1.868) |access-nsieve.js | <FAILED>
             bitops-3bit-bits-in-byte.js |         32->    36 (-12.500) |       2.255-> 2.285 (-1.330) |
                  bitops-bits-in-byte.js |         32->    36 (-12.500) |        3.03->3.02167 (0.275) |
                   bitops-bitwise-and.js |          32->    28 (12.500) |       3.495->3.47833 (0.477) |
                   bitops-nsieve-bits.js |          156->   156 (0.000) |    27.8333->27.9933 (-0.575) |
                controlflow-recursive.js |          220->   220 (0.000) |     1.56333->1.55833 (0.320) |
                           crypto-aes.js |          128->   128 (0.000) |     5.22167->5.20167 (0.383) |
                           crypto-md5.js |          184->   184 (0.000) |       24.335-> 24.31 (0.103) |
                          crypto-sha1.js |          132->   132 (0.000) |      11.1917->11.185 (0.060) |
                    date-format-tofte.js |           72->    72 (0.000) |       3.235->3.20833 (0.824) |
                    date-format-xparb.js |           72->    72 (0.000) |      1.64667-> 1.645 (0.101) |
                          math-cordic.js |           40->    40 (0.000) |     3.33167-> 3.355 (-0.700) |
                    math-partial-sums.js |         32->    36 (-12.500) |     1.96667->1.91667 (2.542) |
                   math-spectral-norm.js |           40->    40 (0.000) |        2.095-> 2.065 (1.432) |regexp-dna.js | <FAILED>
                         string-fasta.js |           48->    44 (8.333) |       5.37->5.39333 (-0.434) |string-tagcloud.js | <FAILED>string-unpack-code.js | <FAILED>string-validate-input.js | <FAILED>
                         Geometric mean: |       RSS reduction: 0.3201% |            Speed up: 0.4678% |
Wed 27 Jan 10:10:48 UTC 2016


