### PR TITLE
Fix Vera++ rule for switch statements.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.cpp
@@ -188,7 +188,6 @@ ecma_builtin_json_parse_string (ecma_json_token_t *token_p) /**< token argument 
           current_p += 5;
           write_p += lit_code_point_to_cesu8 (code_point, write_p);
           continue;
-          /* FALLTHRU */
         }
         default:
         {

--- a/jerry-core/parser/js/js-lexer.cpp
+++ b/jerry-core/parser/js/js-lexer.cpp
@@ -149,7 +149,6 @@ skip_spaces (parser_context_t *context_p) /**< context */
         context_p->source_p++;
         context_p->column++;
         continue;
-        /* FALLTHRU */
       }
 
       case LIT_CHAR_TAB:
@@ -157,7 +156,6 @@ skip_spaces (parser_context_t *context_p) /**< context */
         context_p->column = align_column_to_tab (context_p->column);
         context_p->source_p++;
         continue;
-        /* FALLTHRU */
       }
 
       case '/':

--- a/jerry-core/parser/js/js-parser-expr.cpp
+++ b/jerry-core/parser/js/js-parser-expr.cpp
@@ -713,7 +713,6 @@ parser_process_unary_expression (parser_context_t *context_p) /**< context */
         }
         lexer_next_token (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_LEFT_SQUARE:
@@ -745,7 +744,6 @@ parser_process_unary_expression (parser_context_t *context_p) /**< context */
           parser_emit_cbc (context_p, CBC_PUSH_PROP);
         }
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_LEFT_PAREN:
@@ -911,7 +909,6 @@ parser_process_unary_expression (parser_context_t *context_p) /**< context */
 
         parser_emit_cbc_call (context_p, opcode, call_arguments);
         continue;
-        /* FALLTHRU */
       }
 
       default:

--- a/jerry-core/parser/js/js-parser-statm.cpp
+++ b/jerry-core/parser/js/js-parser-statm.cpp
@@ -1674,7 +1674,6 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
         parser_stack_iterator_init (context_p, &context_p->last_statement);
         lexer_next_token (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_KEYW_VAR:
@@ -1687,21 +1686,18 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
       {
         parser_parse_function_statement (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_KEYW_IF:
       {
         parser_parse_if_statement_start (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_KEYW_SWITCH:
       {
         parser_parse_switch_statement_start (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_KEYW_DO:
@@ -1720,28 +1716,24 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
         parser_stack_iterator_init (context_p, &context_p->last_statement);
         lexer_next_token (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_KEYW_WHILE:
       {
         parser_parse_while_statement_start (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_KEYW_FOR:
       {
         parser_parse_for_statement_start (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_KEYW_WITH:
       {
         parser_parse_with_statement_start (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_KEYW_TRY:
@@ -1769,21 +1761,18 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
         parser_stack_iterator_init (context_p, &context_p->last_statement);
         lexer_next_token (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_KEYW_DEFAULT:
       {
         parser_parse_default_statement (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_KEYW_CASE:
       {
         parser_parse_case_statement (context_p);
         continue;
-        /* FALLTHRU */
       }
 
       case LEXER_KEYW_BREAK:
@@ -1967,7 +1956,6 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
 
           parser_set_breaks_to_current_position (context_p, label.break_list_p);
           continue;
-          /* FALLTHRU */
         }
 
         case PARSER_STATEMENT_IF:
@@ -1977,7 +1965,6 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
             break;
           }
           continue;
-          /* FALLTHRU */
         }
 
         case PARSER_STATEMENT_ELSE:
@@ -1990,7 +1977,6 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
 
           parser_set_branch_to_current_position (context_p, &else_statement.branch);
           continue;
-          /* FALLTHRU */
         }
 
         case PARSER_STATEMENT_DO_WHILE:
@@ -2001,21 +1987,18 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
             lexer_next_token (context_p);
           }
           continue;
-          /* FALLTHRU */
         }
 
         case PARSER_STATEMENT_WHILE:
         {
           parser_parse_while_statement_end (context_p);
           continue;
-          /* FALLTHRU */
         }
 
         case PARSER_STATEMENT_FOR:
         {
           parser_parse_for_statement_end (context_p);
           continue;
-          /* FALLTHRU */
         }
 
         case PARSER_STATEMENT_FOR_IN:
@@ -2043,14 +2026,12 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
           parser_set_breaks_to_current_position (context_p, loop.branch_list_p);
           parser_set_branch_to_current_position (context_p, &for_in_statement.branch);
           continue;
-          /* FALLTHRU */
         }
 
         case PARSER_STATEMENT_WITH:
         {
           parser_parse_with_statement_end (context_p);
           continue;
-          /* FALLTHRU */
         }
 
         default:

--- a/jerry-core/vm/vm.cpp
+++ b/jerry-core/vm/vm.cpp
@@ -794,14 +794,12 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           *(stack_top_p++) = left_value;
           continue;
-          /* FALLTHRU */
         }
         case VM_OC_PUSH_TWO:
         {
           *(stack_top_p++) = left_value;
           *(stack_top_p++) = right_value;
           continue;
-          /* FALLTHRU */
         }
         case VM_OC_PUSH_THREE:
         {
@@ -817,7 +815,6 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                         (void) 0);
           *(stack_top_p++) = left_value;
           continue;
-          /* FALLTHRU */
         }
         case VM_OC_PUSH_UNDEFINED:
         case VM_OC_VOID:
@@ -1233,7 +1230,6 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           is_direct_eval_form_call = true;
           JERRY_ASSERT (*byte_code_p >= CBC_CALL && *byte_code_p <= CBC_CALL2_PROP_BLOCK);
           continue;
-          /* FALLTHRU */
         }
         case VM_OC_CALL_N:
         case VM_OC_CALL_PROP_N:

--- a/tools/vera++/scripts/rules/jerry_switch_case.tcl
+++ b/tools/vera++/scripts/rules/jerry_switch_case.tcl
@@ -127,7 +127,9 @@ foreach fileName [getSourceFileNames] {
                                 set state "wait-for-break"
                                 continue
                             }
-                        } elseif {$next_token_type == "break" || $next_token_type == "return"} {
+                        } elseif {$next_token_type == "break"
+                                  || $next_token_type == "continue"
+                                  || $next_token_type == "return"} {
                             set state "wait-for-semicolon"
                             continue
                         } elseif {[string first "pp_" $next_token_type] == 0} {
@@ -143,7 +145,7 @@ foreach fileName [getSourceFileNames] {
                         continue
                     } elseif {$state == "wait-for-break"} {
                         if {$next_token_type == "case" || $next_token_type == "default"} {
-                            report $fileName [lindex $next_token 1] "Missing break or FALLTHRU comment before case (state $state)"
+                            report $fileName [lindex $next_token 1] "Missing break, continue or FALLTHRU comment before case (state $state)"
                         } elseif {$next_token_type == "leftbrace"} {
                             set state "inside-braces"
                             incr seen_braces 1
@@ -163,7 +165,10 @@ foreach fileName [getSourceFileNames] {
                             set state "fallthru"
                             set line_num [lindex $next_token 1]
                             continue
-                        } elseif {$next_token_type == "break" || $next_token_type == "return" || $next_token_type == "goto"} {
+                        } elseif {$next_token_type == "break"
+                                  || $next_token_type == "continue"
+                                  || $next_token_type == "return"
+                                  || $next_token_type == "goto"} {
                             set state "wait-for-semicolon"
                             continue
                         }
@@ -185,7 +190,9 @@ foreach fileName [getSourceFileNames] {
                             } elseif {$next_token_type == "rightbrace"} {
                                 lappend switch_ends [lindex $next_token 1]
                                 break
-                            } elseif {$next_token_type == "break" || $next_token_type == "return"} {
+                            } elseif {$next_token_type == "break"
+                                      || $next_token_type == "continue"
+                                      || $next_token_type == "return"} {
                                 set state "wait-for-semicolon"
                                 continue
                             } else {
@@ -208,7 +215,9 @@ foreach fileName [getSourceFileNames] {
                             } elseif {$next_token_type == "rightbrace"} {
                                 set state "after-rightbrace"
                                 continue
-                            } elseif {$next_token_type == "break" || $next_token_type == "return"} {
+                            } elseif {$next_token_type == "break"
+                                      || $next_token_type == "continue"
+                                      || $next_token_type == "return"} {
                                 set state "wait-for-semicolon"
                                 continue
                             } else {
@@ -261,7 +270,7 @@ foreach fileName [getSourceFileNames] {
                         } elseif {[string first "pp_" $next_token_type] == 0} {
                             set state "case-blocks-end-preprocessor"
                         } else {
-                            report $fileName [lindex $next_token 1] "Missing break or FALLTHRU comment before rightbrace (state $state)"
+                            report $fileName [lindex $next_token 1] "Missing break, continue or FALLTHRU comment before rightbrace (state $state)"
                         }
                     } else {
                         report $fileName [lindex $next_token 1] "Unknown state: $state"


### PR DESCRIPTION
Don't warn on continue statements without comment in a switch-case.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com