### PR TITLE
Remove jerry_ref_unused_variables template function

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
@@ -93,20 +93,4 @@ extern void \
 ecma_builtin_ ## lowercase_name ## _sort_property_names (void);
 #include "ecma-builtins.inc.h"
 
-
-#ifndef CONFIG_ECMA_COMPACT_PROFILE
-# define ECMA_BUILTIN_CP_UNIMPLEMENTED(...) \
-  JERRY_UNIMPLEMENTED_REF_UNUSED_VARS ("Built-in is not implemented.", __VA_ARGS__)
-#else /* !CONFIG_ECMA_COMPACT_PROFILE */
-# define ECMA_BUILTIN_CP_UNIMPLEMENTED(...) \
-{ \
-  if (false) \
-  { \
-    jerry_ref_unused_variables (0, __VA_ARGS__); \
-  } \
-  ecma_object_t *cp_error_p = ecma_builtin_get (ECMA_BUILTIN_ID_COMPACT_PROFILE_ERROR); \
-  return ecma_make_throw_obj_completion_value (cp_error_p); \
-}
-#endif /* CONFIG_ECMA_COMPACT_PROFILE */
-
 #endif /* !ECMA_BUILTINS_INTERNAL_H */

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -126,7 +126,7 @@ extern void __noreturn jerry_unimplemented (const char *, const char *, const ch
 /**
  * Mark for unreachable points and unimplemented cases
  */
-template<typename... values> extern void jerry_ref_unused_variables (const values & ... unused);
+extern void jerry_ref_unused_variables (void *, ...);
 
 #ifndef JERRY_NDEBUG
 #define JERRY_UNREACHABLE() \

--- a/jerry-core/parser/regexp/re-compiler.cpp
+++ b/jerry-core/parser/regexp/re-compiler.cpp
@@ -60,7 +60,7 @@ re_dump_bytecode (re_bytecode_ctx_t *bc_ctx);
 static uint8_t *
 re_realloc_regexp_bytecode_block (re_bytecode_ctx_t *bc_ctx_p) /**< RegExp bytecode context */
 {
-  JERRY_ASSERT (bc_ctx_p->block_end_p - bc_ctx_p->block_start_p >= 0);
+  JERRY_ASSERT (bc_ctx_p->block_end_p >= bc_ctx_p->block_start_p);
   size_t old_size = (size_t) (bc_ctx_p->block_end_p - bc_ctx_p->block_start_p);
 
   /* If one of the members of RegExp bytecode context is NULL, then all member should be NULL
@@ -69,7 +69,7 @@ re_realloc_regexp_bytecode_block (re_bytecode_ctx_t *bc_ctx_p) /**< RegExp bytec
                 || (bc_ctx_p->current_p && bc_ctx_p->block_end_p && bc_ctx_p->block_start_p));
 
   size_t new_block_size = old_size + REGEXP_BYTECODE_BLOCK_SIZE;
-  JERRY_ASSERT (bc_ctx_p->current_p - bc_ctx_p->block_start_p >= 0);
+  JERRY_ASSERT (bc_ctx_p->current_p >= bc_ctx_p->block_start_p);
   size_t current_ptr_offset = (size_t) (bc_ctx_p->current_p - bc_ctx_p->block_start_p);
 
   uint8_t *new_block_start_p = (uint8_t *) mem_heap_alloc_block (new_block_size,


### PR DESCRIPTION
Removed this function since it was unused and had a C++ feature.