### PR TITLE
Use packed attribute for enums to modify their type

### DIFF
--- a/jerry-core/mem/mem-heap.cpp
+++ b/jerry-core/mem/mem-heap.cpp
@@ -92,7 +92,7 @@ void mem_heap_valgrind_freya_mempool_request (void)
 /**
  * Length type of the block
  */
-typedef enum : uint8_t
+typedef enum __attr_packed___
 {
   MEM_BLOCK_LENGTH_TYPE_GENERAL     = 0, /**< general (may be multi-chunk) block
                                           *


### PR DESCRIPTION
This patch helps to avoid the type definitions for enums (that is a c++11 feature).