### PR TITLE
Add lit_storage prefix for functions in lit-literal-storage.

### DIFF
--- a/jerry-core/lit/lit-literal-storage.cpp
+++ b/jerry-core/lit/lit-literal-storage.cpp
@@ -29,9 +29,9 @@ rcs_record_set_t rcs_lit_storage;
  * @return pointer to the created record
  */
 rcs_record_t *
-lit_create_charset_literal (rcs_record_set_t *rec_set_p, /**< recordset */
-                            const lit_utf8_byte_t *str_p, /**< string to be placed into the record */
-                            const lit_utf8_size_t buf_size) /**< size in bytes of the buffer which holds the string */
+lit_storage_create_charset_literal (rcs_record_set_t *rec_set_p, /**< recordset */
+                                    const lit_utf8_byte_t *str_p, /**< string to be placed into the record */
+                                    const lit_utf8_size_t buf_size) /**< size of the string (in bytes) */
 {
   const size_t record_size = RCS_CHARSET_HEADER_SIZE + buf_size;
   const size_t aligned_record_size = JERRY_ALIGNUP (record_size, RCS_DYN_STORAGE_LENGTH_UNIT);
@@ -44,7 +44,7 @@ lit_create_charset_literal (rcs_record_set_t *rec_set_p, /**< recordset */
   rcs_record_set_hash (rec_p, lit_utf8_string_calc_hash (str_p, rcs_record_get_length (rec_p)));
 
   return rec_p;
-} /* lit_create_charset_literal */
+} /* lit_storage_create_charset_literal */
 
 /**
  * Create magic string record in the literal storage.
@@ -52,14 +52,14 @@ lit_create_charset_literal (rcs_record_set_t *rec_set_p, /**< recordset */
  * @return  pointer to the created record
  */
 rcs_record_t *
-lit_create_magic_literal (rcs_record_set_t *rec_set_p, /**< recordset */
-                          lit_magic_string_id_t id) /**< id of magic string */
+lit_storage_create_magic_literal (rcs_record_set_t *rec_set_p, /**< recordset */
+                                  lit_magic_string_id_t id) /**< id of magic string */
 {
   rcs_record_t *rec_p = rcs_alloc_record (rec_set_p, RCS_RECORD_TYPE_MAGIC_STR, RCS_MAGIC_STR_HEADER_SIZE);
   rcs_record_set_magic_str_id (rec_p, id);
 
   return rec_p;
-} /* lit_create_magic_literal */
+} /* lit_storage_create_magic_literal */
 
 /**
  * Create external magic string record in the literal storage.
@@ -67,14 +67,14 @@ lit_create_magic_literal (rcs_record_set_t *rec_set_p, /**< recordset */
  * @return  pointer to the created record
  */
 rcs_record_t *
-lit_create_magic_literal_ex (rcs_record_set_t *rec_set_p, /**< recordset */
-                             lit_magic_string_ex_id_t id) /**< id of magic string */
+lit_storage_create_magic_literal_ex (rcs_record_set_t *rec_set_p, /**< recordset */
+                                     lit_magic_string_ex_id_t id) /**< id of magic string */
 {
   rcs_record_t *rec_p = rcs_alloc_record (rec_set_p, RCS_RECORD_TYPE_MAGIC_STR_EX, RCS_MAGIC_STR_HEADER_SIZE);
   rcs_record_set_magic_str_ex_id (rec_p, id);
 
   return rec_p;
-} /* lit_create_magic_record_ex */
+} /* lit_storage_create_magic_literal_ex */
 
 /**
  * Create number record in the literal storage.
@@ -82,8 +82,8 @@ lit_create_magic_literal_ex (rcs_record_set_t *rec_set_p, /**< recordset */
  * @return  pointer to the created record
  */
 rcs_record_t *
-lit_create_number_literal (rcs_record_set_t *rec_set_p, /** recordset */
-                           ecma_number_t num) /**< numeric value */
+lit_storage_create_number_literal (rcs_record_set_t *rec_set_p, /** recordset */
+                                   ecma_number_t num) /**< numeric value */
 {
   const size_t record_size = RCS_NUMBER_HEADER_SIZE + sizeof (ecma_number_t);
   rcs_record_t *rec_p = rcs_alloc_record (rec_set_p, RCS_RECORD_TYPE_NUMBER, record_size);
@@ -93,7 +93,7 @@ lit_create_number_literal (rcs_record_set_t *rec_set_p, /** recordset */
   rcs_iterator_write (&it_ctx, &num, sizeof (ecma_number_t));
 
   return rec_p;
-} /* lit_create_number_literal */
+} /* lit_storage_create_number_literal */
 
 /**
  * Count literal records in the storage
@@ -101,7 +101,7 @@ lit_create_number_literal (rcs_record_set_t *rec_set_p, /** recordset */
  * @return number of literals
  */
 uint32_t
-lit_count_literals (rcs_record_set_t *rec_set_p) /**< recordset */
+lit_storage_count_literals (rcs_record_set_t *rec_set_p) /**< recordset */
 {
   uint32_t num = 0;
   rcs_record_t *rec_p;
@@ -117,13 +117,13 @@ lit_count_literals (rcs_record_set_t *rec_set_p) /**< recordset */
   }
 
   return num;
-} /* lit_count_literals */
+} /* lit_storage_count_literals */
 
 /**
  * Dump the contents of the literal storage.
  */
 void
-lit_dump_literals (rcs_record_set_t *rec_set_p) /**< recordset */
+lit_storage_dump_literals (rcs_record_set_t *rec_set_p) /**< recordset */
 {
   rcs_record_t *rec_p;
 
@@ -206,4 +206,4 @@ lit_dump_literals (rcs_record_set_t *rec_set_p) /**< recordset */
 
     printf ("\n");
   }
-} /* lit_dump_literals */
+} /* lit_storage_dump_literals */

--- a/jerry-core/lit/lit-literal-storage.h
+++ b/jerry-core/lit/lit-literal-storage.h
@@ -21,12 +21,12 @@
 
 extern rcs_record_set_t rcs_lit_storage;
 
-extern rcs_record_t *lit_create_charset_literal (rcs_record_set_t *, const lit_utf8_byte_t *, lit_utf8_size_t);
-extern rcs_record_t *lit_create_magic_literal (rcs_record_set_t *, lit_magic_string_id_t);
-extern rcs_record_t *lit_create_magic_literal_ex (rcs_record_set_t *, lit_magic_string_ex_id_t);
-extern rcs_record_t *lit_create_number_literal (rcs_record_set_t *, ecma_number_t);
+extern rcs_record_t *lit_storage_create_charset_literal (rcs_record_set_t *, const lit_utf8_byte_t *, lit_utf8_size_t);
+extern rcs_record_t *lit_storage_create_magic_literal (rcs_record_set_t *, lit_magic_string_id_t);
+extern rcs_record_t *lit_storage_create_magic_literal_ex (rcs_record_set_t *, lit_magic_string_ex_id_t);
+extern rcs_record_t *lit_storage_create_number_literal (rcs_record_set_t *, ecma_number_t);
 
-extern uint32_t lit_count_literals (rcs_record_set_t *);
-extern void lit_dump_literals (rcs_record_set_t *);
+extern uint32_t lit_storage_count_literals (rcs_record_set_t *);
+extern void lit_storage_dump_literals (rcs_record_set_t *);
 
 #endif /* !LIT_LITERAL_STORAGE_H */

--- a/jerry-core/lit/lit-literal.cpp
+++ b/jerry-core/lit/lit-literal.cpp
@@ -25,7 +25,7 @@
  * Initialize literal storage
  */
 void
-lit_init ()
+lit_init (void)
 {
   JERRY_ASSERT (rcs_get_node_data_space_size () % RCS_DYN_STORAGE_LENGTH_UNIT == 0);
 
@@ -39,7 +39,7 @@ lit_init ()
  * Finalize literal storage
  */
 void
-lit_finalize ()
+lit_finalize (void)
 {
   rcs_lit_storage.cleanup ();
   rcs_lit_storage.free ();
@@ -49,9 +49,9 @@ lit_finalize ()
  * Dump records from the literal storage
  */
 void
-lit_dump_literals ()
+lit_dump_literals (void)
 {
-  lit_dump_literals (&rcs_lit_storage);
+  lit_storage_dump_literals (&rcs_lit_storage);
 } /* lit_dump_literals */
 
 /**
@@ -79,7 +79,7 @@ lit_create_literal_from_utf8_string (const lit_utf8_byte_t *str_p, /**< string t
 
     if (!strncmp ((const char *) str_p, (const char *) lit_get_magic_string_utf8 (m_str_id), str_size))
     {
-      return lit_create_magic_literal (&rcs_lit_storage, m_str_id);
+      return lit_storage_create_magic_literal (&rcs_lit_storage, m_str_id);
     }
   }
 
@@ -95,11 +95,11 @@ lit_create_literal_from_utf8_string (const lit_utf8_byte_t *str_p, /**< string t
 
     if (!strncmp ((const char *) str_p, (const char *) lit_get_magic_string_ex_utf8 (m_str_ex_id), str_size))
     {
-      return lit_create_magic_literal_ex (&rcs_lit_storage, m_str_ex_id);
+      return lit_storage_create_magic_literal_ex (&rcs_lit_storage, m_str_ex_id);
     }
   }
 
-  return lit_create_charset_literal (&rcs_lit_storage, str_p, str_size);
+  return lit_storage_create_charset_literal (&rcs_lit_storage, str_p, str_size);
 } /* lit_create_literal_from_utf8_string */
 
 /**
@@ -205,7 +205,7 @@ lit_find_or_create_literal_from_utf8_string (const lit_utf8_byte_t *str_p, /**< 
 lit_literal_t
 lit_create_literal_from_num (ecma_number_t num) /**< number to initialize a new number literal */
 {
-  return lit_create_number_literal (&rcs_lit_storage, num);
+  return lit_storage_create_number_literal (&rcs_lit_storage, num);
 } /* lit_create_literal_from_num */
 
 /**

--- a/jerry-core/lit/lit-literal.h
+++ b/jerry-core/lit/lit-literal.h
@@ -18,9 +18,9 @@
 
 #include "ecma-globals.h"
 
-extern void lit_init ();
-extern void lit_finalize ();
-extern void lit_dump_literals ();
+extern void lit_init (void);
+extern void lit_finalize (void);
+extern void lit_dump_literals (void);
 
 extern lit_literal_t lit_create_literal_from_utf8_string (const lit_utf8_byte_t *, lit_utf8_size_t);
 extern lit_literal_t lit_find_literal_by_utf8_string (const lit_utf8_byte_t *, lit_utf8_size_t);

--- a/jerry-core/lit/lit-snapshot.cpp
+++ b/jerry-core/lit/lit-snapshot.cpp
@@ -143,7 +143,7 @@ lit_dump_literals_for_snapshot (uint8_t *buffer_p, /**< output snapshot buffer *
                                 uint32_t *out_map_num_p, /**< out: number of literals */
                                 uint32_t *out_lit_table_size_p) /**< out: number of bytes, dumped to snapshot buffer */
 {
-  uint32_t literals_num = lit_count_literals (&rcs_lit_storage);
+  uint32_t literals_num = lit_storage_count_literals (&rcs_lit_storage);
   uint32_t lit_table_size = 0;
 
   *out_map_p = NULL;


### PR DESCRIPTION
There are two extern 'lit_dump_literals' symbols in the project:
```
./jerry-core/lit/lit-literal.h                 extern void lit_dump_literals ();
./jerry-core/lit/lit-literal-storage.h         extern void lit_dump_literals (rcs_record_set_t *);
```
Added 'lit_storage' prefix to the functions in lit-literal-storage to eliminate the same names.