### PR TITLE
Fix memory leak in RegExp builtin.

### DIFF
--- a/tests/jerry/regression-test-issue-787.js
+++ b/tests/jerry/regression-test-issue-787.js
@@ -1,0 +1,27 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright 2016 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Array.prototype.push(Math.sin);
+Object.freeze(Array.prototype);
+
+try
+{
+  String.prototype.match(String.prototype);
+  assert (false);
+}
+catch (e)
+{
+  assert (e instanceof TypeError);
+}


### PR DESCRIPTION
Related issue: #787

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com