### PR TITLE
Add missing parentheses for bit operations where type cast is used.

### DIFF
--- a/jerry-core/parser/js/js-lexer.cpp
+++ b/jerry-core/parser/js/js-lexer.cpp
@@ -1767,7 +1767,7 @@ lexer_construct_regexp_object (parser_context_t *context_p, /**< context */
       parser_raise_error (context_p, PARSER_ERR_DUPLICATED_REGEXP_FLAG);
     }
 
-    current_flags |= (uint16_t) flag;
+    current_flags = (uint16_t) (current_flags | flag);
     source_p++;
     column++;
   }

--- a/jerry-core/parser/js/js-parser.cpp
+++ b/jerry-core/parser/js/js-parser.cpp
@@ -408,7 +408,7 @@ parser_encode_literal (uint8_t *dst_p, /**< destination buffer */
     }
     else
     {
-      *dst_p++ = (uint8_t) (literal_index >> 8) | CBC_HIGHEST_BIT_MASK;
+      *dst_p++ = (uint8_t) ((literal_index >> 8) | CBC_HIGHEST_BIT_MASK);
       *dst_p++ = (uint8_t) (literal_index & CBC_MAXIMUM_BYTE_VALUE);
     }
   }
@@ -1358,7 +1358,7 @@ parser_post_processing (parser_context_t *context_p) /**< context */
         else
         {
           JERRY_ASSERT (literal_index <= CBC_MAXIMUM_FULL_VALUE);
-          *first_byte = (uint8_t) (literal_p->prop.index >> 8) | CBC_HIGHEST_BIT_MASK;
+          *first_byte = (uint8_t) ((literal_p->prop.index >> 8) | CBC_HIGHEST_BIT_MASK);
           page_p->bytes[offset] = (uint8_t) (literal_p->prop.index & 0xff);
           length++;
         }


### PR DESCRIPTION
Fix for #853. These modifications are required by gcc 4.9 or above.