### PR TITLE
Remove references to non-existent parser/js/bc and parser/js/collections directories

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -113,8 +113,6 @@ project (JerryCore CXX C ASM)
      ${CMAKE_SOURCE_DIR}/jerry-core/ecma/base
      ${CMAKE_SOURCE_DIR}/jerry-core/ecma/operations
      ${CMAKE_SOURCE_DIR}/jerry-core/parser/js
-     ${CMAKE_SOURCE_DIR}/jerry-core/parser/js/bc
-     ${CMAKE_SOURCE_DIR}/jerry-core/parser/js/collections
      ${CMAKE_SOURCE_DIR}/jerry-core/parser/regexp
      ${CMAKE_SOURCE_DIR}/jerry-core/jrt)
 
@@ -133,8 +131,6 @@ project (JerryCore CXX C ASM)
   file(GLOB SOURCE_CORE_ECMA_BASE             ecma/base/*.cpp)
   file(GLOB SOURCE_CORE_ECMA_OPERATIONS       ecma/operations/*.cpp)
   file(GLOB SOURCE_CORE_PARSER_JS             parser/js/*.cpp)
-  file(GLOB SOURCE_CORE_PARSER_JS_BC          parser/js/bc/*.cpp)
-  file(GLOB SOURCE_CORE_PARSER_JS_COLLECTIONS parser/js/collections/*.cpp)
   file(GLOB SOURCE_CORE_PARSER_REGEXP         parser/regexp/*.cpp)
   file(GLOB SOURCE_CORE_JRT                   jrt/*.cpp)
 
@@ -148,8 +144,6 @@ project (JerryCore CXX C ASM)
       ${SOURCE_CORE_ECMA_BASE}
       ${SOURCE_CORE_ECMA_OPERATIONS}
       ${SOURCE_CORE_PARSER_JS}
-      ${SOURCE_CORE_PARSER_JS_BC}
-      ${SOURCE_CORE_PARSER_JS_COLLECTIONS}
       ${SOURCE_CORE_PARSER_REGEXP}
       ${SOURCE_CORE_JRT})
 


### PR DESCRIPTION
With the merge of the CBC parser, these directories got removed.
The update of the jerry-core/CMakeLists.txt must have been
forgotten, probably because the kept references caused no errors.
Cleaning up now.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu