### PR TITLE
Fix system call related date builtin functions

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -17,6 +17,7 @@
 #include "ecma-alloc.h"
 #include "ecma-builtin-helpers.h"
 #include "ecma-conversion.h"
+#include "ecma-exceptions.h"
 #include "ecma-gc.h"
 #include "ecma-globals.h"
 #include "ecma-helpers.h"
@@ -448,13 +449,17 @@ ecma_builtin_date_utc (ecma_value_t this_arg __attr_unused___, /**< this argumen
 static ecma_value_t
 ecma_builtin_date_now (ecma_value_t this_arg __attr_unused___) /**< this argument */
 {
-  /*
-   * FIXME:
-   *        Get the real system time. ex: gettimeofday() on Linux
-   *        Introduce system macros at first.
-   */
+  struct _timeval tv;
   ecma_number_t *now_num_p = ecma_alloc_number ();
   *now_num_p = ECMA_NUMBER_ZERO;
+
+  if (gettimeofday (&tv, NULL) != 0)
+  {
+    return ecma_raise_type_error ("gettimeofday failed");
+  }
+
+  *now_num_p = ((ecma_number_t) tv.tv_sec) * 1000.0 + ((ecma_number_t) (tv.tv_usec / 1000));
+
   return ecma_make_number_value (now_num_p);
 } /* ecma_builtin_date_now */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -55,21 +55,30 @@ ecma_builtin_helper_def_prop (ecma_object_t *, ecma_string_t *, ecma_value_t,
  * See also:
  *          ECMA-262 v5, 15.9.1.1, 15.9.1.10
  */
-/* Hours in a day. */
+
+/** Hours in a day. */
 #define ECMA_DATE_HOURS_PER_DAY         ((ecma_number_t) 24)
-/* Minutes in an hour. */
+
+/** Minutes in an hour. */
 #define ECMA_DATE_MINUTES_PER_HOUR      ((ecma_number_t) 60)
-/* Seconds in a minute. */
+
+/** Seconds in a minute. */
 #define ECMA_DATE_SECONDS_PER_MINUTE    ((ecma_number_t) 60)
-/* Milliseconds in a second. */
+
+/** Milliseconds in a second. */
 #define ECMA_DATE_MS_PER_SECOND         ((ecma_number_t) 1000)
-/* ECMA_DATE_MS_PER_MINUTE == 60000 */
+
+/** ECMA_DATE_MS_PER_MINUTE == 60000 */
 #define ECMA_DATE_MS_PER_MINUTE         (ECMA_DATE_MS_PER_SECOND * ECMA_DATE_SECONDS_PER_MINUTE)
-/* ECMA_DATE_MS_PER_HOUR == 3600000 */
+
+/** ECMA_DATE_MS_PER_HOUR == 3600000 */
 #define ECMA_DATE_MS_PER_HOUR           (ECMA_DATE_MS_PER_MINUTE * ECMA_DATE_MINUTES_PER_HOUR)
-/* ECMA_DATE_MS_PER_DAY == 86400000 */
+
+/** ECMA_DATE_MS_PER_DAY == 86400000 */
 #define ECMA_DATE_MS_PER_DAY            (ECMA_DATE_MS_PER_HOUR * ECMA_DATE_HOURS_PER_DAY)
-/* This gives a range of 8,640,000,000,000,000 milliseconds
+
+/**
+ * This gives a range of 8,640,000,000,000,000 milliseconds
  * to either side of 01 January, 1970 UTC.
  */
 #define ECMA_DATE_MAX_VALUE             8.64e15

--- a/jerry-libc/include/time.h
+++ b/jerry-libc/include/time.h
@@ -1,0 +1,46 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JERRY_LIBC_TIME_H
+#define JERRY_LIBC_TIME_H
+
+#ifdef __cplusplus
+# define EXTERN_C "C"
+#else /* !__cplusplus */
+# define EXTERN_C
+#endif /* !__cplusplus */
+
+/**
+ * Time value structure
+ */
+struct _timeval
+{
+  unsigned long tv_sec;   /**< seconds */
+  unsigned long tv_usec;  /**< microseconds */
+};
+
+/**
+ * Timezone structure
+ */
+struct timezone
+{
+  int tz_minuteswest;     /**< minutes west of Greenwich */
+  int tz_dsttime;         /**< type of DST correction */
+};
+
+extern EXTERN_C int gettimeofday (void *tp, void *tzp);
+
+#endif /* !JERRY_LIBC_TIME_H */

--- a/jerry-libc/target/darwin/jerry-libc-target.c
+++ b/jerry-libc/target/darwin/jerry-libc-target.c
@@ -1,4 +1,5 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +29,7 @@
 #include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <time.h>
 
 #include "jerry-libc-defs.h"
 
@@ -384,3 +386,14 @@ fwrite (const void *ptr, /**< data to write */
   return bytes_written / size;
 } /* fwrite */
 
+/**
+ * This function can get the time as well as a timezone.
+ *
+ * @return 0 if success, -1 otherwise
+ */
+int
+gettimeofday (void *tp,  /**< struct timeval */
+              void *tzp) /**< struct timezone */
+{
+  return (int) syscall_2 (__NR_gettimeofday, (long int) tp, (long int) tzp);
+} /* gettimeofday */

--- a/jerry-libc/target/linux/jerry-libc-target.c
+++ b/jerry-libc/target/linux/jerry-libc-target.c
@@ -1,4 +1,5 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +29,7 @@
 #include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <time.h>
 
 #include "jerry-libc-defs.h"
 
@@ -383,6 +385,18 @@ fwrite (const void *ptr, /**< data to write */
 
   return bytes_written / size;
 } /* fwrite */
+
+/**
+ * This function can get the time as well as a timezone.
+ *
+ * @return 0 if success, -1 otherwise
+ */
+int
+gettimeofday (void *tp,  /**< struct timeval */
+              void *tzp) /**< struct timezone */
+{
+  return (int) syscall_2 (__NR_gettimeofday, (long int) tp, (long int) tzp);
+} /* gettimeofday */
 
 // FIXME
 #if 0

--- a/jerry-libc/target/mcu-stubs/jerry-libc-target.c
+++ b/jerry-libc/target/mcu-stubs/jerry-libc-target.c
@@ -1,4 +1,5 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "jerry-libc-defs.h"
 
@@ -61,3 +63,14 @@ fwrite (const void *ptr __attr_unused___, /**< data to write */
   return size * nmemb;
 } /* fwrite */
 
+/**
+ * This function can get the time as well as a timezone.
+ *
+ * @return 0 if success, -1 otherwise
+ */
+int
+gettimeofday (void *tp __attr_unused___,  /**< struct timeval */
+              void *tzp __attr_unused___) /**< struct timezone */
+{
+  return 0;
+} /* gettimeofday */

--- a/tests/jerry/date-annexb.js
+++ b/tests/jerry/date-annexb.js
@@ -1,5 +1,5 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright 2015-2016 Samsung Electronics Co., Ltd.
+// Copyright 2015-2016 University of Szeged.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,8 +40,7 @@ assert (d.getFullYear() === 2004 && d.getMonth() === 1 && d.getDate() === 29);
 d.setYear(2015);
 assert (d.getFullYear() === 2015 && d.getMonth() === 2 && d.getDate() === 1);
 
-d = new Date(2015, 8, 17);
-assert (d.toGMTString() === "Thu, 17 Sep 2015 00:00:00 GMT");
+assert (/Thu, 17 Sep 2015 \d{2}:\d{2}:\d{2} GMT/.test (new Date("2015-09-17").toGMTString()));
 
 d = new Date(NaN);
 assert (d.toGMTString() === "Invalid Date");

--- a/tests/jerry/date-construct.js
+++ b/tests/jerry/date-construct.js
@@ -1,5 +1,5 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright 2015-2016 Samsung Electronics Co., Ltd.
+// Copyright 2015-2016 University of Szeged.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ d = new Date(1420070400000);
 assert (d.valueOf() == 1420070400000);
 
 d = new Date(2015,0,1,0,0,0,0);
-assert (d.valueOf() == 1420070400000);
+assert (d.valueOf() - (d.getTimezoneOffset() * 60000) == 1420070400000);
 
 d = new Date(8.64e+15);
 assert (d.valueOf() == 8.64e+15);
@@ -80,6 +80,3 @@ catch (e)
 assert (typeof Date (2015) == "string");
 assert (typeof Date() != typeof (new Date ()));
 assert (Date (Number.NaN) == Date ());
-
-// Fixme: remove this case when Date() gives the current time.
-assert (Date (2015,1,2) == "Thu Jan 01 1970 00:00:00 GMT+0000");

--- a/tests/jerry/date-tostring.js
+++ b/tests/jerry/date-tostring.js
@@ -1,5 +1,5 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright 2015-2016 Samsung Electronics Co., Ltd.
+// Copyright 2015-2016 University of Szeged.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ assert (new Date (2015, 7, 1, 0, Infinity, 0) == "Invalid Date");
 assert (new Date (NaN, 1, 1, 0, 0, 0) == "Invalid Date");
 assert (new Date (2015, NaN, 1, 0, 0, 0) == "Invalid Date");
 assert (new Date (2015, 7, 1, 0, NaN, 0) == "Invalid Date");
-assert (new Date ("2015-02-13") == "Fri Feb 13 2015 00:00:00 GMT+0000");
-assert (new Date ("2015-07-08T11:29:05.023") == "Wed Jul 08 2015 11:29:05 GMT+0000");
+assert (/Fri Feb 13 2015 \d{2}:\d{2}:\d{2} GMT\+\d{2}:\d{2}/.test (new Date ("2015-02-13")));
+assert (/Wed Jul 08 2015 \d{2}:\d{2}:\d{2} GMT\+\d{2}:\d{2}/.test (new Date ("2015-07-08T11:29:05.023")));
 
 try
 {
@@ -35,12 +35,12 @@ catch (e)
 }
 
 var date = new Date(0);
-assert (date.toString() === "Thu Jan 01 1970 00:00:00 GMT+0000");
+assert (/Thu Jan 01 1970 \d{2}:\d{2}:\d{2} GMT\+\d{2}:\d{2}/.test (date.toString()));
 assert (date.toUTCString() === "Thu, 01 Jan 1970 00:00:00 GMT");
 assert (date.toISOString() === "1970-01-01T00:00:00.000Z");
 
 date = new Date("2015-08-12T09:40:20.000Z")
-assert (date.toString() === "Wed Aug 12 2015 09:40:20 GMT+0000");
+assert (/Wed Aug 12 2015 \d{2}:\d{2}:\d{2} GMT\+\d{2}:\d{2}/.test (date.toString()));
 assert (date.toUTCString() === "Wed, 12 Aug 2015 09:40:20 GMT");
 assert (date.toISOString() === "2015-08-12T09:40:20.000Z");
 
@@ -146,9 +146,5 @@ assert (typeof Date() != typeof (new Date ()));
 assert (Date () == (new Date ()).toString ());
 assert (Date (2015, 1, 1) == (new Date ()).toString ());
 assert (Date (Number.NaN) == Date ());
-
-// Fixme: remove these cases when TZA and DST are supported.
-assert (new Date ("2015-07-08T11:29:05.023-02:00").toString () == "Wed Jul 08 2015 13:29:05 GMT+0000");
-assert (new Date ("2015-07-08T11:29:05.023-02:00").toLocaleString () == "Wed Jul 08 2015 13:29:05 GMT+0000");
 
 assert (new Date ("2015-07-08T11:29:05.023Z").toISOString() == "2015-07-08T11:29:05.023Z");

--- a/tests/unit/test-common.h
+++ b/tests/unit/test-common.h
@@ -24,8 +24,6 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
-#include <sys/time.h>
-
 
 /**
  * Verify that unit tests are built with all debug checks enabled


### PR DESCRIPTION
Related issues: #213, #691
 * Fixed 'ecma_date_local_tza' and 'ecma_date_daylight_saving_ta' date builtin helper functions
 * Added syscall of gettimeofday function to get the current system time and timezone.
 * Fixed related regression test files.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com