### PR TITLE
Add support for travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: c
+
+os: linux
+dist: trusty
+sudo: required
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tools/apt-get-install-deps.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tools/brew-install-deps.sh; fi
+
+install: make prerequisites
+
+script: "make -j VERBOSE=1 NINJA=1 $TARGET"
+
+env:
+  - TARGET="check-signed-off check-vera check-cpp"
+  - TARGET="build.linux test-js-precommit"
+  - TARGET=build.mcu_stm32f3
+  - TARGET=build.mcu_stm32f4
+  - TARGET=test-unit
+
+matrix:
+  include:
+    - os: osx
+      env: TARGET="build.darwin test-js-precommit"
+    - os: osx
+      env: TARGET=test-unit
+  allow_failures:
+    - os: osx

--- a/tools/apt-get-install-deps.sh
+++ b/tools/apt-get-install-deps.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2016 Samsung Electronics Co., Ltd.
+# Copyright 2016 University of Szeged
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sudo apt-get update -q
+sudo apt-get install -q -y \
+    make cmake ninja-build \
+    gcc gcc-arm-none-eabi \
+    cppcheck vera++

--- a/tools/brew-install-deps.sh
+++ b/tools/brew-install-deps.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2016 Samsung Electronics Co., Ltd.
+# Copyright 2016 University of Szeged
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+brew update
+
+PKGS="
+    cmake ninja
+    cppcheck vera++
+    "
+
+for pkg in $PKGS
+do
+    if ! ( brew list -1 | grep -q "^${pkg}\$" )
+    then
+        brew install $pkg
+    fi
+done


### PR DESCRIPTION
Fully fledged checks, builds, and tests on Linux, non-voting native builds and unit tests on OS X.