### PR TITLE
Remove completion value.

### DIFF
--- a/jerry-core/config.h
+++ b/jerry-core/config.h
@@ -160,7 +160,7 @@
 #endif /* CONFIG_ECMA_COMPACT_PROFILE */
 
 /**
- * Number of ecma-values inlined into VM stack frame
+ * Number of ecma values inlined into VM stack frame
  */
 #define CONFIG_VM_STACK_FRAME_INLINED_VALUES_NUMBER (16)
 

--- a/jerry-core/ecma/base/ecma-alloc.c
+++ b/jerry-core/ecma/base/ecma-alloc.c
@@ -29,8 +29,6 @@ JERRY_STATIC_ASSERT (ECMA_OBJECT_LEX_ENV_TYPE_SIZE <= sizeof (uint64_t) * JERRY_
 JERRY_STATIC_ASSERT (sizeof (ecma_collection_header_t) == sizeof (uint64_t));
 JERRY_STATIC_ASSERT (sizeof (ecma_collection_chunk_t) == sizeof (uint64_t));
 JERRY_STATIC_ASSERT (sizeof (ecma_string_t) == sizeof (uint64_t));
-JERRY_STATIC_ASSERT (sizeof (ecma_completion_value_t) == sizeof (uint32_t));
-JERRY_STATIC_ASSERT (sizeof (ecma_label_descriptor_t) == sizeof (uint64_t));
 JERRY_STATIC_ASSERT (sizeof (ecma_getter_setter_pointers_t) <= sizeof (uint64_t));
 
 /** \addtogroup ecma ECMA
@@ -87,7 +85,6 @@ DECLARE_ROUTINES_FOR (number)
 DECLARE_ROUTINES_FOR (collection_header)
 DECLARE_ROUTINES_FOR (collection_chunk)
 DECLARE_ROUTINES_FOR (string)
-DECLARE_ROUTINES_FOR (label_descriptor)
 DECLARE_ROUTINES_FOR (getter_setter_pointers)
 DECLARE_ROUTINES_FOR (external_pointer)
 

--- a/jerry-core/ecma/base/ecma-alloc.h
+++ b/jerry-core/ecma/base/ecma-alloc.h
@@ -98,18 +98,6 @@ extern ecma_string_t *ecma_alloc_string (void);
 extern void ecma_dealloc_string (ecma_string_t *);
 
 /**
- * Allocate memory for label descriptor
- *
- * @return pointer to allocated memory
- */
-extern ecma_label_descriptor_t *ecma_alloc_label_descriptor (void);
-
-/**
- * Dealloc memory from label descriptor
- */
-extern void ecma_dealloc_label_descriptor (ecma_label_descriptor_t *);
-
-/**
  * Allocate memory for getter-setter pointer pair
  *
  * @return pointer to allocated memory

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -329,8 +329,8 @@ ecma_gc_mark (ecma_object_t *object_p) /**< object to mark from */
 
           switch (property_id)
           {
-            case ECMA_INTERNAL_PROPERTY_NUMBER_INDEXED_ARRAY_VALUES: /* a collection of ecma-values */
-            case ECMA_INTERNAL_PROPERTY_STRING_INDEXED_ARRAY_VALUES: /* a collection of ecma-values */
+            case ECMA_INTERNAL_PROPERTY_NUMBER_INDEXED_ARRAY_VALUES: /* a collection of ecma values */
+            case ECMA_INTERNAL_PROPERTY_STRING_INDEXED_ARRAY_VALUES: /* a collection of ecma values */
             {
               JERRY_UNIMPLEMENTED ("Indexed array storage is not implemented yet.");
             }
@@ -363,7 +363,7 @@ ecma_gc_mark (ecma_object_t *object_p) /**< object to mark from */
               break;
             }
 
-            case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_THIS: /* an ecma-value */
+            case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_THIS: /* an ecma value */
             {
               if (ecma_is_value_object (property_value))
               {
@@ -375,7 +375,7 @@ ecma_gc_mark (ecma_object_t *object_p) /**< object to mark from */
               break;
             }
 
-            case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS: /* a collection of ecma-values */
+            case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS: /* a collection of ecma values */
             {
               ecma_collection_header_t *bound_arg_list_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_header_t,
                                                                                       property_value);

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -34,7 +34,7 @@
  */
 
 /**
- * Ecma-pointer field is used to calculate ecma-value's address.
+ * Ecma-pointer field is used to calculate ecma value's address.
  *
  * Ecma-pointer contains value's shifted offset from common Ecma-pointers' base.
  * The offset is shifted right by MEM_ALIGNMENT_LOG.
@@ -52,7 +52,7 @@
  */
 
 /**
- * Type of ecma-value
+ * Type of ecma value
  */
 typedef enum
 {
@@ -63,7 +63,7 @@ typedef enum
 } ecma_type_t;
 
 /**
- * Simple ecma-values
+ * Simple ecma values
  */
 typedef enum
 {
@@ -80,7 +80,7 @@ typedef enum
   ECMA_SIMPLE_VALUE_TRUE, /**< boolean true */
   ECMA_SIMPLE_VALUE_ARRAY_HOLE, /**< array hole, used for initialization of an array literal */
   ECMA_SIMPLE_VALUE_REGISTER_REF, /**< register reference, a special "base" value for vm */
-  ECMA_SIMPLE_VALUE__COUNT /** count of simple ecma-values */
+  ECMA_SIMPLE_VALUE__COUNT /** count of simple ecma values */
 } ecma_simple_value_t;
 
 /**
@@ -94,40 +94,9 @@ typedef enum
 } ecma_property_type_t;
 
 /**
- * Type of block evaluation (completion) result.
+ * Description of an ecma value
  *
- * See also: ECMA-262 v5, 8.9.
- */
-typedef enum
-{
-  ECMA_COMPLETION_TYPE_NORMAL, /**< default completion */
-  ECMA_COMPLETION_TYPE_RETURN, /**< completion with return */
-  ECMA_COMPLETION_TYPE_JUMP, /**< implementation-defined completion type
-                              *   for jump statements (break, continue)
-                              *   that require completion of one or several
-                              *   statements, before performing related jump.
-                              *
-                              *   For example, 'break' in the following code
-                              *   requires to return from opfunc_with handler
-                              *   before performing jump to the loop end:
-                              *
-                              *     for (var i = 0; i < 10; i++)
-                              *     {
-                              *        with (obj)
-                              *        {
-                              *          break;
-                              *        }
-                              *     }
-                              */
-  ECMA_COMPLETION_TYPE_THROW, /**< completion with throw */
-  ECMA_COMPLETION_TYPE_META /**< implementation-defined completion type
-                                 for meta opcode */
-} ecma_completion_type_t;
-
-/**
- * Description of an ecma-value
- *
- * Bit-field structure: type (2) | value (ECMA_POINTER_FIELD_WIDTH)
+ * Bit-field structure: type (2) | error (1) | value (ECMA_POINTER_FIELD_WIDTH)
  */
 typedef uint32_t ecma_value_t;
 
@@ -138,63 +107,23 @@ typedef uint32_t ecma_value_t;
 #define ECMA_VALUE_TYPE_WIDTH (2)
 
 /**
+ * Value is error (boolean)
+ */
+#define ECMA_VALUE_ERROR_POS (ECMA_VALUE_TYPE_POS + \
+                              ECMA_VALUE_TYPE_WIDTH)
+#define ECMA_VALUE_ERROR_WIDTH (1)
+
+/**
  * Simple value (ecma_simple_value_t) or compressed pointer to value (depending on value_type)
  */
-#define ECMA_VALUE_VALUE_POS (ECMA_VALUE_TYPE_POS + \
-                              ECMA_VALUE_TYPE_WIDTH)
+#define ECMA_VALUE_VALUE_POS (ECMA_VALUE_ERROR_POS + \
+                              ECMA_VALUE_ERROR_WIDTH)
 #define ECMA_VALUE_VALUE_WIDTH (ECMA_POINTER_FIELD_WIDTH)
 
 /**
  * Size of ecma value description, in bits
  */
 #define ECMA_VALUE_SIZE (ECMA_VALUE_VALUE_POS + ECMA_VALUE_VALUE_WIDTH)
-
-/**
- * Description of a block completion value
- *
- * See also: ECMA-262 v5, 8.9.
- *
- *                                               value (16)
- * Bit-field structure: type (8) | padding (8) <
- *                                               break / continue target
- */
-typedef uint32_t ecma_completion_value_t;
-
-/**
- * Value
- *
- * Used for normal, return, throw and exit completion types.
- */
-#define ECMA_COMPLETION_VALUE_VALUE_POS (0)
-#define ECMA_COMPLETION_VALUE_VALUE_WIDTH (ECMA_VALUE_SIZE)
-
-/**
- * Type (ecma_completion_type_t)
- */
-#define ECMA_COMPLETION_VALUE_TYPE_POS (JERRY_ALIGNUP (ECMA_COMPLETION_VALUE_VALUE_POS + \
-                                                                  ECMA_COMPLETION_VALUE_VALUE_WIDTH, \
-                                                                  JERRY_BITSINBYTE))
-#define ECMA_COMPLETION_VALUE_TYPE_WIDTH (8)
-
-/**
- * Size of ecma completion value description, in bits
- */
-#define ECMA_COMPLETION_VALUE_SIZE (ECMA_COMPLETION_VALUE_TYPE_POS + \
-                                    ECMA_COMPLETION_VALUE_TYPE_WIDTH)
-
-/**
- * Label
- *
- * Used for break and continue completion types.
- */
-typedef struct
-{
-  /** Target's offset */
-  uint32_t offset;
-
-  /** Levels to label left */
-  uint32_t depth;
-} ecma_label_descriptor_t;
 
 /**
  * Internal properties' identifiers.

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -31,12 +31,12 @@
 JERRY_STATIC_ASSERT (sizeof (ecma_value_t) * JERRY_BITSINBYTE >= ECMA_VALUE_SIZE);
 
 /**
- * Get type field of ecma-value
+ * Get type field of ecma value
  *
  * @return type field
  */
 ecma_type_t __attr_pure___
-ecma_get_value_type_field (ecma_value_t value) /**< ecma-value */
+ecma_get_value_type_field (ecma_value_t value) /**< ecma value */
 {
   return (ecma_type_t) jrt_extract_bit_field (value,
                                               ECMA_VALUE_TYPE_POS,
@@ -44,12 +44,12 @@ ecma_get_value_type_field (ecma_value_t value) /**< ecma-value */
 } /* ecma_get_value_type_field */
 
 /**
- * Get value field of ecma-value
+ * Get value field of ecma value
  *
  * @return value field
  */
 static uintptr_t __attr_pure___
-ecma_get_value_value_field (ecma_value_t value) /**< ecma-value */
+ecma_get_value_value_field (ecma_value_t value) /**< ecma value */
 {
   return (uintptr_t) jrt_extract_bit_field (value,
                                             ECMA_VALUE_VALUE_POS,
@@ -57,12 +57,12 @@ ecma_get_value_value_field (ecma_value_t value) /**< ecma-value */
 } /* ecma_get_value_value_field */
 
 /**
- * Set type field of ecma-value
+ * Set type field of ecma value
  *
- * @return ecma-value with updated field
+ * @return ecma value with updated field
  */
 static ecma_value_t __attr_pure___
-ecma_set_value_type_field (ecma_value_t value, /**< ecma-value to set field in */
+ecma_set_value_type_field (ecma_value_t value, /**< ecma value to set field in */
                            ecma_type_t type_field) /**< new field value */
 {
   return (ecma_value_t) jrt_set_bit_field_value (value,
@@ -72,12 +72,12 @@ ecma_set_value_type_field (ecma_value_t value, /**< ecma-value to set field in *
 } /* ecma_set_value_type_field */
 
 /**
- * Set value field of ecma-value
+ * Set value field of ecma value
  *
- * @return ecma-value with updated field
+ * @return ecma value with updated field
  */
 static ecma_value_t __attr_pure___
-ecma_set_value_value_field (ecma_value_t value, /**< ecma-value to set field in */
+ecma_set_value_value_field (ecma_value_t value, /**< ecma value to set field in */
                             uintptr_t value_field) /**< new field value */
 {
   return (ecma_value_t) jrt_set_bit_field_value (value,
@@ -93,7 +93,7 @@ ecma_set_value_value_field (ecma_value_t value, /**< ecma-value to set field in 
  *         false - otherwise.
  */
 bool __attr_pure___ __attr_always_inline___
-ecma_is_value_empty (ecma_value_t value) /**< ecma-value */
+ecma_is_value_empty (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
           && ecma_get_value_value_field (value) == ECMA_SIMPLE_VALUE_EMPTY);
@@ -106,7 +106,7 @@ ecma_is_value_empty (ecma_value_t value) /**< ecma-value */
  *         false - otherwise.
  */
 bool __attr_pure___ __attr_always_inline___
-ecma_is_value_undefined (ecma_value_t value) /**< ecma-value */
+ecma_is_value_undefined (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
           && ecma_get_value_value_field (value) == ECMA_SIMPLE_VALUE_UNDEFINED);
@@ -119,7 +119,7 @@ ecma_is_value_undefined (ecma_value_t value) /**< ecma-value */
  *         false - otherwise.
  */
 bool __attr_pure___ __attr_always_inline___
-ecma_is_value_null (ecma_value_t value) /**< ecma-value */
+ecma_is_value_null (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
           && ecma_get_value_value_field (value) == ECMA_SIMPLE_VALUE_NULL);
@@ -132,7 +132,7 @@ ecma_is_value_null (ecma_value_t value) /**< ecma-value */
  *         false - otherwise.
  */
 bool __attr_pure___ __attr_always_inline___
-ecma_is_value_boolean (ecma_value_t value) /**< ecma-value */
+ecma_is_value_boolean (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
           && (ecma_get_value_value_field (value) == ECMA_SIMPLE_VALUE_TRUE
@@ -142,18 +142,28 @@ ecma_is_value_boolean (ecma_value_t value) /**< ecma-value */
 /**
  * Check if the value is true.
  *
- * Warning:
- *         value must be boolean
- *
  * @return true - if the value contains ecma-true simple value,
  *         false - otherwise.
  */
 bool __attr_pure___ __attr_always_inline___
-ecma_is_value_true (ecma_value_t value) /**< ecma-value */
+ecma_is_value_true (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
           && ecma_get_value_value_field (value) == ECMA_SIMPLE_VALUE_TRUE);
 } /* ecma_is_value_true */
+
+/**
+ * Check if the value is false.
+ *
+ * @return true - if the value contains ecma-false simple value,
+ *         false - otherwise.
+ */
+bool __attr_pure___ __attr_always_inline___
+ecma_is_value_false (ecma_value_t value) /**< ecma value */
+{
+  return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
+          && ecma_get_value_value_field (value) == ECMA_SIMPLE_VALUE_FALSE);
+} /* ecma_is_value_false */
 
 /**
  * Check if the value is array hole.
@@ -162,7 +172,7 @@ ecma_is_value_true (ecma_value_t value) /**< ecma-value */
  *         false - otherwise.
  */
 bool __attr_pure___ __attr_always_inline___
-ecma_is_value_array_hole (ecma_value_t value) /**< ecma-value */
+ecma_is_value_array_hole (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
           && ecma_get_value_value_field (value) == ECMA_SIMPLE_VALUE_ARRAY_HOLE);
@@ -175,7 +185,7 @@ ecma_is_value_array_hole (ecma_value_t value) /**< ecma-value */
  *         false - otherwise.
  */
 bool __attr_pure___ __attr_always_inline___
-ecma_is_value_number (ecma_value_t value) /**< ecma-value */
+ecma_is_value_number (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_NUMBER);
 } /* ecma_is_value_number */
@@ -187,7 +197,7 @@ ecma_is_value_number (ecma_value_t value) /**< ecma-value */
  *         false - otherwise.
  */
 bool __attr_pure___ __attr_always_inline___
-ecma_is_value_string (ecma_value_t value) /**< ecma-value */
+ecma_is_value_string (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_STRING);
 } /* ecma_is_value_string */
@@ -199,17 +209,29 @@ ecma_is_value_string (ecma_value_t value) /**< ecma-value */
  *         false - otherwise.
  */
 bool __attr_pure___ __attr_always_inline___
-ecma_is_value_object (ecma_value_t value) /**< ecma-value */
+ecma_is_value_object (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_OBJECT);
 } /* ecma_is_value_object */
+
+/**
+ * Check if the value is an error value.
+ *
+ * @return true - if the value contains an error value,
+ *         false - otherwise.
+ */
+bool __attr_pure___ __attr_always_inline___
+ecma_is_value_error (ecma_value_t value) /**< ecma value */
+{
+  return (value & (1u << ECMA_VALUE_ERROR_POS)) != 0;
+} /* ecma_is_value_error */
 
 /**
  * Debug assertion that specified value's type is one of ECMA-defined
  * script-visible types, i.e.: undefined, null, boolean, number, string, object.
  */
 void
-ecma_check_value_type_is_spec_defined (ecma_value_t value) /**< ecma-value */
+ecma_check_value_type_is_spec_defined (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_undefined (value)
                 || ecma_is_value_null (value)
@@ -272,7 +294,7 @@ ecma_make_string_value (const ecma_string_t *ecma_string_p) /**< string to refer
 } /* ecma_make_string_value */
 
 /**
- * object value constructor
+ * Object value constructor
  */
 ecma_value_t __attr_const___
 ecma_make_object_value (const ecma_object_t *object_p) /**< object to reference in value */
@@ -291,12 +313,34 @@ ecma_make_object_value (const ecma_object_t *object_p) /**< object to reference 
 } /* ecma_make_object_value */
 
 /**
- * Get pointer to ecma-number from ecma-value
+ * Error value constructor
+ */
+ecma_value_t __attr_const___
+ecma_make_error_value (ecma_value_t value) /**< original ecma value */
+{
+  /* Error values cannot be converted. */
+  JERRY_ASSERT (!ecma_is_value_error (value));
+
+  return value | (1u << ECMA_VALUE_ERROR_POS);
+} /* ecma_make_error_value */
+
+
+/**
+  * Error value constructor
+  */
+ecma_value_t __attr_const___
+ecma_make_error_obj_value (const ecma_object_t *object_p) /**< object to reference in value */
+{
+  return ecma_make_error_value (ecma_make_object_value (object_p));
+} /* ecma_make_error_obj_value */
+
+/**
+ * Get pointer to ecma-number from ecma value
  *
  * @return the pointer
  */
 ecma_number_t *__attr_pure___
-ecma_get_number_from_value (ecma_value_t value) /**< ecma-value */
+ecma_get_number_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_NUMBER);
 
@@ -305,12 +349,12 @@ ecma_get_number_from_value (ecma_value_t value) /**< ecma-value */
 } /* ecma_get_number_from_value */
 
 /**
- * Get pointer to ecma-string from ecma-value
+ * Get pointer to ecma-string from ecma value
  *
  * @return the pointer
  */
 ecma_string_t *__attr_pure___
-ecma_get_string_from_value (ecma_value_t value) /**< ecma-value */
+ecma_get_string_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_STRING);
 
@@ -319,12 +363,12 @@ ecma_get_string_from_value (ecma_value_t value) /**< ecma-value */
 } /* ecma_get_string_from_value */
 
 /**
- * Get pointer to ecma-object from ecma-value
+ * Get pointer to ecma-object from ecma value
  *
  * @return the pointer
  */
 ecma_object_t *__attr_pure___
-ecma_get_object_from_value (ecma_value_t value) /**< ecma-value */
+ecma_get_object_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_OBJECT);
 
@@ -333,7 +377,24 @@ ecma_get_object_from_value (ecma_value_t value) /**< ecma-value */
 } /* ecma_get_object_from_value */
 
 /**
- * Copy ecma-value.
+ * Get the value from an error ecma value
+ *
+ * @return ecma value
+ */
+ecma_value_t __attr_pure___
+ecma_get_value_from_error_value (ecma_value_t value) /**< ecma value */
+{
+  JERRY_ASSERT (ecma_is_value_error (value));
+
+  value = (ecma_value_t) (value & ~(1u << ECMA_VALUE_ERROR_POS));
+
+  JERRY_ASSERT (!ecma_is_value_error (value));
+
+  return value;
+} /* ecma_get_value_from_error_value */
+
+/**
+ * Copy ecma value.
  *
  * Note:
  *  Operation algorithm.
@@ -342,7 +403,7 @@ ecma_get_object_from_value (ecma_value_t value) /**< ecma-value */
  *      simply return the value as it was passed;
  *    case number:
  *      copy the number
- *      and return new ecma-value
+ *      and return new ecma value
  *      pointing to copy of the number;
  *    case string:
  *      increase reference counter of the string
@@ -354,7 +415,7 @@ ecma_get_object_from_value (ecma_value_t value) /**< ecma-value */
  * @return See note.
  */
 ecma_value_t
-ecma_copy_value (ecma_value_t value, /**< ecma-value */
+ecma_copy_value (ecma_value_t value, /**< ecma value */
                  bool do_ref_if_object) /**< if the value is object value,
                                              increment reference counter of the object */
 {
@@ -408,12 +469,10 @@ ecma_copy_value (ecma_value_t value, /**< ecma-value */
 } /* ecma_copy_value */
 
 /**
- * Free the ecma-value
+ * Free the ecma value
  */
 void
-ecma_free_value (ecma_value_t value, /**< value description */
-                 bool do_deref_if_object) /**< if the value is object value,
-                                               decrement reference counter of the object */
+ecma_free_value (ecma_value_t value) /**< value description */
 {
   switch (ecma_get_value_type_field (value))
   {
@@ -439,414 +498,23 @@ ecma_free_value (ecma_value_t value, /**< value description */
 
     case ECMA_TYPE_OBJECT:
     {
-      if (do_deref_if_object)
-      {
-        ecma_deref_object (ecma_get_object_from_value (value));
-      }
+      ecma_deref_object (ecma_get_object_from_value (value));
       break;
     }
   }
 } /* ecma_free_value */
 
 /**
- * Get type field of completion value
- *
- * @return type field
- */
-static ecma_completion_type_t __attr_const___
-ecma_get_completion_value_type_field (ecma_completion_value_t completion_value) /**< completion value */
-{
-  return (ecma_completion_type_t) jrt_extract_bit_field (completion_value,
-                                                         ECMA_COMPLETION_VALUE_TYPE_POS,
-                                                         ECMA_COMPLETION_VALUE_TYPE_WIDTH);
-} /* ecma_get_completion_value_type_field */
-
-/**
- * Get value field of completion value
- *
- * @return value field
- */
-static ecma_value_t __attr_const___
-ecma_get_completion_value_value_field (ecma_completion_value_t completion_value) /**< completion value */
-{
-  return (ecma_value_t) jrt_extract_bit_field (completion_value,
-                                               ECMA_COMPLETION_VALUE_VALUE_POS,
-                                               ECMA_COMPLETION_VALUE_VALUE_WIDTH);
-} /* ecma_get_completion_value_value_field */
-
-/**
- * Set type field of completion value
- *
- * @return completion value with updated field
- */
-static ecma_completion_value_t __attr_const___
-ecma_set_completion_value_type_field (ecma_completion_value_t completion_value, /**< completion value
-                                                                                 * to set field in */
-                                      ecma_completion_type_t type_field) /**< new field value */
-{
-  return (ecma_completion_value_t) jrt_set_bit_field_value (completion_value,
-                                                            type_field,
-                                                            ECMA_COMPLETION_VALUE_TYPE_POS,
-                                                            ECMA_COMPLETION_VALUE_TYPE_WIDTH);
-} /* ecma_set_completion_value_type_field */
-
-/**
- * Set value field of completion value
- *
- * @return completion value with updated field
- */
-static ecma_completion_value_t __attr_pure___
-ecma_set_completion_value_value_field (ecma_completion_value_t completion_value, /**< completion value
-                                                                                  * to set field in */
-                                       ecma_value_t value_field) /**< new field value */
-{
-  return (ecma_completion_value_t) jrt_set_bit_field_value (completion_value,
-                                                            value_field,
-                                                            ECMA_COMPLETION_VALUE_VALUE_POS,
-                                                            ECMA_COMPLETION_VALUE_VALUE_WIDTH);
-} /* ecma_set_completion_value_value_field */
-
-
-/**
- * Normal, throw, return, exit and meta completion values constructor
- *
- * @return completion value
- */
-ecma_completion_value_t __attr_pure___ __attr_always_inline___
-ecma_make_completion_value (ecma_completion_type_t type, /**< type */
-                            ecma_value_t value) /**< value */
-{
-  const bool is_type_ok = (type == ECMA_COMPLETION_TYPE_NORMAL
-                     || type == ECMA_COMPLETION_TYPE_THROW
-                     || type == ECMA_COMPLETION_TYPE_RETURN
-                     || (type == ECMA_COMPLETION_TYPE_META
-                         && ecma_is_value_empty (value)));
-
-  JERRY_ASSERT (is_type_ok);
-
-  ecma_completion_value_t completion_value = 0;
-
-  completion_value = ecma_set_completion_value_type_field (completion_value,
-                                                           type);
-  completion_value = ecma_set_completion_value_value_field (completion_value,
-                                                            value);
-
-  return completion_value;
-} /* ecma_make_completion_value */
-
-/**
- * Simple normal completion value constructor
- *
- * @return completion value
- */
-ecma_completion_value_t __attr_const___ __attr_always_inline___
-ecma_make_simple_completion_value (ecma_simple_value_t simple_value) /**< simple ecma-value */
-{
-  JERRY_ASSERT (simple_value == ECMA_SIMPLE_VALUE_UNDEFINED
-                || simple_value == ECMA_SIMPLE_VALUE_NULL
-                || simple_value == ECMA_SIMPLE_VALUE_FALSE
-                || simple_value == ECMA_SIMPLE_VALUE_TRUE);
-
-  return ecma_make_completion_value (ECMA_COMPLETION_TYPE_NORMAL,
-                                     ecma_make_simple_value (simple_value));
-} /* ecma_make_simple_completion_value */
-
-/**
- * Normal completion value constructor
- *
- * @return completion value
- */
-ecma_completion_value_t __attr_pure___ __attr_always_inline___
-ecma_make_normal_completion_value (ecma_value_t value) /**< value */
-{
-  return ecma_make_completion_value (ECMA_COMPLETION_TYPE_NORMAL, value);
-} /* ecma_make_normal_completion_value */
-
-/**
- * Throw completion value constructor
- *
- * @return completion value
- */
-ecma_completion_value_t __attr_pure___ __attr_always_inline___
-ecma_make_throw_completion_value (ecma_value_t value) /**< value */
-{
-  return ecma_make_completion_value (ECMA_COMPLETION_TYPE_THROW, value);
-} /* ecma_make_throw_completion_value */
-
-/**
- * Throw completion value constructor.
- *
- * @return 'throw' completion value
- */
-ecma_completion_value_t __attr_const___
-ecma_make_throw_obj_completion_value (ecma_object_t *exception_p) /**< an object */
-{
-  JERRY_ASSERT (exception_p != NULL
-                && !ecma_is_lexical_environment (exception_p));
-
-  ecma_value_t exception = ecma_make_object_value (exception_p);
-
-  return ecma_make_throw_completion_value (exception);
-} /* ecma_make_throw_obj_completion_value */
-
-/**
- * Empty completion value constructor.
- *
- * @return (normal, empty, reserved) completion value.
- */
-ecma_completion_value_t __attr_const___ __attr_always_inline___
-ecma_make_empty_completion_value (void)
-{
-  return ecma_make_completion_value (ECMA_COMPLETION_TYPE_NORMAL,
-                                     ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY));
-} /* ecma_make_empty_completion_value */
-
-/**
- * Return completion value constructor
- *
- * @return completion value
- */
-ecma_completion_value_t __attr_pure___ __attr_always_inline___
-ecma_make_return_completion_value (ecma_value_t value) /**< value */
-{
-  return ecma_make_completion_value (ECMA_COMPLETION_TYPE_RETURN, value);
-} /* ecma_make_return_completion_value */
-
-/**
- * Meta completion value constructor
- *
- * @return completion value
- */
-ecma_completion_value_t __attr_const___ __attr_always_inline___
-ecma_make_meta_completion_value (void)
-{
-  return ecma_make_completion_value (ECMA_COMPLETION_TYPE_META,
-                                     ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY));
-} /* ecma_make_meta_completion_value */
-
-/**
- * Get ecma-value from specified completion value
- *
- * @return ecma-value
- */
-ecma_value_t __attr_const___ __attr_always_inline___
-ecma_get_completion_value_value (ecma_completion_value_t completion_value) /**< completion value */
-{
-  const ecma_completion_type_t type = ecma_get_completion_value_type_field (completion_value);
-
-  const bool is_type_ok = (type == ECMA_COMPLETION_TYPE_NORMAL
-                           || type == ECMA_COMPLETION_TYPE_THROW
-                           || type == ECMA_COMPLETION_TYPE_RETURN);
-
-  JERRY_ASSERT (is_type_ok);
-
-  return ecma_get_completion_value_value_field (completion_value);
-} /* ecma_get_completion_value_value */
-
-/**
- * Get pointer to ecma-number from completion value
- *
- * @return pointer
- */
-ecma_number_t *__attr_const___
-ecma_get_number_from_completion_value (ecma_completion_value_t completion_value) /**< completion value */
-{
-  return ecma_get_number_from_value (ecma_get_completion_value_value (completion_value));
-} /* ecma_get_number_from_completion_value */
-
-/**
- * Get pointer to ecma-string from completion value
- *
- * @return pointer
- */
-ecma_string_t *__attr_const___
-ecma_get_string_from_completion_value (ecma_completion_value_t completion_value) /**< completion value */
-{
-  return ecma_get_string_from_value (ecma_get_completion_value_value (completion_value));
-} /* ecma_get_string_from_completion_value */
-
-/**
- * Get pointer to ecma-object from completion value
- *
- * @return pointer
- */
-ecma_object_t *__attr_const___
-ecma_get_object_from_completion_value (ecma_completion_value_t completion_value) /**< completion value */
-{
-  return ecma_get_object_from_value (ecma_get_completion_value_value (completion_value));
-} /* ecma_get_object_from_completion_value */
-
-/**
- * Copy ecma-completion value.
- *
- * @return (source.type, ecma_copy_value (source.value), source.target).
- */
-ecma_completion_value_t
-ecma_copy_completion_value (ecma_completion_value_t value) /**< completion value */
-{
-  const ecma_completion_type_t type = ecma_get_completion_value_type_field (value);
-  const bool is_type_ok = (type == ECMA_COMPLETION_TYPE_NORMAL
-                           || type == ECMA_COMPLETION_TYPE_THROW
-                           || type == ECMA_COMPLETION_TYPE_RETURN
-                           || type == ECMA_COMPLETION_TYPE_JUMP);
-
-  JERRY_ASSERT (is_type_ok);
-
-  return ecma_make_completion_value (type,
-                                     ecma_copy_value (ecma_get_completion_value_value_field (value),
-                                                      true));
-} /* ecma_copy_completion_value */
-
-/**
- * Free the completion value.
+ * Free the ecma value if not an object
  */
 void
-ecma_free_completion_value (ecma_completion_value_t completion_value) /**< completion value */
+ecma_free_value_if_not_object (ecma_value_t value) /**< value description */
 {
-  switch (ecma_get_completion_value_type_field (completion_value))
+  if (ecma_get_value_type_field (value) != ECMA_TYPE_OBJECT)
   {
-    case ECMA_COMPLETION_TYPE_NORMAL:
-    case ECMA_COMPLETION_TYPE_THROW:
-    case ECMA_COMPLETION_TYPE_RETURN:
-    {
-      ecma_value_t v = ecma_get_completion_value_value_field (completion_value);
-      ecma_free_value (v, true);
-      break;
-    }
-    case ECMA_COMPLETION_TYPE_JUMP:
-    {
-      break;
-    }
-    case ECMA_COMPLETION_TYPE_META:
-    {
-      JERRY_UNREACHABLE ();
-    }
+    ecma_free_value (value);
   }
-} /* ecma_free_completion_value */
-
-/**
- * Check if the completion value is normal value.
- *
- * @return true - if the completion type is normal,
- *         false - otherwise.
- */
-bool __attr_const___ __attr_always_inline___
-ecma_is_completion_value_normal (ecma_completion_value_t value) /**< completion value */
-{
-  return (ecma_get_completion_value_type_field (value) == ECMA_COMPLETION_TYPE_NORMAL);
-} /* ecma_is_completion_value_normal */
-
-/**
- * Check if the completion value is throw value.
- *
- * @return true - if the completion type is throw,
- *         false - otherwise.
- */
-bool __attr_const___ __attr_always_inline___
-ecma_is_completion_value_throw (ecma_completion_value_t value) /**< completion value */
-{
-  return (ecma_get_completion_value_type_field (value) == ECMA_COMPLETION_TYPE_THROW);
-} /* ecma_is_completion_value_throw */
-
-/**
- * Check if the completion value is return value.
- *
- * @return true - if the completion type is return,
- *         false - otherwise.
- */
-bool __attr_const___ __attr_always_inline___
-ecma_is_completion_value_return (ecma_completion_value_t value) /**< completion value */
-{
-  return (ecma_get_completion_value_type_field (value) == ECMA_COMPLETION_TYPE_RETURN);
-} /* ecma_is_completion_value_return */
-
-/**
- * Check if the completion value is meta value.
- *
- * @return true - if the completion type is meta,
- *         false - otherwise.
- */
-bool __attr_const___ __attr_always_inline___
-ecma_is_completion_value_meta (ecma_completion_value_t value) /**< completion value */
-{
-  if (ecma_get_completion_value_type_field (value) == ECMA_COMPLETION_TYPE_META)
-  {
-    JERRY_ASSERT (ecma_is_value_empty (ecma_get_completion_value_value_field (value)));
-
-    return true;
-  }
-  else
-  {
-    return false;
-  }
-} /* ecma_is_completion_value_meta */
-
-/**
- * Check if the completion value is break / continue value.
- *
- * @return true - if the completion type is break / continue,
- *         false - otherwise.
- */
-bool __attr_const___ __attr_always_inline___
-ecma_is_completion_value_jump (ecma_completion_value_t value) /**< completion value */
-{
-  return (ecma_get_completion_value_type_field (value) == ECMA_COMPLETION_TYPE_JUMP);
-} /* ecma_is_completion_value_jump */
-
-/**
- * Check if the completion value is specified normal simple value.
- *
- * @return true - if the completion type is normal and
- *                value contains specified simple ecma-value,
- *         false - otherwise.
- */
-bool __attr_const___ __attr_always_inline___
-ecma_is_completion_value_normal_simple_value (ecma_completion_value_t value, /**< completion value */
-                                              ecma_simple_value_t simple_value) /**< simple value to check
-                                                                                     for equality with */
-{
-  return (value == ecma_make_simple_completion_value (simple_value));
-} /* ecma_is_completion_value_normal_simple_value */
-
-/**
- * Check if the completion value is normal true.
- *
- * @return true - if the completion type is normal and
- *                value contains ecma-true simple value,
- *         false - otherwise.
- */
-bool __attr_const___ __attr_always_inline___
-ecma_is_completion_value_normal_true (ecma_completion_value_t value) /**< completion value */
-{
-  return ecma_is_completion_value_normal_simple_value (value, ECMA_SIMPLE_VALUE_TRUE);
-} /* ecma_is_completion_value_normal_true */
-
-/**
- * Check if the completion value is normal false.
- *
- * @return true - if the completion type is normal and
- *                value contains ecma-false simple value,
- *         false - otherwise.
- */
-bool __attr_const___ __attr_always_inline___
-ecma_is_completion_value_normal_false (ecma_completion_value_t value) /**< completion value */
-{
-  return ecma_is_completion_value_normal_simple_value (value, ECMA_SIMPLE_VALUE_FALSE);
-} /* ecma_is_completion_value_normal_false */
-
-/**
- * Check if the completion value is normal empty value.
- *
- * @return true - if the completion type is normal and
- *                value contains empty simple value,
- *         false - otherwise.
- */
-bool __attr_const___ __attr_always_inline___
-ecma_is_completion_value_empty (ecma_completion_value_t value) /**< completion value */
-{
-  return (ecma_is_completion_value_normal (value)
-          && ecma_is_value_empty (ecma_get_completion_value_value_field (value)));
-} /* ecma_is_completion_value_empty */
+} /* ecma_free_value_if_not_object */
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-helpers-values-collection.c
+++ b/jerry-core/ecma/base/ecma-helpers-values-collection.c
@@ -26,13 +26,13 @@
 #include "jrt.h"
 
 /**
- * Allocate a collection of ecma-values.
+ * Allocate a collection of ecma values.
  *
  * @return pointer to the collection's header
  */
 ecma_collection_header_t *
-ecma_new_values_collection (const ecma_value_t values_buffer[], /**< ecma-values */
-                            ecma_length_t values_number, /**< number of ecma-values */
+ecma_new_values_collection (const ecma_value_t values_buffer[], /**< ecma values */
+                            ecma_length_t values_number, /**< number of ecma values */
                             bool do_ref_if_object) /**< if the value is object value,
                                                         increase reference counter of the object */
 {
@@ -77,7 +77,7 @@ ecma_new_values_collection (const ecma_value_t values_buffer[], /**< ecma-values
 } /* ecma_new_values_collection */
 
 /**
- * Free the collection of ecma-values.
+ * Free the collection of ecma values.
  */
 void
 ecma_free_values_collection (ecma_collection_header_t *header_p, /**< collection's header */
@@ -104,7 +104,14 @@ ecma_free_values_collection (ecma_collection_header_t *header_p, /**< collection
     {
       JERRY_ASSERT (cur_value_buf_iter_p < cur_value_buf_end_p);
 
-      ecma_free_value (*cur_value_buf_iter_p, do_deref_if_object);
+      if (do_deref_if_object)
+      {
+        ecma_free_value (*cur_value_buf_iter_p);
+      }
+      else
+      {
+        ecma_free_value_if_not_object (*cur_value_buf_iter_p);
+      }
 
       cur_value_buf_iter_p++;
       value_index++;
@@ -120,11 +127,11 @@ ecma_free_values_collection (ecma_collection_header_t *header_p, /**< collection
 } /* ecma_free_values_collection */
 
 /**
- * Append new value to ecma-values collection
+ * Append new value to ecma values collection
  */
 void
 ecma_append_to_values_collection (ecma_collection_header_t *header_p, /**< collection's header */
-                                  ecma_value_t v, /**< ecma-value to append */
+                                  ecma_value_t v, /**< ecma value to append */
                                   bool do_ref_if_object) /**< if the value is object value,
                                                               increase reference counter of the object */
 {
@@ -192,10 +199,7 @@ ecma_append_to_values_collection (ecma_collection_header_t *header_p, /**< colle
  *         the function invalidates all iterators that are configured to access the passed collection
  */
 void
-ecma_remove_last_value_from_values_collection (ecma_collection_header_t *header_p, /**< collection's header */
-                                               bool do_deref_if_object) /**< if the value to remove
-                                                                         *   is object value, decrement
-                                                                         *   reference counter of the object */
+ecma_remove_last_value_from_values_collection (ecma_collection_header_t *header_p) /**< collection's header */
 {
   JERRY_ASSERT (header_p != NULL && header_p->unit_number > 0);
 
@@ -211,7 +215,7 @@ ecma_remove_last_value_from_values_collection (ecma_collection_header_t *header_
 
   ecma_value_t value_to_remove = values_p[pos_of_value_to_remove_in_chunk];
 
-  ecma_free_value (value_to_remove, do_deref_if_object);
+  ecma_free_value (value_to_remove);
 
   header_p->unit_number--;
 

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -716,7 +716,7 @@ ecma_free_named_data_property (ecma_object_t *object_p, /**< object the property
                                                      property_p->u.named_data_property.name_p));
 
   ecma_value_t v = ecma_get_named_data_property_value (property_p);
-  ecma_free_value (v, false);
+  ecma_free_value_if_not_object (v);
 
   ecma_dealloc_property (property_p);
 } /* ecma_free_named_data_property */
@@ -811,7 +811,7 @@ ecma_free_internal_property (ecma_property_t *property_p) /**< the property */
 
     case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_THIS:
     {
-      ecma_free_value (property_value, false);
+      ecma_free_value_if_not_object (property_value);
       break;
     }
 
@@ -951,7 +951,7 @@ ecma_assert_object_contains_the_property (const ecma_object_t *object_p, /**< ec
 /**
  * Get value field of named data property
  *
- * @return ecma-value
+ * @return ecma value
  */
 ecma_value_t
 ecma_get_named_data_property_value (const ecma_property_t *prop_p) /**< property */
@@ -998,7 +998,7 @@ ecma_named_data_property_assign_value (ecma_object_t *obj_p, /**< object */
   else
   {
     ecma_value_t v = ecma_get_named_data_property_value (prop_p);
-    ecma_free_value (v, false);
+    ecma_free_value_if_not_object (v);
 
     ecma_set_named_data_property_value (prop_p, ecma_copy_value (value, false));
   }
@@ -1262,7 +1262,7 @@ ecma_free_property_descriptor (ecma_property_descriptor_t *prop_desc_p) /**< pro
 {
   if (prop_desc_p->is_value_defined)
   {
-    ecma_free_value (prop_desc_p->value, true);
+    ecma_free_value (prop_desc_p->value);
   }
 
   if (prop_desc_p->is_get_defined
@@ -1340,7 +1340,7 @@ ecma_bytecode_ref (ecma_compiled_code_t *bytecode_p) /**< byte code pointer */
     jerry_fatal (ERR_REF_COUNT_LIMIT);
   }
 
-  bytecode_p->status_flags = (uint16_t) (bytecode_p->status_flags + (1 << ECMA_BYTECODE_REF_SHIFT));
+  bytecode_p->status_flags = (uint16_t) (bytecode_p->status_flags + (1u << ECMA_BYTECODE_REF_SHIFT));
 } /* ecma_bytecode_ref */
 
 /**
@@ -1352,9 +1352,9 @@ ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p) /**< byte code pointer */
 {
   JERRY_ASSERT ((bytecode_p->status_flags >> ECMA_BYTECODE_REF_SHIFT) > 0);
 
-  bytecode_p->status_flags = (uint16_t) (bytecode_p->status_flags - (1 << ECMA_BYTECODE_REF_SHIFT));
+  bytecode_p->status_flags = (uint16_t) (bytecode_p->status_flags - (1u << ECMA_BYTECODE_REF_SHIFT));
 
-  if (bytecode_p->status_flags >= (1 << ECMA_BYTECODE_REF_SHIFT))
+  if (bytecode_p->status_flags >= (1u << ECMA_BYTECODE_REF_SHIFT))
   {
     /* Non-zero reference counter. */
     return;

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -59,11 +59,13 @@ extern bool ecma_is_value_undefined (ecma_value_t);
 extern bool ecma_is_value_null (ecma_value_t);
 extern bool ecma_is_value_boolean (ecma_value_t);
 extern bool ecma_is_value_true (ecma_value_t);
+extern bool ecma_is_value_false (ecma_value_t);
 extern bool ecma_is_value_array_hole (ecma_value_t);
 
 extern bool ecma_is_value_number (ecma_value_t);
 extern bool ecma_is_value_string (ecma_value_t);
 extern bool ecma_is_value_object (ecma_value_t);
+extern bool ecma_is_value_error (ecma_value_t);
 
 extern void ecma_check_value_type_is_spec_defined (ecma_value_t);
 
@@ -71,36 +73,15 @@ extern ecma_value_t ecma_make_simple_value (const ecma_simple_value_t value);
 extern ecma_value_t ecma_make_number_value (const ecma_number_t *);
 extern ecma_value_t ecma_make_string_value (const ecma_string_t *);
 extern ecma_value_t ecma_make_object_value (const ecma_object_t *);
+extern ecma_value_t ecma_make_error_value (ecma_value_t);
+extern ecma_value_t ecma_make_error_obj_value (const ecma_object_t *);
 extern ecma_number_t *ecma_get_number_from_value (ecma_value_t) __attr_pure___;
 extern ecma_string_t *ecma_get_string_from_value (ecma_value_t) __attr_pure___;
 extern ecma_object_t *ecma_get_object_from_value (ecma_value_t) __attr_pure___;
+extern ecma_value_t ecma_get_value_from_error_value (ecma_value_t) __attr_pure___;
 extern ecma_value_t ecma_copy_value (ecma_value_t, bool);
-extern void ecma_free_value (ecma_value_t, bool);
-
-extern ecma_completion_value_t ecma_make_completion_value (ecma_completion_type_t, ecma_value_t);
-extern ecma_completion_value_t ecma_make_simple_completion_value (ecma_simple_value_t);
-extern ecma_completion_value_t ecma_make_normal_completion_value (ecma_value_t);
-extern ecma_completion_value_t ecma_make_throw_completion_value (ecma_value_t);
-extern ecma_completion_value_t ecma_make_throw_obj_completion_value (ecma_object_t *);
-extern ecma_completion_value_t ecma_make_empty_completion_value (void);
-extern ecma_completion_value_t ecma_make_return_completion_value (ecma_value_t);
-extern ecma_completion_value_t ecma_make_meta_completion_value (void);
-extern ecma_value_t ecma_get_completion_value_value (ecma_completion_value_t);
-extern ecma_number_t *ecma_get_number_from_completion_value (ecma_completion_value_t) __attr_const___;
-extern ecma_string_t *ecma_get_string_from_completion_value (ecma_completion_value_t) __attr_const___;
-extern ecma_object_t *ecma_get_object_from_completion_value (ecma_completion_value_t) __attr_const___;
-extern ecma_completion_value_t ecma_copy_completion_value (ecma_completion_value_t);
-extern void ecma_free_completion_value (ecma_completion_value_t);
-
-extern bool ecma_is_completion_value_normal (ecma_completion_value_t);
-extern bool ecma_is_completion_value_throw (ecma_completion_value_t);
-extern bool ecma_is_completion_value_return (ecma_completion_value_t);
-extern bool ecma_is_completion_value_meta (ecma_completion_value_t);
-extern bool ecma_is_completion_value_jump (ecma_completion_value_t);
-extern bool ecma_is_completion_value_normal_simple_value (ecma_completion_value_t, ecma_simple_value_t);
-extern bool ecma_is_completion_value_normal_true (ecma_completion_value_t);
-extern bool ecma_is_completion_value_normal_false (ecma_completion_value_t);
-extern bool ecma_is_completion_value_empty (ecma_completion_value_t);
+extern void ecma_free_value (ecma_value_t);
+extern void ecma_free_value_if_not_object (ecma_value_t);
 
 /* ecma-helpers-string.c */
 extern ecma_string_t *ecma_new_ecma_string_from_utf8 (const lit_utf8_byte_t *, lit_utf8_size_t);
@@ -167,11 +148,11 @@ extern void ecma_number_to_decimal (ecma_number_t, uint64_t *, int32_t *, int32_
 extern ecma_collection_header_t *ecma_new_values_collection (const ecma_value_t[], ecma_length_t, bool);
 extern void ecma_free_values_collection (ecma_collection_header_t *, bool);
 extern void ecma_append_to_values_collection (ecma_collection_header_t *, ecma_value_t, bool);
-extern void ecma_remove_last_value_from_values_collection (ecma_collection_header_t *, bool);
+extern void ecma_remove_last_value_from_values_collection (ecma_collection_header_t *);
 extern ecma_collection_header_t *ecma_new_strings_collection (ecma_string_t *[], ecma_length_t);
 
 /**
- * Context of ecma-values' collection iterator
+ * Context of ecma values' collection iterator
  */
 typedef struct
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -1,5 +1,5 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,14 +52,14 @@
 /**
  * Helper function to set an object's length property
  *
- * @return completion value (return value of the [[Put]] method)
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value (return value of the [[Put]] method)
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_helper_set_length (ecma_object_t *object, /**< object*/
                                                 ecma_number_t length) /**< new length */
 {
-  ecma_completion_value_t ret_value;
+  ecma_value_t ret_value;
   ecma_string_t *magic_string_length_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
 
   ecma_number_t *len_p = ecma_alloc_number ();
@@ -81,18 +81,18 @@ ecma_builtin_array_prototype_helper_set_length (ecma_object_t *object, /**< obje
  * See also:
  *          ECMA-262 v5, 15.4.4.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_to_string (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t return_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this_value,
                   ecma_op_to_object (this_arg),
-                  return_value);
+                  ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this_value);
 
@@ -101,19 +101,19 @@ ecma_builtin_array_prototype_object_to_string (ecma_value_t this_arg) /**< this 
   /* 2. */
   ECMA_TRY_CATCH (join_value,
                   ecma_op_object_get (obj_p, join_magic_string_p),
-                  return_value);
+                  ret_value);
 
   if (!ecma_op_is_callable (join_value))
   {
     /* 3. */
-    return_value = ecma_builtin_helper_object_to_string (this_arg);
+    ret_value = ecma_builtin_helper_object_to_string (this_arg);
   }
   else
   {
     /* 4. */
     ecma_object_t *join_func_obj_p = ecma_get_object_from_value (join_value);
 
-    return_value = ecma_op_function_call (join_func_obj_p, this_arg, NULL, 0);
+    ret_value = ecma_op_function_call (join_func_obj_p, this_arg, NULL, 0);
   }
 
   ECMA_FINALIZE (join_value);
@@ -122,7 +122,7 @@ ecma_builtin_array_prototype_object_to_string (ecma_value_t this_arg) /**< this 
 
   ECMA_FINALIZE (obj_this_value);
 
-  return return_value;
+  return ret_value;
 } /* ecma_builtin_array_prototype_object_to_string */
 
 /**
@@ -131,13 +131,13 @@ ecma_builtin_array_prototype_object_to_string (ecma_value_t this_arg) /**< this 
  * See also:
  *          ECMA-262 v5, 15.4.4.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_value,
@@ -167,7 +167,7 @@ ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_ar
   if (length == 0)
   {
     ecma_string_t *empty_string_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (empty_string_p));
+    ret_value = ecma_make_string_value (empty_string_p);
   }
   else
   {
@@ -179,7 +179,7 @@ ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_ar
     ecma_string_t *return_string_p = ecma_copy_or_ref_ecma_string (ecma_get_string_from_value (first_value));
 
     /* 9-10. */
-    for (uint32_t k = 1; ecma_is_completion_value_empty (ret_value) && (k < length); k++)
+    for (uint32_t k = 1; ecma_is_value_empty (ret_value) && (k < length); k++)
     {
       ecma_string_t *part_string_p = ecma_concat_ecma_strings (return_string_p, separator_string_p);
 
@@ -198,9 +198,9 @@ ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_ar
       ecma_deref_ecma_string (part_string_p);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
-      ret_value = ecma_make_normal_completion_value (ecma_make_string_value (return_string_p));
+      ret_value = ecma_make_string_value (return_string_p);
     }
     else
     {
@@ -229,15 +229,15 @@ ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_ar
  * See also:
  *          ECMA-262 v5, 15.4.4.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_concat (ecma_value_t this_arg, /**< this argument */
                                             const ecma_value_t args[], /**< arguments list */
                                             ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -245,8 +245,8 @@ ecma_builtin_array_prototype_object_concat (ecma_value_t this_arg, /**< this arg
                   ret_value);
 
   /* 2. */
-  ecma_completion_value_t new_array = ecma_op_create_array_object (0, 0, false);
-  ecma_object_t *new_array_p = ecma_get_object_from_completion_value (new_array);
+  ecma_value_t new_array = ecma_op_create_array_object (0, 0, false);
+  ecma_object_t *new_array_p = ecma_get_object_from_value (new_array);
   uint32_t new_length = 0;
 
   /* 5.b - 5.c for this_arg */
@@ -256,7 +256,7 @@ ecma_builtin_array_prototype_object_concat (ecma_value_t this_arg, /**< this arg
 
   /* 5. */
   for (uint32_t arg_index = 0;
-       arg_index < args_number && ecma_is_completion_value_empty (ret_value);
+       arg_index < args_number && ecma_is_value_empty (ret_value);
        arg_index++)
   {
     ECMA_TRY_CATCH (concat_value,
@@ -267,7 +267,7 @@ ecma_builtin_array_prototype_object_concat (ecma_value_t this_arg, /**< this arg
 
   ECMA_FINALIZE (concat_this_value);
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (set_length_value,
                     ecma_builtin_array_prototype_helper_set_length (new_array_p, ecma_uint32_to_number (new_length)),
@@ -277,7 +277,7 @@ ecma_builtin_array_prototype_object_concat (ecma_value_t this_arg, /**< this arg
   }
   else
   {
-    ecma_free_completion_value (new_array);
+    ecma_free_value (new_array);
   }
 
   ECMA_FINALIZE (obj_this);
@@ -291,16 +291,17 @@ ecma_builtin_array_prototype_object_concat (ecma_value_t this_arg, /**< this arg
  * See also:
  *          ECMA-262 v5.1, 15.4.4.2 4th step
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+
+static ecma_value_t
 ecma_op_array_get_separator_string (ecma_value_t separator) /**< possible separator */
 {
   if (ecma_is_value_undefined (separator))
   {
     ecma_string_t *comma_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_COMMA_CHAR);
-    return ecma_make_normal_completion_value (ecma_make_string_value (comma_string_p));
+    return ecma_make_string_value (comma_string_p);
   }
   else
   {
@@ -314,14 +315,14 @@ ecma_op_array_get_separator_string (ecma_value_t separator) /**< possible separa
  * See also:
  *          ECMA-262 v5.1, 15.4.4.2
  *
- * @return ecma_completion_value_t value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma_value_t value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_op_array_get_to_string_at_index (ecma_object_t *obj_p, /**< this object */
                                       uint32_t index) /**< array index */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_string_t *index_string_p = ecma_new_ecma_string_from_uint32 (index);
 
   ECMA_TRY_CATCH (index_value,
@@ -332,7 +333,7 @@ ecma_op_array_get_to_string_at_index (ecma_object_t *obj_p, /**< this object */
       || ecma_is_value_null (index_value))
   {
     ecma_string_t *empty_string_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (empty_string_p));
+    ret_value = ecma_make_string_value (empty_string_p);
   }
   else
   {
@@ -352,14 +353,14 @@ ecma_op_array_get_to_string_at_index (ecma_object_t *obj_p, /**< this object */
  * See also:
  *          ECMA-262 v5, 15.4.4.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argument */
                                    const ecma_value_t separator_arg) /**< separator argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_value,
@@ -391,7 +392,7 @@ ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argume
   {
     /* 6. */
     ecma_string_t *empty_string_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (empty_string_p));
+    ret_value = ecma_make_string_value (empty_string_p);
   }
   else
   {
@@ -405,7 +406,7 @@ ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argume
     ecma_string_t *return_string_p = ecma_copy_or_ref_ecma_string (ecma_get_string_from_value (first_value));
 
     /* 9-10. */
-    for (uint32_t k = 1; ecma_is_completion_value_empty (ret_value) && (k < length); k++)
+    for (uint32_t k = 1; ecma_is_value_empty (ret_value) && (k < length); k++)
     {
       /* 10.a */
       ecma_string_t *part_string_p = ecma_concat_ecma_strings (return_string_p, separator_string_p);
@@ -427,9 +428,9 @@ ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argume
       ecma_deref_ecma_string (part_string_p);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
-      ret_value = ecma_make_normal_completion_value (ecma_make_string_value (return_string_p));
+      ret_value = ecma_make_string_value (return_string_p);
     }
     else
     {
@@ -458,13 +459,13 @@ ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argume
  * See also:
  *          ECMA-262 v5, 15.4.4.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_pop (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -493,7 +494,7 @@ ecma_builtin_array_prototype_object_pop (ecma_value_t this_arg) /**< this argume
                     ret_value);
 
     /* 4.b */
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 
     ECMA_FINALIZE (set_length_value)
   }
@@ -514,7 +515,7 @@ ecma_builtin_array_prototype_object_pop (ecma_value_t this_arg) /**< this argume
                     ecma_builtin_array_prototype_helper_set_length (obj_p, ecma_uint32_to_number (len)),
                     ret_value);
 
-    ret_value = ecma_make_normal_completion_value (ecma_copy_value (get_value, true));
+    ret_value = ecma_copy_value (get_value, true);
 
     ECMA_FINALIZE (set_length_value);
     ECMA_FINALIZE (del_value);
@@ -537,15 +538,15 @@ ecma_builtin_array_prototype_object_pop (ecma_value_t this_arg) /**< this argume
  * See also:
  *          ECMA-262 v5, 15.4.4.7
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_push (ecma_value_t this_arg, /**< this argument */
                                           const ecma_value_t *argument_list_p, /**< arguments list */
                                           ecma_length_t arguments_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this_value, ecma_op_to_object (this_arg), ret_value);
@@ -564,7 +565,7 @@ ecma_builtin_array_prototype_object_push (ecma_value_t this_arg, /**< this argum
 
   /* 5. */
   for (uint32_t index = 0;
-       index < arguments_number && ecma_is_completion_value_empty (ret_value);
+       index < arguments_number && ecma_is_value_empty (ret_value);
        index++, n++)
   {
     /* 5.a */
@@ -580,7 +581,7 @@ ecma_builtin_array_prototype_object_push (ecma_value_t this_arg, /**< this argum
   }
 
   /* 6. */
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (set_length_value,
                     ecma_builtin_array_prototype_helper_set_length (obj_p, n),
@@ -589,7 +590,7 @@ ecma_builtin_array_prototype_object_push (ecma_value_t this_arg, /**< this argum
     ecma_number_t *ret_num_p = ecma_alloc_number ();
     *ret_num_p = n;
 
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+    ret_value = ecma_make_number_value (ret_num_p);
 
     ECMA_FINALIZE (set_length_value)
   }
@@ -611,13 +612,13 @@ ecma_builtin_array_prototype_object_push (ecma_value_t this_arg, /**< this argum
  * See also:
  *          ECMA-262 v5, 15.4.4.8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_reverse (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -640,7 +641,7 @@ ecma_builtin_array_prototype_object_reverse (ecma_value_t this_arg) /**< this ar
   uint32_t middle = len / 2;
 
   /* 5-6. */
-  for (uint32_t lower = 0; lower < middle && ecma_is_completion_value_empty (ret_value); lower++)
+  for (uint32_t lower = 0; lower < middle && ecma_is_value_empty (ret_value); lower++)
   {
     /* 6.a */
     uint32_t upper = len - lower - 1;
@@ -687,10 +688,10 @@ ecma_builtin_array_prototype_object_reverse (ecma_value_t this_arg) /**< this ar
     ecma_deref_ecma_string (upper_str_p);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /* 7. */
-    ret_value = ecma_make_normal_completion_value (ecma_copy_value (obj_this, true));
+    ret_value = ecma_copy_value (obj_this, true);
   }
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
@@ -707,13 +708,13 @@ ecma_builtin_array_prototype_object_reverse (ecma_value_t this_arg) /**< this ar
  * See also:
  *          ECMA-262 v5, 15.4.4.9
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -740,7 +741,7 @@ ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argu
                     ecma_builtin_array_prototype_helper_set_length (obj_p, ECMA_NUMBER_ZERO),
                     ret_value);
 
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 
     ECMA_FINALIZE (set_length_value);
   }
@@ -752,7 +753,7 @@ ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argu
     ECMA_TRY_CATCH (first_value, ecma_op_object_get (obj_p, index_str_p), ret_value);
 
     /* 6. and 7. */
-    for (uint32_t k = 1; k < len && ecma_is_completion_value_empty (ret_value); k++)
+    for (uint32_t k = 1; k < len && ecma_is_value_empty (ret_value); k++)
     {
       /* 7.a */
       ecma_string_t *from_str_p = ecma_new_ecma_string_from_uint32 (k);
@@ -782,7 +783,7 @@ ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argu
       ecma_deref_ecma_string (from_str_p);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       len--;
       ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (len);
@@ -795,7 +796,7 @@ ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argu
                       ecma_builtin_array_prototype_helper_set_length (obj_p, ecma_uint32_to_number (len)),
                       ret_value);
       /* 10. */
-      ret_value = ecma_make_normal_completion_value (ecma_copy_value (first_value, true));
+      ret_value = ecma_copy_value (first_value, true);
 
       ECMA_FINALIZE (set_length_value);
       ECMA_FINALIZE (del_value);
@@ -820,15 +821,15 @@ ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argu
  * See also:
  *          ECMA-262 v5, 15.4.4.10
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_slice (ecma_value_t this_arg, /**< 'this' argument */
                               ecma_value_t arg1, /**< start */
                               ecma_value_t arg2) /**< end */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -874,14 +875,14 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t this_arg, /**< 'this' ar
 
   JERRY_ASSERT (start <= len && end <= len);
 
-  ecma_completion_value_t new_array = ecma_op_create_array_object (0, 0, false);
-  ecma_object_t *new_array_p = ecma_get_object_from_completion_value (new_array);
+  ecma_value_t new_array = ecma_op_create_array_object (0, 0, false);
+  ecma_object_t *new_array_p = ecma_get_object_from_value (new_array);
 
   /* 9. */
   uint32_t n = 0;
 
   /* 10. */
-  for (uint32_t k = start; k < end && ecma_is_completion_value_empty (ret_value); k++, n++)
+  for (uint32_t k = start; k < end && ecma_is_value_empty (ret_value); k++, n++)
   {
     /* 10.a */
     ecma_string_t *curr_idx_str_p = ecma_new_ecma_string_from_uint32 (k);
@@ -896,14 +897,14 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t this_arg, /**< 'this' ar
 
       /* 10.c.ii */
       /* This will always be a simple value since 'is_throw' is false, so no need to free. */
-      ecma_completion_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
-                                                                       to_idx_str_p,
-                                                                       get_value,
-                                                                       true, /* Writable */
-                                                                       true, /* Enumerable */
-                                                                       true, /* Configurable */
-                                                                       false);
-      JERRY_ASSERT (ecma_is_completion_value_normal_true (put_comp));
+      ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
+                                                            to_idx_str_p,
+                                                            get_value,
+                                                            true, /* Writable */
+                                                            true, /* Enumerable */
+                                                            true, /* Configurable */
+                                                            false);
+      JERRY_ASSERT (ecma_is_value_true (put_comp));
 
       ecma_deref_ecma_string (to_idx_str_p);
 
@@ -913,13 +914,13 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t this_arg, /**< 'this' ar
     ecma_deref_ecma_string (curr_idx_str_p);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     ret_value = new_array;
   }
   else
   {
-    ecma_free_completion_value (new_array);
+    ecma_free_value (new_array);
   }
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
@@ -936,10 +937,10 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t this_arg, /**< 'this' ar
  * See also:
  *          ECMA-262 v5, 15.4.4.11
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_sort_compare_helper (ecma_value_t j, /**< left value */
                                                          ecma_value_t k, /**< right value */
                                                          ecma_value_t comparefn) /**< compare function */
@@ -950,7 +951,7 @@ ecma_builtin_array_prototype_object_sort_compare_helper (ecma_value_t j, /**< le
    * compares greater than any other value, undefined property values always
    * sort to the end of the result, followed by non-existent property values.
    */
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_number_t *result_p = ecma_alloc_number ();
 
   bool j_is_undef = ecma_is_value_undefined (j);
@@ -1033,9 +1034,9 @@ ecma_builtin_array_prototype_object_sort_compare_helper (ecma_value_t j, /**< le
     }
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (result_p));
+    ret_value = ecma_make_number_value (result_p);
   }
   else
   {
@@ -1049,23 +1050,23 @@ ecma_builtin_array_prototype_object_sort_compare_helper (ecma_value_t j, /**< le
  * Function used to reconstruct the ordered binary tree.
  * Shifts 'index' down in the tree until it is in the correct position.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_array_to_heap_helper (ecma_value_t array[], /**< heap data array */
                                                           int index, /**< current item index */
                                                           int right, /**< right index is a maximum index */
                                                           ecma_value_t comparefn) /**< compare function */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* Left child of the current index. */
   int child = index * 2 + 1;
   ecma_value_t swap = array[index];
   bool should_break = false;
 
-  while (child <= right && ecma_is_completion_value_empty (ret_value) && !should_break)
+  while (child <= right && ecma_is_value_empty (ret_value) && !should_break)
   {
     if (child < right)
     {
@@ -1087,7 +1088,7 @@ ecma_builtin_array_prototype_object_array_to_heap_helper (ecma_value_t array[], 
       ECMA_FINALIZE (child_compare_value);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       JERRY_ASSERT (child <= right);
 
@@ -1119,7 +1120,7 @@ ecma_builtin_array_prototype_object_array_to_heap_helper (ecma_value_t array[], 
     }
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /*
      * Loop ended, either current child does not exist, or is less than swap.
@@ -1129,7 +1130,7 @@ ecma_builtin_array_prototype_object_array_to_heap_helper (ecma_value_t array[], 
     JERRY_ASSERT (parent >= 0 && parent <= right);
     array[parent] = swap;
 
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
   }
 
   return ret_value;
@@ -1138,18 +1139,18 @@ ecma_builtin_array_prototype_object_array_to_heap_helper (ecma_value_t array[], 
 /**
  * Heapsort function
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_array_heap_sort_helper (ecma_value_t array[], /**< array to sort */
                                                             int right, /**< right index */
                                                             ecma_value_t comparefn) /**< compare function */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* First, construct the ordered binary tree from the array. */
-  for (int i = right / 2; i >= 0 && ecma_is_completion_value_empty (ret_value); i--)
+  for (int i = right / 2; i >= 0 && ecma_is_value_empty (ret_value); i--)
   {
     ECMA_TRY_CATCH (value,
                     ecma_builtin_array_prototype_object_array_to_heap_helper (array,
@@ -1161,7 +1162,7 @@ ecma_builtin_array_prototype_object_array_heap_sort_helper (ecma_value_t array[]
   }
 
   /* Sorting elements. */
-  for (int i = right; i > 0 && ecma_is_completion_value_empty (ret_value); i--)
+  for (int i = right; i > 0 && ecma_is_value_empty (ret_value); i--)
   {
     /*
      * The top element will always contain the largest value.
@@ -1190,20 +1191,20 @@ ecma_builtin_array_prototype_object_array_heap_sort_helper (ecma_value_t array[]
  * See also:
  *          ECMA-262 v5, 15.4.4.11
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argument */
                                           ecma_value_t arg1) /**< comparefn */
 {
   /* Check if the provided compare function is callable. */
   if (!ecma_is_value_undefined (arg1) && !ecma_op_is_callable (arg1))
   {
-    return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    return ecma_raise_type_error ("");
   }
 
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (obj_this,
                   ecma_op_to_object (this_arg),
@@ -1230,7 +1231,7 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
 
   /* Count properties with name that is array index less than len */
   while (ecma_collection_iterator_next (&iter)
-         && ecma_is_completion_value_empty (ret_value))
+         && ecma_is_value_empty (ret_value))
   {
     ecma_string_t *property_name_p = ecma_get_string_from_value (*iter.current_value_p);
 
@@ -1250,7 +1251,7 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
 
   /* Copy unsorted array into a native c array. */
   while (ecma_collection_iterator_next (&iter)
-         && ecma_is_completion_value_empty (ret_value))
+         && ecma_is_value_empty (ret_value))
   {
     ecma_string_t *property_name_p = ecma_get_string_from_value (*iter.current_value_p);
 
@@ -1271,10 +1272,10 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
   }
 
   JERRY_ASSERT (copied_num == defined_prop_count
-                || !ecma_is_completion_value_empty (ret_value));
+                || !ecma_is_value_empty (ret_value));
 
   /* Sorting. */
-  if (copied_num > 1 && ecma_is_completion_value_empty (ret_value))
+  if (copied_num > 1 && ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (sort_value,
                     ecma_builtin_array_prototype_object_array_heap_sort_helper (values_buffer,
@@ -1286,7 +1287,7 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
 
   /* Put sorted values to the front of the array. */
   for (uint32_t index = 0;
-       index < copied_num && ecma_is_completion_value_empty (ret_value);
+       index < copied_num && ecma_is_value_empty (ret_value);
        index++)
   {
     ecma_string_t *index_string_p = ecma_new_ecma_string_from_uint32 (index);
@@ -1300,7 +1301,7 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
   /* Free values that were copied to the local array. */
   for (uint32_t index = 0; index < copied_num; index++)
   {
-    ecma_free_value (values_buffer[index], true);
+    ecma_free_value (values_buffer[index]);
   }
 
   MEM_FINALIZE_LOCAL_ARRAY (values_buffer);
@@ -1310,7 +1311,7 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
   ecma_collection_iterator_init (&iter, array_index_props_p);
 
   while (ecma_collection_iterator_next (&iter)
-         && ecma_is_completion_value_empty (ret_value))
+         && ecma_is_value_empty (ret_value))
   {
     ecma_string_t *property_name_p = ecma_get_string_from_value (*iter.current_value_p);
 
@@ -1327,9 +1328,9 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
 
   ecma_free_values_collection (array_index_props_p, true);
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
-    ret_value = ecma_make_normal_completion_value (ecma_copy_value (this_arg, true));
+    ret_value = ecma_copy_value (this_arg, true);
   }
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
@@ -1346,15 +1347,15 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
  * See also:
  *          ECMA-262 v5, 15.4.4.12
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this argument */
                                           const ecma_value_t args[], /**< arguments list */
                                           ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -1377,8 +1378,8 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
 
   const uint32_t len = ecma_number_to_uint32 (len_number);
 
-  ecma_completion_value_t new_array = ecma_op_create_array_object (0, 0, false);
-  ecma_object_t *new_array_p = ecma_get_object_from_completion_value (new_array);
+  ecma_value_t new_array = ecma_op_create_array_object (0, 0, false);
+  ecma_object_t *new_array_p = ecma_get_object_from_value (new_array);
 
   uint32_t start = 0;
   uint32_t delete_count = 0;
@@ -1438,7 +1439,7 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
   uint32_t k;
 
   for (uint32_t del_item_idx, k = 0;
-       k < delete_count && ecma_is_completion_value_empty (ret_value);
+       k < delete_count && ecma_is_value_empty (ret_value);
        k++)
   {
     /* 9.a */
@@ -1457,14 +1458,14 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
 
       /* 9.c.ii */
       /* This will always be a simple value since 'is_throw' is false, so no need to free. */
-      ecma_completion_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
-                                                                       idx_str_new_p,
-                                                                       get_value,
-                                                                       true, /* Writable */
-                                                                       true, /* Enumerable */
-                                                                       true, /* Configurable */
-                                                                       false);
-      JERRY_ASSERT (ecma_is_completion_value_normal_true (put_comp));
+      ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
+                                                            idx_str_new_p,
+                                                            get_value,
+                                                            true, /* Writable */
+                                                            true, /* Enumerable */
+                                                            true, /* Configurable */
+                                                            false);
+      JERRY_ASSERT (ecma_is_value_true (put_comp));
 
       ecma_deref_ecma_string (idx_str_new_p);
       ECMA_FINALIZE (get_value);
@@ -1495,7 +1496,7 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
     if (item_count < delete_count)
     {
       /* 12.b */
-      for (k = start; k < (len - delete_count) && ecma_is_completion_value_empty (ret_value); k++)
+      for (k = start; k < (len - delete_count) && ecma_is_value_empty (ret_value); k++)
       {
         from = k + delete_count;
         ecma_string_t *from_str_p = ecma_new_ecma_string_from_uint32 (from);
@@ -1533,7 +1534,7 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
       }
 
       /* 12.d */
-      for (k = len; k > new_len && ecma_is_completion_value_empty (ret_value); k--)
+      for (k = len; k > new_len && ecma_is_value_empty (ret_value); k--)
       {
         ecma_string_t *str_idx_p = ecma_new_ecma_string_from_uint32 (k - 1);
         ECMA_TRY_CATCH (del_value,
@@ -1548,7 +1549,7 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
     else if (item_count > delete_count)
     {
       /* 13.b */
-      for (k = len - delete_count; k > start  && ecma_is_completion_value_empty (ret_value); k--)
+      for (k = len - delete_count; k > start  && ecma_is_value_empty (ret_value); k--)
       {
         from = k + delete_count - 1;
         ecma_string_t *from_str_p = ecma_new_ecma_string_from_uint32 (from);
@@ -1590,7 +1591,7 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
   /* 15. */
   ecma_length_t idx = 0;
   for (ecma_length_t arg_index = 2;
-       arg_index < args_number && ecma_is_completion_value_empty (ret_value);
+       arg_index < args_number && ecma_is_value_empty (ret_value);
        arg_index++, idx++)
   {
     ecma_string_t *str_idx_p = ecma_new_ecma_string_from_uint32 ((uint32_t) (start + idx));
@@ -1603,7 +1604,7 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
   }
 
   /* 16. */
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (set_length_value,
                     ecma_builtin_array_prototype_helper_set_length (obj_p, ecma_uint32_to_number (new_len)),
@@ -1612,13 +1613,13 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
     ECMA_FINALIZE (set_length_value);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     ret_value = new_array;
   }
   else
   {
-    ecma_free_completion_value (new_array);
+    ecma_free_value (new_array);
   }
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
@@ -1635,15 +1636,15 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
  * See also:
  *          ECMA-262 v5, 15.4.4.13
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_unshift (ecma_value_t this_arg, /**< this argument */
                                              const ecma_value_t args[], /**< arguments list */
                                              ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -1664,7 +1665,7 @@ ecma_builtin_array_prototype_object_unshift (ecma_value_t this_arg, /**< this ar
   uint32_t len = ecma_number_to_uint32 (len_number);
 
   /* 5. and 6. */
-  for (uint32_t k = len; k > 0 && ecma_is_completion_value_empty (ret_value); k--)
+  for (uint32_t k = len; k > 0 && ecma_is_value_empty (ret_value); k--)
   {
     /* 6.a */
     ecma_string_t *from_str_p = ecma_new_ecma_string_from_uint32 (k - 1);
@@ -1695,7 +1696,7 @@ ecma_builtin_array_prototype_object_unshift (ecma_value_t this_arg, /**< this ar
   }
 
   for (uint32_t arg_index = 0;
-       arg_index < args_number && ecma_is_completion_value_empty (ret_value);
+       arg_index < args_number && ecma_is_value_empty (ret_value);
        arg_index++)
   {
     ecma_string_t *to_str_p = ecma_new_ecma_string_from_uint32 (arg_index);
@@ -1705,7 +1706,7 @@ ecma_builtin_array_prototype_object_unshift (ecma_value_t this_arg, /**< this ar
     ecma_deref_ecma_string (to_str_p);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     ecma_number_t new_len = ecma_uint32_to_number (len) + ecma_uint32_to_number (args_number);
     /* 10. */
@@ -1714,7 +1715,7 @@ ecma_builtin_array_prototype_object_unshift (ecma_value_t this_arg, /**< this ar
                     ret_value);
     ecma_number_t *num_p = ecma_alloc_number ();
     *num_p = new_len;
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+    ret_value = ecma_make_number_value (num_p);
 
     ECMA_FINALIZE (set_length_value);
   }
@@ -1733,15 +1734,15 @@ ecma_builtin_array_prototype_object_unshift (ecma_value_t this_arg, /**< this ar
  * See also:
  *          ECMA-262 v5, 15.4.4.14
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_index_of (ecma_value_t this_arg, /**< this argument */
                                               ecma_value_t arg1, /**< searchElement */
                                               ecma_value_t arg2) /**< fromIndex */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -1766,7 +1767,7 @@ ecma_builtin_array_prototype_object_index_of (ecma_value_t this_arg, /**< this a
   {
     ecma_number_t *num_p = ecma_alloc_number ();
     *num_p = ecma_int32_to_number (-1);
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+    ret_value = ecma_make_number_value (num_p);
   }
   else
   {
@@ -1782,7 +1783,7 @@ ecma_builtin_array_prototype_object_index_of (ecma_value_t this_arg, /**< this a
     {
       JERRY_ASSERT (from_idx < len);
 
-      for (; from_idx < len && found_index < 0 && ecma_is_completion_value_empty (ret_value); from_idx++)
+      for (; from_idx < len && found_index < 0 && ecma_is_value_empty (ret_value); from_idx++)
       {
         ecma_string_t *idx_str_p = ecma_new_ecma_string_from_uint32 (from_idx);
 
@@ -1805,11 +1806,11 @@ ecma_builtin_array_prototype_object_index_of (ecma_value_t this_arg, /**< this a
       }
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       ecma_number_t *num_p = ecma_alloc_number ();
       *num_p = found_index;
-      ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+      ret_value = ecma_make_number_value (num_p);
     }
 
     ECMA_OP_TO_NUMBER_FINALIZE (arg_from_idx);
@@ -1832,15 +1833,15 @@ ecma_builtin_array_prototype_object_index_of (ecma_value_t this_arg, /**< this a
  * See also:
  *          ECMA-262 v5, 15.4.4.15
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_last_index_of (ecma_value_t this_arg, /**< this argument */
                                                    const ecma_value_t args[], /**< arguments list */
                                                    ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_value_t search_element = (args_number > 0) ? args[0] : ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 
   /* 1. */
@@ -1867,7 +1868,7 @@ ecma_builtin_array_prototype_object_last_index_of (ecma_value_t this_arg, /**< t
   /* 4. */
   if (len == 0)
   {
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+    ret_value = ecma_make_number_value (num_p);
   }
   else
   {
@@ -1936,7 +1937,7 @@ ecma_builtin_array_prototype_object_last_index_of (ecma_value_t this_arg, /**< t
      * for an underflow instead. This is safe, because from_idx will always start in [0, len - 1],
      * and len is in [0, UINT_MAX], so from_idx >= len means we've had an underflow, and should stop.
      */
-    for (; from_idx < len && *num_p < 0 && ecma_is_completion_value_empty (ret_value); from_idx--)
+    for (; from_idx < len && *num_p < 0 && ecma_is_value_empty (ret_value); from_idx--)
     {
       /* 8.a */
       ecma_string_t *idx_str_p = ecma_new_ecma_string_from_uint32 (from_idx);
@@ -1959,9 +1960,9 @@ ecma_builtin_array_prototype_object_last_index_of (ecma_value_t this_arg, /**< t
       ecma_deref_ecma_string (idx_str_p);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
-      ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+      ret_value = ecma_make_number_value (num_p);
     }
     else
     {
@@ -1983,15 +1984,15 @@ ecma_builtin_array_prototype_object_last_index_of (ecma_value_t this_arg, /**< t
  * See also:
  *          ECMA-262 v5, 15.4.4.16
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argument */
                                            ecma_value_t arg1, /**< callbackfn */
                                            ecma_value_t arg2) /**< thisArg */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -2014,7 +2015,7 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
   /* 4. */
   if (!ecma_op_is_callable (arg1))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -2023,13 +2024,13 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
     ecma_object_t *func_object_p;
 
     /* We already checked that arg1 is callable, so it will always coerce to an object. */
-    ecma_completion_value_t to_object_comp = ecma_op_to_object (arg1);
-    JERRY_ASSERT (ecma_is_completion_value_normal (to_object_comp));
+    ecma_value_t to_object_comp = ecma_op_to_object (arg1);
+    JERRY_ASSERT (!ecma_is_value_error (to_object_comp));
 
-    func_object_p = ecma_get_object_from_completion_value (to_object_comp);
+    func_object_p = ecma_get_object_from_value (to_object_comp);
 
     /* 7. */
-    for (uint32_t index = 0; index < len && ecma_is_completion_value_empty (ret_value); index++)
+    for (uint32_t index = 0; index < len && ecma_is_value_empty (ret_value); index++)
     {
       /* 7.a */
       ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (index);
@@ -2048,9 +2049,9 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
         ECMA_TRY_CATCH (call_value, ecma_op_function_call (func_object_p, arg2, call_args, 3), ret_value);
 
         /* 7.c.iii, ecma_op_to_boolean always returns a simple value, so no need to free. */
-        if (ecma_is_completion_value_normal_false (ecma_op_to_boolean (call_value)))
+        if (ecma_is_value_false (ecma_op_to_boolean (call_value)))
         {
-          ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
+          ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
         }
 
         ECMA_FINALIZE (call_value);
@@ -2060,13 +2061,13 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
       ecma_deref_ecma_string (index_str_p);
     }
 
-    ecma_free_completion_value (to_object_comp);
+    ecma_free_value (to_object_comp);
     ecma_dealloc_number (num_p);
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       /* 8. */
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
     }
   }
 
@@ -2084,15 +2085,15 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
  * See also:
  *          ECMA-262 v5, 15.4.4.17
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argument */
                                           ecma_value_t arg1, /**< callbackfn */
                                           ecma_value_t arg2) /**< thisArg */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -2115,7 +2116,7 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
   /* 4. */
   if (!ecma_op_is_callable (arg1))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -2124,13 +2125,13 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
     ecma_object_t *func_object_p;
 
     /* We already checked that arg1 is callable, so it will always coerce to an object. */
-    ecma_completion_value_t to_object_comp = ecma_op_to_object (arg1);
-    JERRY_ASSERT (ecma_is_completion_value_normal (to_object_comp));
+    ecma_value_t to_object_comp = ecma_op_to_object (arg1);
+    JERRY_ASSERT (!ecma_is_value_error (to_object_comp));
 
-    func_object_p = ecma_get_object_from_completion_value (to_object_comp);
+    func_object_p = ecma_get_object_from_value (to_object_comp);
 
     /* 7. */
-    for (uint32_t index = 0; index < len && ecma_is_completion_value_empty (ret_value); index++)
+    for (uint32_t index = 0; index < len && ecma_is_value_empty (ret_value); index++)
     {
       /* 7.a */
       ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (index);
@@ -2149,9 +2150,9 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
         ECMA_TRY_CATCH (call_value, ecma_op_function_call (func_object_p, arg2, call_args, 3), ret_value);
 
         /* 7.c.iii, ecma_op_to_boolean always returns a simple value, so no need to free. */
-        if (ecma_is_completion_value_normal_true (ecma_op_to_boolean (call_value)))
+        if (ecma_is_value_true (ecma_op_to_boolean (call_value)))
         {
-          ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+          ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
         }
 
         ECMA_FINALIZE (call_value);
@@ -2161,13 +2162,13 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
       ecma_deref_ecma_string (index_str_p);
     }
 
-    ecma_free_completion_value (to_object_comp);
+    ecma_free_value (to_object_comp);
     ecma_dealloc_number (num_p);
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       /* 8. */
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
     }
   }
 
@@ -2185,15 +2186,15 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
  * See also:
  *          ECMA-262 v5, 15.4.4.18
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_for_each (ecma_value_t this_arg, /**< this argument */
                                               ecma_value_t arg1, /**< callbackfn */
                                               ecma_value_t arg2) /**< thisArg */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
                   ecma_op_to_object (this_arg),
@@ -2215,7 +2216,7 @@ ecma_builtin_array_prototype_object_for_each (ecma_value_t this_arg, /**< this a
   /* 4. */
   if (!ecma_op_is_callable (arg1))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -2224,13 +2225,13 @@ ecma_builtin_array_prototype_object_for_each (ecma_value_t this_arg, /**< this a
     ecma_object_t *func_object_p;
 
     /* We already checked that arg1 is callable, so it will always coerce to an object. */
-    ecma_completion_value_t to_object_comp = ecma_op_to_object (arg1);
-    JERRY_ASSERT (ecma_is_completion_value_normal (to_object_comp));
+    ecma_value_t to_object_comp = ecma_op_to_object (arg1);
+    JERRY_ASSERT (!ecma_is_value_error (to_object_comp));
 
-    func_object_p = ecma_get_object_from_completion_value (to_object_comp);
+    func_object_p = ecma_get_object_from_value (to_object_comp);
 
     /* Iterate over array and call callbackfn on every element */
-    for (uint32_t index = 0; index < len && ecma_is_completion_value_empty (ret_value); index++)
+    for (uint32_t index = 0; index < len && ecma_is_value_empty (ret_value); index++)
     {
       /* 7.a */
       ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (index);
@@ -2255,13 +2256,13 @@ ecma_builtin_array_prototype_object_for_each (ecma_value_t this_arg, /**< this a
       ecma_deref_ecma_string (index_str_p);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       /* 8. */
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
     }
 
-    ecma_free_completion_value (to_object_comp);
+    ecma_free_value (to_object_comp);
     ecma_dealloc_number (num_p);
   }
 
@@ -2279,15 +2280,15 @@ ecma_builtin_array_prototype_object_for_each (ecma_value_t this_arg, /**< this a
  * See also:
  *          ECMA-262 v5, 15.4.4.19
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argument */
                                          ecma_value_t arg1, /**< callbackfn */
                                          ecma_value_t arg2) /**< thisArg */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -2310,7 +2311,7 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
   /* 4. */
   if (!ecma_op_is_callable (arg1))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -2322,14 +2323,14 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
     /* 5. arg2 is simply used as T */
 
     /* 6. */
-    ecma_completion_value_t new_array = ecma_op_create_array_object (NULL, 0, false);
-    JERRY_ASSERT (ecma_is_completion_value_normal (new_array));
-    ecma_object_t *new_array_p = ecma_get_object_from_completion_value (new_array);
+    ecma_value_t new_array = ecma_op_create_array_object (NULL, 0, false);
+    JERRY_ASSERT (!ecma_is_value_error (new_array));
+    ecma_object_t *new_array_p = ecma_get_object_from_value (new_array);
 
     /* 7-8. */
     ecma_value_t current_index;
 
-    for (uint32_t index = 0; index < len && ecma_is_completion_value_empty (ret_value); index++)
+    for (uint32_t index = 0; index < len && ecma_is_value_empty (ret_value); index++)
     {
       /* 8.a */
       ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (index);
@@ -2347,14 +2348,14 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
 
         /* 8.c.iii */
         /* This will always be a simple value since 'is_throw' is false, so no need to free. */
-        ecma_completion_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
-                                                                         index_str_p,
-                                                                         mapped_value,
-                                                                         true, /* Writable */
-                                                                         true, /* Enumerable */
-                                                                         true, /* Configurable */
-                                                                         false);
-        JERRY_ASSERT (ecma_is_completion_value_normal_true (put_comp));
+        ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
+                                                              index_str_p,
+                                                              mapped_value,
+                                                              true, /* Writable */
+                                                              true, /* Enumerable */
+                                                              true, /* Configurable */
+                                                              false);
+        JERRY_ASSERT (ecma_is_value_true (put_comp));
 
         ECMA_FINALIZE (mapped_value);
         ECMA_FINALIZE (current_value);
@@ -2363,7 +2364,7 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
       ecma_deref_ecma_string (index_str_p);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       ECMA_TRY_CATCH (set_length_value,
                       ecma_builtin_array_prototype_helper_set_length (new_array_p, ecma_uint32_to_number (len)),
@@ -2373,7 +2374,7 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
     }
     else
     {
-      ecma_free_completion_value (new_array);
+      ecma_free_value (new_array);
     }
 
     ecma_dealloc_number (num_p);
@@ -2393,15 +2394,15 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
  * See also:
  *          ECMA-262 v5, 15.4.4.20
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this argument */
                                             ecma_value_t arg1, /**< callbackfn */
                                             ecma_value_t arg2) /**< thisArg */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj_this,
@@ -2424,7 +2425,7 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
   /* 4. */
   if (!ecma_op_is_callable (arg1))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -2433,9 +2434,9 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
     ecma_object_t *func_object_p;
 
     /* 6. */
-    ecma_completion_value_t new_array = ecma_op_create_array_object (NULL, 0, false);
-    JERRY_ASSERT (ecma_is_completion_value_normal (new_array));
-    ecma_object_t *new_array_p = ecma_get_object_from_completion_value (new_array);
+    ecma_value_t new_array = ecma_op_create_array_object (NULL, 0, false);
+    JERRY_ASSERT (!ecma_is_value_error (new_array));
+    ecma_object_t *new_array_p = ecma_get_object_from_value (new_array);
 
     /* We already checked that arg1 is callable, so it will always be an object. */
     JERRY_ASSERT (ecma_is_value_object (arg1));
@@ -2445,7 +2446,7 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
     uint32_t new_array_index = 0;
 
     /* 9. */
-    for (uint32_t index = 0; index < len && ecma_is_completion_value_empty (ret_value); index++)
+    for (uint32_t index = 0; index < len && ecma_is_value_empty (ret_value); index++)
     {
       /* 9.a */
       ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (index);
@@ -2464,19 +2465,19 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
         ECMA_TRY_CATCH (call_value, ecma_op_function_call (func_object_p, arg2, call_args, 3), ret_value);
 
         /* 9.c.iii, ecma_op_to_boolean always returns a simple value, so no need to free. */
-        if (ecma_is_completion_value_normal_true (ecma_op_to_boolean (call_value)))
+        if (ecma_is_value_true (ecma_op_to_boolean (call_value)))
         {
           ecma_string_t *to_index_string_p = ecma_new_ecma_string_from_uint32 (new_array_index);
 
           /* This will always be a simple value since 'is_throw' is false, so no need to free. */
-          ecma_completion_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
-                                                                           to_index_string_p,
-                                                                           get_value,
-                                                                           true, /* Writable */
-                                                                           true, /* Enumerable */
-                                                                           true, /* Configurable */
-                                                                           false);
-          JERRY_ASSERT (ecma_is_completion_value_normal_true (put_comp));
+          ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
+                                                                to_index_string_p,
+                                                                get_value,
+                                                                true, /* Writable */
+                                                                true, /* Enumerable */
+                                                                true, /* Configurable */
+                                                                false);
+          JERRY_ASSERT (ecma_is_value_true (put_comp));
 
           ecma_deref_ecma_string (to_index_string_p);
           new_array_index++;
@@ -2491,14 +2492,14 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
 
     ecma_dealloc_number (num_p);
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       /* 10. */
       ret_value = new_array;
     }
     else
     {
-      ecma_free_completion_value (new_array);
+      ecma_free_value (new_array);
     }
   }
 
@@ -2516,15 +2517,15 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
  * See also:
  *          ECMA-262 v5, 15.4.4.21
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this argument */
                                             const ecma_value_t args[], /**< arguments list */
                                             ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_value_t callbackfn = (args_number > 0) ? args[0] : ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
   ecma_value_t initial_value = (args_number > 1) ? args[1] : ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 
@@ -2549,7 +2550,7 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
   /* 4. */
   if (!ecma_op_is_callable (callbackfn))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -2563,7 +2564,7 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
     /* 5. */
     if (len_number == ECMA_NUMBER_ZERO && ecma_is_value_undefined (initial_value))
     {
-      ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+      ret_value = ecma_raise_type_error ("");
     }
     else
     {
@@ -2580,7 +2581,7 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
         /* 8.a */
         bool k_present = false;
         /* 8.b */
-        while (!k_present && index < len && ecma_is_completion_value_empty (ret_value))
+        while (!k_present && index < len && ecma_is_value_empty (ret_value))
         {
           /* 8.b.i */
           ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (index);
@@ -2600,13 +2601,13 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
         /* 8.c */
         if (!k_present)
         {
-          ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+          ret_value = ecma_raise_type_error ("");
         }
       }
       /* 9. */
       ecma_value_t current_index;
 
-      for (; index < len && ecma_is_completion_value_empty (ret_value); index++)
+      for (; index < len && ecma_is_value_empty (ret_value); index++)
       {
         /* 9.a */
         ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (index);
@@ -2627,7 +2628,7 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
                                                  4),
                           ret_value);
 
-          ecma_free_value (accumulator, true);
+          ecma_free_value (accumulator);
           accumulator = ecma_copy_value (call_value, true);
 
           ECMA_FINALIZE (call_value);
@@ -2637,13 +2638,13 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
         /* 9.d in for loop */
       }
 
-      if (ecma_is_completion_value_empty (ret_value))
+      if (ecma_is_value_empty (ret_value))
       {
-        ret_value = ecma_make_normal_completion_value (ecma_copy_value (accumulator, true));
+        ret_value = ecma_copy_value (accumulator, true);
       }
     }
 
-    ecma_free_value (accumulator, true);
+    ecma_free_value (accumulator);
     ecma_dealloc_number (num_p);
   }
 
@@ -2661,15 +2662,15 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
  * See also:
  *          ECMA-262 v5, 15.4.4.22
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< this argument */
                                                   const ecma_value_t args[], /**< arguments list */
                                                   ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_value_t callbackfn = (args_number > 0) ? args[0] : ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
   ecma_value_t initial_value = (args_number > 1) ? args[1] : ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 
@@ -2694,7 +2695,7 @@ ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< th
   /* 4. */
   if (!ecma_op_is_callable (callbackfn))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -2706,7 +2707,7 @@ ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< th
     /* 5. */
     if (len_number == ECMA_NUMBER_ZERO && ecma_is_value_undefined (initial_value))
     {
-      ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+      ret_value = ecma_raise_type_error ("");
     }
     else
     {
@@ -2726,7 +2727,7 @@ ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< th
         /* 8.a */
         bool k_present = false;
         /* 8.b */
-        while (!k_present && index >= 0 && ecma_is_completion_value_empty (ret_value))
+        while (!k_present && index >= 0 && ecma_is_value_empty (ret_value))
         {
           /* 8.b.i */
           ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 ((uint32_t) index);
@@ -2746,13 +2747,13 @@ ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< th
         /* 8.c */
         if (!k_present)
         {
-          ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+          ret_value = ecma_raise_type_error ("");
         }
       }
       /* 9. */
       ecma_value_t current_index;
 
-      for (; index >= 0 && ecma_is_completion_value_empty (ret_value); index--)
+      for (; index >= 0 && ecma_is_value_empty (ret_value); index--)
       {
         /* 9.a */
         ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 ((uint32_t) index);
@@ -2773,7 +2774,7 @@ ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< th
                                                  4),
                           ret_value);
 
-          ecma_free_value (accumulator, true);
+          ecma_free_value (accumulator);
           accumulator = ecma_copy_value (call_value, true);
 
           ECMA_FINALIZE (call_value);
@@ -2783,12 +2784,12 @@ ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< th
         /* 9.d in for loop */
       }
 
-      if (ecma_is_completion_value_empty (ret_value))
+      if (ecma_is_value_empty (ret_value))
       {
-        ret_value = ecma_make_normal_completion_value (ecma_copy_value (accumulator, true));
+        ret_value = ecma_copy_value (accumulator, true);
       }
 
-      ecma_free_value (accumulator, true);
+      ecma_free_value (accumulator);
       ecma_dealloc_number (num_p);
     }
   }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array.c
@@ -50,10 +50,10 @@
  * See also:
  *          ECMA-262 v5, 15.4.3.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_array_object_is_array (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                     ecma_value_t arg) /**< first argument */
 {
@@ -69,15 +69,15 @@ ecma_builtin_array_object_is_array (ecma_value_t this_arg __attr_unused___, /**<
     }
   }
 
-  return ecma_make_simple_completion_value (is_array);
+  return ecma_make_simple_value (is_array);
 } /* ecma_builtin_array_object_is_array */
 
 /**
  * Handle calling [[Call]] of built-in Array object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                   ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -89,9 +89,9 @@ ecma_builtin_array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arg
 /**
  * Handle calling [[Construct]] of built-in Array object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_array_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                        ecma_length_t arguments_list_len) /**< number of arguments */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
@@ -50,13 +50,13 @@
  * See also:
  *          ECMA-262 v5, 15.6.4.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_boolean_prototype_object_to_string (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (value_of_ret,
                   ecma_builtin_boolean_prototype_object_value_of (this_arg),
@@ -75,7 +75,7 @@ ecma_builtin_boolean_prototype_object_to_string (ecma_value_t this_arg) /**< thi
     ret_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_FALSE);
   }
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_string_value (ret_str_p));
+  ret_value = ecma_make_string_value (ret_str_p);
 
   ECMA_FINALIZE (value_of_ret);
 
@@ -88,15 +88,15 @@ ecma_builtin_boolean_prototype_object_to_string (ecma_value_t this_arg) /**< thi
  * See also:
  *          ECMA-262 v5, 15.6.4.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_boolean_prototype_object_value_of (ecma_value_t this_arg) /**< this argument */
 {
   if (ecma_is_value_boolean (this_arg))
   {
-    return ecma_make_normal_completion_value (this_arg);
+    return this_arg;
   }
   else if (ecma_is_value_object (this_arg))
   {
@@ -115,11 +115,11 @@ ecma_builtin_boolean_prototype_object_value_of (ecma_value_t this_arg) /**< this
 
       JERRY_ASSERT (ecma_is_value_boolean (ret_boolean_value));
 
-      return ecma_make_normal_completion_value (ret_boolean_value);
+      return ret_boolean_value;
     }
   }
 
-  return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+  return ecma_raise_type_error ("");
 } /* ecma_builtin_boolean_prototype_object_value_of */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.c
@@ -47,9 +47,9 @@
 /**
  * Handle calling [[Call]] of built-in Boolean object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_boolean_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                     ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -72,9 +72,9 @@ ecma_builtin_boolean_dispatch_call (const ecma_value_t *arguments_list_p, /**< a
 /**
  * Handle calling [[Construct]] of built-in Boolean object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_boolean_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                          ecma_length_t arguments_list_len) /**< number of arguments */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-compact-profile-error.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-compact-profile-error.c
@@ -46,29 +46,29 @@
 /**
  * Handle calling [[Call]] of built-in CompactProfileError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_compact_profile_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                                   ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
-  return ecma_make_throw_obj_completion_value (ecma_builtin_get (ECMA_BUILTIN_ID_COMPACT_PROFILE_ERROR));
+  return ecma_make_error_value (ecma_make_object_value (ecma_builtin_get (ECMA_BUILTIN_ID_COMPACT_PROFILE_ERROR)));
 } /* ecma_builtin_compact_profile_error_dispatch_call */
 
 /**
  * Handle calling [[Construct]] of built-in CompactProfileError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_compact_profile_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                                        ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
-  return ecma_make_throw_obj_completion_value (ecma_builtin_get (ECMA_BUILTIN_ID_COMPACT_PROFILE_ERROR));
+  return ecma_make_error_value (ecma_make_object_value (ecma_builtin_get (ECMA_BUILTIN_ID_COMPACT_PROFILE_ERROR)));
 } /* ecma_builtin_compact_profile_error_dispatch_construct */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -1,5 +1,5 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,13 +49,13 @@
  * See also:
  *          ECMA-262 v5, 15.9.5.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_to_string (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (prim_value,
                   ecma_date_get_primitive_value (this_arg),
@@ -66,7 +66,7 @@ ecma_builtin_date_prototype_to_string (ecma_value_t this_arg) /**< this argument
   if (ecma_number_is_nan (*prim_num_p))
   {
     ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INVALID_DATE_UL);
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (magic_str_p));
+    ret_value = ecma_make_string_value (magic_str_p);
   }
   else
   {
@@ -84,13 +84,13 @@ ecma_builtin_date_prototype_to_string (ecma_value_t this_arg) /**< this argument
  * See also:
  *          ECMA-262 v5, 15.9.5.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_to_date_string (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (this_arg)
       || ecma_object_get_class_name (ecma_get_object_from_value (this_arg)) != LIT_MAGIC_STRING_DATE_UL)
@@ -112,7 +112,7 @@ ecma_builtin_date_prototype_to_date_string (ecma_value_t this_arg) /**< this arg
     if (ecma_number_is_nan (*prim_value_num_p))
     {
       ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INVALID_DATE_UL);
-      ret_value = ecma_make_normal_completion_value (ecma_make_string_value (magic_str_p));
+      ret_value = ecma_make_string_value (magic_str_p);
     }
     else
     {
@@ -131,13 +131,13 @@ ecma_builtin_date_prototype_to_date_string (ecma_value_t this_arg) /**< this arg
  * See also:
  *          ECMA-262 v5, 15.9.5.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_to_time_string (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (this_arg)
       || ecma_object_get_class_name (ecma_get_object_from_value (this_arg)) != LIT_MAGIC_STRING_DATE_UL)
@@ -159,7 +159,7 @@ ecma_builtin_date_prototype_to_time_string (ecma_value_t this_arg) /**< this arg
     if (ecma_number_is_nan (*prim_value_num_p))
     {
       ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INVALID_DATE_UL);
-      ret_value = ecma_make_normal_completion_value (ecma_make_string_value (magic_str_p));
+      ret_value = ecma_make_string_value (magic_str_p);
     }
     else
     {
@@ -178,10 +178,10 @@ ecma_builtin_date_prototype_to_time_string (ecma_value_t this_arg) /**< this arg
  * See also:
  *          ECMA-262 v5, 15.9.5.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_to_locale_string (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_builtin_date_prototype_to_string (this_arg);
@@ -193,10 +193,10 @@ ecma_builtin_date_prototype_to_locale_string (ecma_value_t this_arg) /**< this a
  * See also:
  *          ECMA-262 v5, 15.9.5.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_to_locale_date_string (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_builtin_date_prototype_to_date_string (this_arg);
@@ -208,10 +208,10 @@ ecma_builtin_date_prototype_to_locale_date_string (ecma_value_t this_arg) /**< t
  * See also:
  *          ECMA-262 v5, 15.9.5.7
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_to_locale_time_string (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_builtin_date_prototype_to_time_string (this_arg);
@@ -223,10 +223,10 @@ ecma_builtin_date_prototype_to_locale_time_string (ecma_value_t this_arg) /**< t
  * See also:
  *          ECMA-262 v5, 15.9.5.8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_value_of (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_builtin_date_prototype_get_time (this_arg);
@@ -238,10 +238,10 @@ ecma_builtin_date_prototype_value_of (ecma_value_t this_arg) /**< this argument 
  * See also:
  *          ECMA-262 v5, 15.9.5.9
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_get_time (ecma_value_t this_arg) /**< this argument */
 {
   if (ecma_is_value_object (this_arg))
@@ -258,11 +258,11 @@ ecma_builtin_date_prototype_get_time (ecma_value_t this_arg) /**< this argument 
       ecma_number_t *ret_num_p = ecma_alloc_number ();
       *ret_num_p = *prim_value_num_p;
 
-      return ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+      return ecma_make_number_value (ret_num_p);
     }
   }
 
-  return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+  return ecma_raise_type_error ("");
 } /* ecma_builtin_date_prototype_get_time */
 
 /**
@@ -280,14 +280,14 @@ ecma_builtin_date_prototype_get_time (ecma_value_t this_arg) /**< this argument 
 /**
  * Implementation of Data.prototype built-in's getter routines
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
 #define DEFINE_GETTER(_ecma_paragraph, _routine_name, _getter_name, _timezone) \
-static ecma_completion_value_t \
+static ecma_value_t \
 ecma_builtin_date_prototype_get_ ## _routine_name (ecma_value_t this_arg) /**< this argument */ \
 { \
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value (); \
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY); \
  \
   /* 1. */ \
   ECMA_TRY_CATCH (value, ecma_builtin_date_prototype_get_time (this_arg), ret_value); \
@@ -296,14 +296,14 @@ ecma_builtin_date_prototype_get_ ## _routine_name (ecma_value_t this_arg) /**< t
   if (ecma_number_is_nan (*this_num_p)) \
   { \
     ecma_string_t *nan_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAN); \
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (nan_str_p)); \
+    ret_value = ecma_make_string_value (nan_str_p); \
   } \
   else \
   { \
     /* 3. */ \
     ecma_number_t *ret_num_p = ecma_alloc_number (); \
     *ret_num_p = _getter_name (DEFINE_GETTER_ARGUMENT_ ## _timezone (*this_num_p)); \
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p)); \
+    ret_value = ecma_make_number_value (ret_num_p); \
   } \
   ECMA_FINALIZE (value); \
   \
@@ -338,14 +338,14 @@ DEFINE_GETTER (ECMA-262 v5 15.9.5.26, timezone_offset, ecma_date_timezone_offset
  * See also:
  *          ECMA-262 v5, 15.9.5.27
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_time (ecma_value_t this_arg, /**< this argument */
                                       ecma_value_t time) /**< time */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (this_arg)
       || ecma_object_get_class_name (ecma_get_object_from_value (this_arg)) != LIT_MAGIC_STRING_DATE_UL)
@@ -370,7 +370,7 @@ ecma_builtin_date_prototype_set_time (ecma_value_t this_arg, /**< this argument 
     *prim_value_num_p = *value_p;
 
     /* 3. */
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (value_p));
+    ret_value = ecma_make_number_value (value_p);
     ECMA_OP_TO_NUMBER_FINALIZE (t);
   }
 
@@ -383,14 +383,14 @@ ecma_builtin_date_prototype_set_time (ecma_value_t this_arg, /**< this argument 
  * See also:
  *          ECMA-262 v5, 15.9.5.28
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_milliseconds (ecma_value_t this_arg, /**< this argument */
                                               ecma_value_t ms) /**< millisecond */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -420,14 +420,14 @@ ecma_builtin_date_prototype_set_milliseconds (ecma_value_t this_arg, /**< this a
  * See also:
  *          ECMA-262 v5, 15.9.5.29
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_utc_milliseconds (ecma_value_t this_arg, /**< this argument */
                                                   ecma_value_t ms) /**< millisecond */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -457,15 +457,15 @@ ecma_builtin_date_prototype_set_utc_milliseconds (ecma_value_t this_arg, /**< th
  * See also:
  *          ECMA-262 v5, 15.9.5.30
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_seconds (ecma_value_t this_arg, /**< this argument */
                                          ecma_value_t sec, /**< second */
                                          ecma_value_t ms) /**< millisecond */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -502,15 +502,15 @@ ecma_builtin_date_prototype_set_seconds (ecma_value_t this_arg, /**< this argume
  * See also:
  *          ECMA-262 v5, 15.9.5.31
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_utc_seconds (ecma_value_t this_arg, /**< this argument */
                                              ecma_value_t sec, /**< second */
                                              ecma_value_t ms) /**< millisecond */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -547,15 +547,15 @@ ecma_builtin_date_prototype_set_utc_seconds (ecma_value_t this_arg, /**< this ar
  * See also:
  *          ECMA-262 v5, 15.9.5.32
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_minutes (ecma_value_t this_arg, /**< this argument */
                                          const ecma_value_t args[], /**< arguments list */
                                          ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -588,7 +588,7 @@ ecma_builtin_date_prototype_set_minutes (ecma_value_t this_arg, /**< this argume
     ECMA_OP_TO_NUMBER_FINALIZE (min);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /* 5-8. */
     ecma_number_t hour = ecma_date_hour_from_time (t);
@@ -608,15 +608,15 @@ ecma_builtin_date_prototype_set_minutes (ecma_value_t this_arg, /**< this argume
  * See also:
  *          ECMA-262 v5, 15.9.5.33
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_utc_minutes (ecma_value_t this_arg, /**< this argument */
                                              const ecma_value_t args[], /**< arguments list */
                                              ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -649,7 +649,7 @@ ecma_builtin_date_prototype_set_utc_minutes (ecma_value_t this_arg, /**< this ar
     ECMA_OP_TO_NUMBER_FINALIZE (min);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /* 5-8. */
     ecma_number_t hour = ecma_date_hour_from_time (t);
@@ -669,15 +669,15 @@ ecma_builtin_date_prototype_set_utc_minutes (ecma_value_t this_arg, /**< this ar
  * See also:
  *          ECMA-262 v5, 15.9.5.34
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_hours (ecma_value_t this_arg, /**< this argument */
                                        const ecma_value_t args[], /**< arguments list */
                                        ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -719,7 +719,7 @@ ecma_builtin_date_prototype_set_hours (ecma_value_t this_arg, /**< this argument
     ECMA_OP_TO_NUMBER_FINALIZE (hour);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /* 6-9. */
     ret_value = ecma_date_set_internal_property (this_arg,
@@ -738,15 +738,15 @@ ecma_builtin_date_prototype_set_hours (ecma_value_t this_arg, /**< this argument
  * See also:
  *          ECMA-262 v5, 15.9.5.35
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_utc_hours (ecma_value_t this_arg, /**< this argument */
                                            const ecma_value_t args[], /**< arguments list */
                                            ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -788,7 +788,7 @@ ecma_builtin_date_prototype_set_utc_hours (ecma_value_t this_arg, /**< this argu
     ECMA_OP_TO_NUMBER_FINALIZE (hour);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /* 6-9. */
     ret_value = ecma_date_set_internal_property (this_arg,
@@ -807,14 +807,14 @@ ecma_builtin_date_prototype_set_utc_hours (ecma_value_t this_arg, /**< this argu
  * See also:
  *          ECMA-262 v5, 15.9.5.36
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_date (ecma_value_t this_arg, /**< this argument */
                                       ecma_value_t date) /**< date */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -843,14 +843,14 @@ ecma_builtin_date_prototype_set_date (ecma_value_t this_arg, /**< this argument 
  * See also:
  *          ECMA-262 v5, 15.9.5.37
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_utc_date (ecma_value_t this_arg, /**< this argument */
                                           ecma_value_t date) /**< date */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -879,15 +879,15 @@ ecma_builtin_date_prototype_set_utc_date (ecma_value_t this_arg, /**< this argum
  * See also:
  *          ECMA-262 v5, 15.9.5.38
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_month (ecma_value_t this_arg, /**< this argument */
                                        ecma_value_t month, /**< month */
                                        ecma_value_t date) /**< date */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -923,15 +923,15 @@ ecma_builtin_date_prototype_set_month (ecma_value_t this_arg, /**< this argument
  * See also:
  *          ECMA-262 v5, 15.9.5.39
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_utc_month (ecma_value_t this_arg, /**< this argument */
                                            ecma_value_t month, /**< month */
                                            ecma_value_t date) /**< date */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -967,15 +967,15 @@ ecma_builtin_date_prototype_set_utc_month (ecma_value_t this_arg, /**< this argu
  * See also:
  *          ECMA-262 v5, 15.9.5.40
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_full_year (ecma_value_t this_arg, /**< this argument */
                                            const ecma_value_t args[], /**< arguments list */
                                            ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -1012,7 +1012,7 @@ ecma_builtin_date_prototype_set_full_year (ecma_value_t this_arg, /**< this argu
     ECMA_OP_TO_NUMBER_FINALIZE (year);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /* 5-8. */
     ret_value = ecma_date_set_internal_property (this_arg,
@@ -1031,15 +1031,15 @@ ecma_builtin_date_prototype_set_full_year (ecma_value_t this_arg, /**< this argu
  * See also:
  *          ECMA-262 v5, 15.9.5.41
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_utc_full_year (ecma_value_t this_arg, /**< this argument */
                                                const ecma_value_t args[], /**< arguments list */
                                                ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -1076,7 +1076,7 @@ ecma_builtin_date_prototype_set_utc_full_year (ecma_value_t this_arg, /**< this 
     ECMA_OP_TO_NUMBER_FINALIZE (year);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /* 5-8. */
     ret_value = ecma_date_set_internal_property (this_arg,
@@ -1095,13 +1095,13 @@ ecma_builtin_date_prototype_set_utc_full_year (ecma_value_t this_arg, /**< this 
  * See also:
  *          ECMA-262 v5, 15.9.5.42
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_to_utc_string (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (prim_value,
                   ecma_date_get_primitive_value (this_arg),
@@ -1112,7 +1112,7 @@ ecma_builtin_date_prototype_to_utc_string (ecma_value_t this_arg) /**< this argu
   if (ecma_number_is_nan (*prim_num_p))
   {
     ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INVALID_DATE_UL);
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (magic_str_p));
+    ret_value = ecma_make_string_value (magic_str_p);
   }
   else
   {
@@ -1130,13 +1130,13 @@ ecma_builtin_date_prototype_to_utc_string (ecma_value_t this_arg) /**< this argu
  * See also:
  *          ECMA-262 v5, 15.9.5.43
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_to_iso_string (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (prim_value,
                   ecma_date_get_primitive_value (this_arg),
@@ -1146,7 +1146,7 @@ ecma_builtin_date_prototype_to_iso_string (ecma_value_t this_arg) /**< this argu
 
   if (ecma_number_is_nan (*prim_num_p) || ecma_number_is_infinity (*prim_num_p))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_RANGE));
+    ret_value = ecma_raise_range_error ("");
   }
   else
   {
@@ -1164,14 +1164,14 @@ ecma_builtin_date_prototype_to_iso_string (ecma_value_t this_arg) /**< this argu
  * See also:
  *          ECMA-262 v5, 15.9.5.44
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_to_json (ecma_value_t this_arg, /**< this argument */
                                      ecma_value_t arg __attr_unused___) /**< key */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (obj,
@@ -1194,7 +1194,7 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg, /**< this argument *
     }
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     ecma_string_t *to_iso_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_TO_ISO_STRING_UL);
     ecma_object_t *value_obj_p = ecma_get_object_from_value (obj);
@@ -1207,7 +1207,7 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg, /**< this argument *
     /* 5. */
     if (!ecma_op_is_callable (to_iso))
     {
-      ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+      ret_value = ecma_raise_type_error ("");
     }
     /* 6. */
     else
@@ -1235,13 +1235,13 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg, /**< this argument *
  * See also:
  *          ECMA-262 v5, AnnexB.B.2.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_get_year (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -1250,14 +1250,14 @@ ecma_builtin_date_prototype_get_year (ecma_value_t this_arg) /**< this argument 
   if (ecma_number_is_nan (*this_num_p))
   {
     ecma_string_t *nan_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAN);
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (nan_str_p));
+    ret_value = ecma_make_string_value (nan_str_p);
   }
   else
   {
     /* 3. */
     ecma_number_t *ret_num_p = ecma_alloc_number ();
     *ret_num_p = ecma_date_year_from_time (ecma_date_local_time (*this_num_p)) - 1900;
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+    ret_value = ecma_make_number_value (ret_num_p);
   }
   ECMA_FINALIZE (value);
 
@@ -1270,14 +1270,14 @@ ecma_builtin_date_prototype_get_year (ecma_value_t this_arg) /**< this argument 
  * See also:
  *          ECMA-262 v5, AnnexB.B.2.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_prototype_set_year (ecma_value_t this_arg, /**< this argument */
                                       ecma_value_t year) /**< year argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
@@ -1309,7 +1309,7 @@ ecma_builtin_date_prototype_set_year (ecma_value_t this_arg, /**< this argument 
 
   ECMA_OP_TO_NUMBER_FINALIZE (year_value);
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /* 5-8. */
     ecma_number_t m = ecma_date_month_from_time (t);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -1,5 +1,5 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,11 +75,11 @@ ecma_date_parse_date_chars (lit_utf8_byte_t **str_p, /**< pointer to the cesu8 s
   *
   * @return result of MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))
   */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to the Date constructor */
                             ecma_length_t args_len) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_number_t *prim_value_p = ecma_alloc_number ();
   *prim_value_p = ecma_number_make_nan ();
 
@@ -95,7 +95,7 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
   ecma_number_t milliseconds = ECMA_NUMBER_ZERO;
 
   /* 3. */
-  if (args_len >= 3 && ecma_is_completion_value_empty (ret_value))
+  if (args_len >= 3 && ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (date_value, ecma_op_to_number (args[2]), ret_value);
     date = *ecma_get_number_from_value (date_value);
@@ -103,7 +103,7 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
   }
 
   /* 4. */
-  if (args_len >= 4 && ecma_is_completion_value_empty (ret_value))
+  if (args_len >= 4 && ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (hours_value, ecma_op_to_number (args[3]), ret_value);
     hours = *ecma_get_number_from_value (hours_value);
@@ -111,7 +111,7 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
   }
 
   /* 5. */
-  if (args_len >= 5 && ecma_is_completion_value_empty (ret_value))
+  if (args_len >= 5 && ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (minutes_value, ecma_op_to_number (args[4]), ret_value);
     minutes = *ecma_get_number_from_value (minutes_value);
@@ -119,7 +119,7 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
   }
 
   /* 6. */
-  if (args_len >= 6 && ecma_is_completion_value_empty (ret_value))
+  if (args_len >= 6 && ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (seconds_value, ecma_op_to_number (args[5]), ret_value);
     seconds = *ecma_get_number_from_value (seconds_value);
@@ -127,14 +127,14 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
   }
 
   /* 7. */
-  if (args_len >= 7 && ecma_is_completion_value_empty (ret_value))
+  if (args_len >= 7 && ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (milliseconds_value, ecma_op_to_number (args[6]), ret_value);
     milliseconds = *ecma_get_number_from_value (milliseconds_value);
     ECMA_FINALIZE (milliseconds_value);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     if (!ecma_number_is_nan (year) && !ecma_number_is_infinity (year))
     {
@@ -163,9 +163,9 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
   ECMA_FINALIZE (month_value);
   ECMA_FINALIZE (year_value);
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (prim_value_p));
+    ret_value = ecma_make_number_value (prim_value_p);
   }
   else
   {
@@ -182,14 +182,14 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
  *          ECMA-262 v5, 15.9.4.2
  *          ECMA-262 v5, 15.9.1.15
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argument */
                          ecma_value_t arg) /**< string */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_number_t *date_num_p = ecma_alloc_number ();
   *date_num_p = ecma_number_make_nan ();
 
@@ -389,7 +389,7 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
     }
   }
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (date_num_p));
+  ret_value = ecma_make_number_value (date_num_p);
 
   MEM_FINALIZE_LOCAL_ARRAY (date_start_p);
   ECMA_FINALIZE (date_str_value);
@@ -403,15 +403,15 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
  * See also:
  *          ECMA-262 v5, 15.9.4.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_utc (ecma_value_t this_arg __attr_unused___, /**< this argument */
                        const ecma_value_t args[], /**< arguments list */
                        ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (args_number < 2)
   {
@@ -421,7 +421,7 @@ ecma_builtin_date_utc (ecma_value_t this_arg __attr_unused___, /**< this argumen
      */
     ecma_number_t *nan_p = ecma_alloc_number ();
     *nan_p = ecma_number_make_nan ();
-    return ecma_make_normal_completion_value (ecma_make_number_value (nan_p));
+    return ecma_make_number_value (nan_p);
   }
 
   ECMA_TRY_CATCH (time_value, ecma_date_construct_helper (args, args_number), ret_value);
@@ -429,7 +429,7 @@ ecma_builtin_date_utc (ecma_value_t this_arg __attr_unused___, /**< this argumen
   ecma_number_t *time_p = ecma_get_number_from_value (time_value);
   ecma_number_t *time_clip_p = ecma_alloc_number ();
   *time_clip_p = ecma_date_time_clip (*time_p);
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (time_clip_p));
+  ret_value = ecma_make_number_value (time_clip_p);
 
   ECMA_FINALIZE (time_value);
 
@@ -442,10 +442,10 @@ ecma_builtin_date_utc (ecma_value_t this_arg __attr_unused___, /**< this argumen
  * See also:
  *          ECMA-262 v5, 15.9.4.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_date_now (ecma_value_t this_arg __attr_unused___) /**< this argument */
 {
   /*
@@ -455,7 +455,7 @@ ecma_builtin_date_now (ecma_value_t this_arg __attr_unused___) /**< this argumen
    */
   ecma_number_t *now_num_p = ecma_alloc_number ();
   *now_num_p = ECMA_NUMBER_ZERO;
-  return ecma_make_normal_completion_value (ecma_make_number_value (now_num_p));
+  return ecma_make_number_value (now_num_p);
 } /* ecma_builtin_date_now */
 
 /**
@@ -464,13 +464,13 @@ ecma_builtin_date_now (ecma_value_t this_arg __attr_unused___) /**< this argumen
  * See also:
  *          ECMA-262 v5, 15.9.2.1
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_date_dispatch_call (const ecma_value_t *arguments_list_p __attr_unused___, /**< arguments list */
                                  ecma_length_t arguments_list_len __attr_unused___) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (now_val,
                   ecma_builtin_date_now (ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED)),
@@ -489,13 +489,13 @@ ecma_builtin_date_dispatch_call (const ecma_value_t *arguments_list_p __attr_unu
  * See also:
  *          ECMA-262 v5, 15.9.3.1
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                       ecma_length_t arguments_list_len) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_number_t *prim_value_num_p = NULL;
 
   ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_DATE_PROTOTYPE);
@@ -562,7 +562,7 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
     *prim_value_num_p = ecma_number_make_nan ();
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     if (!ecma_number_is_nan (*prim_value_num_p) && ecma_number_is_infinity (*prim_value_num_p))
     {
@@ -577,11 +577,11 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
                                                                         ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
     ECMA_SET_POINTER (prim_value_prop_p->u.internal_property.value, prim_value_num_p);
 
-    ret_value = ecma_make_normal_completion_value (ecma_make_object_value (obj_p));
+    ret_value = ecma_make_object_value (obj_p);
   }
   else
   {
-    JERRY_ASSERT (ecma_is_completion_value_throw (ret_value));
+    JERRY_ASSERT (ecma_is_value_error (ret_value));
     ecma_deref_object (obj_p);
   }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
@@ -51,18 +51,18 @@
  * See also:
  *          ECMA-262 v5, 15.11.4.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   // 2.
   if (!ecma_is_value_object (this_arg))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -73,22 +73,22 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
                     ecma_op_object_get (obj_p, name_magic_string_p),
                     ret_value);
 
-    ecma_completion_value_t name_to_str_completion;
+    ecma_value_t name_to_str_completion;
 
     if (ecma_is_value_undefined (name_get_ret_value))
     {
       ecma_string_t *error_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_ERROR_UL);
 
-      name_to_str_completion = ecma_make_normal_completion_value (ecma_make_string_value (error_magic_string_p));
+      name_to_str_completion = ecma_make_string_value (error_magic_string_p);
     }
     else
     {
       name_to_str_completion = ecma_op_to_string (name_get_ret_value);
     }
 
-    if (unlikely (!ecma_is_completion_value_normal (name_to_str_completion)))
+    if (unlikely (ecma_is_value_error (name_to_str_completion)))
     {
-      ret_value = ecma_copy_completion_value (name_to_str_completion);
+      ret_value = ecma_copy_value (name_to_str_completion, true);
     }
     else
     {
@@ -98,27 +98,27 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
                       ecma_op_object_get (obj_p, message_magic_string_p),
                       ret_value);
 
-      ecma_completion_value_t msg_to_str_completion;
+      ecma_value_t msg_to_str_completion;
 
       if (ecma_is_value_undefined (msg_get_ret_value))
       {
         ecma_string_t *empty_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
 
-        msg_to_str_completion = ecma_make_normal_completion_value (ecma_make_string_value (empty_magic_string_p));
+        msg_to_str_completion = ecma_make_string_value (empty_magic_string_p);
       }
       else
       {
         msg_to_str_completion = ecma_op_to_string (msg_get_ret_value);
       }
 
-      if (unlikely (!ecma_is_completion_value_normal (msg_to_str_completion)))
+      if (unlikely (ecma_is_value_error (msg_to_str_completion)))
       {
-        ret_value = ecma_copy_completion_value (msg_to_str_completion);
+        ret_value = ecma_copy_value (msg_to_str_completion, true);
       }
       else
       {
-        ecma_string_t *name_string_p = ecma_get_string_from_completion_value (name_to_str_completion);
-        ecma_string_t *msg_string_p = ecma_get_string_from_completion_value (msg_to_str_completion);
+        ecma_string_t *name_string_p = ecma_get_string_from_value (name_to_str_completion);
+        ecma_string_t *msg_string_p = ecma_get_string_from_value (msg_to_str_completion);
 
         ecma_string_t *ret_str_p;
 
@@ -173,17 +173,17 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
           MEM_FINALIZE_LOCAL_ARRAY (ret_str_buffer);
         }
 
-        ret_value = ecma_make_normal_completion_value (ecma_make_string_value (ret_str_p));
+        ret_value = ecma_make_string_value (ret_str_p);
       }
 
-      ecma_free_completion_value (msg_to_str_completion);
+      ecma_free_value (msg_to_str_completion);
 
       ECMA_FINALIZE (msg_get_ret_value);
 
       ecma_deref_ecma_string (message_magic_string_p);
     }
 
-    ecma_free_completion_value (name_to_str_completion);
+    ecma_free_value (name_to_str_completion);
 
     ECMA_FINALIZE (name_get_ret_value);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error.c
@@ -46,9 +46,9 @@
 /**
  * Handle calling [[Call]] of built-in Error object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                   ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -57,7 +57,7 @@ ecma_builtin_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arg
   if (arguments_list_len != 0
       && !ecma_is_value_undefined (arguments_list_p[0]))
   {
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (msg_str_value,
                     ecma_op_to_string (arguments_list_p[0]),
@@ -66,7 +66,7 @@ ecma_builtin_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arg
     ecma_string_t *message_string_p = ecma_get_string_from_value (msg_str_value);
     ecma_object_t *new_error_object_p = ecma_new_standard_error_with_message (ECMA_ERROR_COMMON,
                                                                               message_string_p);
-    ret_value = ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    ret_value = ecma_make_object_value (new_error_object_p);
 
     ECMA_FINALIZE (msg_str_value);
 
@@ -76,16 +76,16 @@ ecma_builtin_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arg
   {
     ecma_object_t *new_error_object_p = ecma_new_standard_error (ECMA_ERROR_COMMON);
 
-    return ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    return ecma_make_object_value (new_error_object_p);
   }
 } /* ecma_builtin_error_dispatch_call */
 
 /**
  * Handle calling [[Construct]] of built-in Error object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                        ecma_length_t arguments_list_len) /**< number of arguments */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror.c
@@ -46,9 +46,9 @@
 /**
  * Handle calling [[Call]] of built-in EvalError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_eval_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                        ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -57,7 +57,7 @@ ecma_builtin_eval_error_dispatch_call (const ecma_value_t *arguments_list_p, /**
   if (arguments_list_len != 0
       && !ecma_is_value_undefined (arguments_list_p[0]))
   {
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (msg_str_value,
                     ecma_op_to_string (arguments_list_p[0]),
@@ -66,7 +66,7 @@ ecma_builtin_eval_error_dispatch_call (const ecma_value_t *arguments_list_p, /**
     ecma_string_t *message_string_p = ecma_get_string_from_value (msg_str_value);
     ecma_object_t *new_error_object_p = ecma_new_standard_error_with_message (ECMA_ERROR_EVAL,
                                                                               message_string_p);
-    ret_value = ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    ret_value = ecma_make_object_value (new_error_object_p);
 
     ECMA_FINALIZE (msg_str_value);
 
@@ -76,16 +76,16 @@ ecma_builtin_eval_error_dispatch_call (const ecma_value_t *arguments_list_p, /**
   {
     ecma_object_t *new_error_object_p = ecma_new_standard_error (ECMA_ERROR_EVAL);
 
-    return ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    return ecma_make_object_value (new_error_object_p);
   }
 } /* ecma_builtin_eval_error_dispatch_call */
 
 /**
  * Handle calling [[Construct]] of built-in EvalError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_eval_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                             ecma_length_t arguments_list_len) /**< number of arguments */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -1,5 +1,5 @@
 /* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,22 +50,22 @@
  * See also:
  *          ECMA-262 v5, 15.3.4.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_function_prototype_object_to_string (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_op_is_callable (this_arg))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
     ecma_string_t *function_to_string_p = ecma_get_magic_string (LIT_MAGIC_STRING__FUNCTION_TO_STRING);
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (function_to_string_p));
+    ret_value = ecma_make_string_value (function_to_string_p);
   }
   return ret_value;
 } /* ecma_builtin_function_prototype_object_to_string */
@@ -76,20 +76,20 @@ ecma_builtin_function_prototype_object_to_string (ecma_value_t this_arg) /**< th
  * See also:
  *          ECMA-262 v5, 15.3.4.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this argument */
                                               ecma_value_t arg1, /**< first argument */
                                               ecma_value_t arg2) /**< second argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   if (!ecma_op_is_callable (this_arg))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -105,7 +105,7 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
       /* 3. */
       if (!ecma_is_value_object (arg2))
       {
-        ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+        ret_value = ecma_raise_type_error ("");
       }
       else
       {
@@ -130,7 +130,7 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
 
         /* 7. */
         for (uint32_t index = 0;
-             index < length && ecma_is_completion_value_empty (ret_value);
+             index < length && ecma_is_value_empty (ret_value);
              index++)
         {
           ecma_string_t *curr_idx_str_p = ecma_new_ecma_string_from_uint32 (index);
@@ -146,7 +146,7 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
           ecma_deref_ecma_string (curr_idx_str_p);
         }
 
-        if (ecma_is_completion_value_empty (ret_value))
+        if (ecma_is_value_empty (ret_value))
         {
           JERRY_ASSERT (last_index == length);
           ret_value = ecma_op_function_call (func_obj_p,
@@ -157,7 +157,7 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
 
         for (uint32_t index = 0; index < last_index; index++)
         {
-          ecma_free_value (arguments_list_p[index], true);
+          ecma_free_value (arguments_list_p[index]);
         }
 
         MEM_FINALIZE_LOCAL_ARRAY (arguments_list_p);
@@ -178,17 +178,17 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
  * See also:
  *          ECMA-262 v5, 15.3.4.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_function_prototype_object_call (ecma_value_t this_arg, /**< this argument */
                                              const ecma_value_t *arguments_list_p, /**< list of arguments */
                                              ecma_length_t arguments_number) /**< number of arguments */
 {
   if (!ecma_op_is_callable (this_arg))
   {
-    return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    return ecma_raise_type_error ("");
   }
   else
   {
@@ -218,20 +218,20 @@ ecma_builtin_function_prototype_object_call (ecma_value_t this_arg, /**< this ar
  * See also:
  *          ECMA-262 v5, 15.3.4.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this argument */
                                              const ecma_value_t *arguments_list_p, /**< list of arguments */
                                              ecma_length_t arguments_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 2. */
   if (!ecma_op_is_callable (this_arg))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -285,18 +285,15 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
     /* 15. */
     if (ecma_object_get_class_name (this_arg_obj_p) == LIT_MAGIC_STRING_FUNCTION_UL)
     {
-      ecma_completion_value_t get_len_completion = ecma_op_object_get (this_arg_obj_p,
-                                                                       magic_string_length_p);
-      JERRY_ASSERT (ecma_is_completion_value_normal (get_len_completion));
-
-      ecma_value_t len_value = ecma_get_completion_value_value (get_len_completion);
-      JERRY_ASSERT (ecma_is_value_number (len_value));
+      ecma_value_t get_len_value = ecma_op_object_get (this_arg_obj_p, magic_string_length_p);
+      JERRY_ASSERT (!ecma_is_value_error (get_len_value));
+      JERRY_ASSERT (ecma_is_value_number (get_len_value));
 
       const ecma_length_t bound_arg_count = arg_count > 1 ? arg_count - 1 : 0;
 
       /* 15.a */
-      *length_p = *ecma_get_number_from_value (len_value) - ecma_uint32_to_number (bound_arg_count);
-      ecma_free_completion_value (get_len_completion);
+      *length_p = *ecma_get_number_from_value (get_len_value) - ecma_uint32_to_number (bound_arg_count);
+      ecma_free_value (get_len_value);
 
       /* 15.b */
       if (ecma_number_is_negative (*length_p))
@@ -311,16 +308,15 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
     }
 
     /* 17. */
-    ecma_completion_value_t completion = ecma_builtin_helper_def_prop (function_p,
-                                                                       magic_string_length_p,
-                                                                       ecma_make_number_value (length_p),
-                                                                       false, /* Writable */
-                                                                       false, /* Enumerable */
-                                                                       false, /* Configurable */
-                                                                       false); /* Failure handling */
+    ecma_value_t completion = ecma_builtin_helper_def_prop (function_p,
+                                                            magic_string_length_p,
+                                                            ecma_make_number_value (length_p),
+                                                            false, /* Writable */
+                                                            false, /* Enumerable */
+                                                            false, /* Configurable */
+                                                            false); /* Failure handling */
 
-    JERRY_ASSERT (ecma_is_completion_value_normal_true (completion)
-                  || ecma_is_completion_value_normal_false (completion));
+    JERRY_ASSERT (ecma_is_value_boolean (completion));
 
     ecma_deref_ecma_string (magic_string_length_p);
     ecma_dealloc_number (length_p);
@@ -349,8 +345,7 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
                                                      &prop_desc,
                                                      false);
 
-    JERRY_ASSERT (ecma_is_completion_value_normal_true (completion)
-                  || ecma_is_completion_value_normal_false (completion));
+    JERRY_ASSERT (ecma_is_value_boolean (completion));
 
     ecma_deref_ecma_string (magic_string_caller_p);
 
@@ -360,14 +355,13 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
                                                      &prop_desc,
                                                      false);
 
-    JERRY_ASSERT (ecma_is_completion_value_normal_true (completion)
-                  || ecma_is_completion_value_normal_false (completion));
+    JERRY_ASSERT (ecma_is_value_boolean (completion));
 
     ecma_deref_ecma_string (magic_string_arguments_p);
     ecma_deref_object (thrower_p);
 
     /* 22. */
-    ret_value = ecma_make_normal_completion_value (ecma_make_object_value (function_p));
+    ret_value = ecma_make_object_value (function_p);
   }
 
   return ret_value;
@@ -376,29 +370,29 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
 /**
  * Handle calling [[Call]] of built-in Function.prototype object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_function_prototype_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                                ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
-  return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+  return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 } /* ecma_builtin_function_prototype_dispatch_call */
 
 /**
  * Handle calling [[Construct]] of built-in Function.prototype object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_function_prototype_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                                     ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
-  return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+  return ecma_raise_type_error ("");
 } /* ecma_builtin_function_prototype_dispatch_construct */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
@@ -44,9 +44,9 @@
 /**
  * Handle calling [[Call]] of built-in Function object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_function_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                      ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -61,16 +61,16 @@ ecma_builtin_function_dispatch_call (const ecma_value_t *arguments_list_p, /**< 
  * Performs the operation described in ECMA 262 v5.1 15.3.2.1 steps 5.a-d
  *
  *
- * @return completion value - concatenated arguments as a string.
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value - concatenated arguments as a string.
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_function_helper_get_function_expression (const ecma_value_t *arguments_list_p, /**< arguments list */
                                                       ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ecma_string_t *left_parenthesis_str_p, *right_parenthesis_str_p;
   ecma_string_t *left_brace_str_p, *right_brace_str_p;
@@ -99,7 +99,7 @@ ecma_builtin_function_helper_get_function_expression (const ecma_value_t *argume
   expr_str_p = concated_str_p;
 
   for (ecma_length_t idx = 0;
-       idx < number_of_function_args && ecma_is_completion_value_empty (ret_value);
+       idx < number_of_function_args && ecma_is_value_empty (ret_value);
        idx++)
   {
     ECMA_TRY_CATCH (str_arg_value,
@@ -122,7 +122,7 @@ ecma_builtin_function_helper_get_function_expression (const ecma_value_t *argume
     ECMA_FINALIZE (str_arg_value);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     concated_str_p = ecma_concat_ecma_strings (expr_str_p, right_parenthesis_str_p);
     ecma_deref_ecma_string (expr_str_p);
@@ -164,9 +164,9 @@ ecma_builtin_function_helper_get_function_expression (const ecma_value_t *argume
   ecma_deref_ecma_string (function_kw_str_p);
   ecma_deref_ecma_string (empty_str_p);
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (expr_str_p));
+    ret_value = ecma_make_string_value (expr_str_p);
   }
   else
   {
@@ -182,15 +182,15 @@ ecma_builtin_function_helper_get_function_expression (const ecma_value_t *argume
  * See also:
  *          ECMA-262 v5, 15.3.
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_function_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                           ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (arguments_value,
                   ecma_builtin_function_helper_get_function_expression (arguments_list_p,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -1,5 +1,5 @@
 /* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged
+ * Copyright 2015-2016 University of Szeged
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,15 +57,15 @@
  * are outputted as is, using "%c" format argument, and other code points are outputted as "\uhhll",
  * where hh and ll are values of code point's high and low bytes, correspondingly.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_print (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                   const ecma_value_t args[], /**< arguments list */
                                   ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /*
    * TODO:
@@ -73,7 +73,7 @@ ecma_builtin_global_object_print (ecma_value_t this_arg __attr_unused___, /**< t
    */
 
   for (ecma_length_t arg_index = 0;
-       ecma_is_completion_value_empty (ret_value) && arg_index < args_number;
+       ecma_is_value_empty (ret_value) && arg_index < args_number;
        arg_index++)
   {
     ECMA_TRY_CATCH (str_value,
@@ -133,9 +133,9 @@ ecma_builtin_global_object_print (ecma_value_t this_arg __attr_unused___, /**< t
 
   printf ("\n");
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
-    ret_value = ecma_make_normal_completion_value (ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED));
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
   }
 
   return ret_value;
@@ -147,14 +147,14 @@ ecma_builtin_global_object_print (ecma_value_t this_arg __attr_unused___, /**< t
  * See also:
  *          ECMA-262 v5, 15.1.2.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_eval (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                  ecma_value_t x) /**< routine's first argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   bool is_direct_eval = vm_is_direct_eval_form_call ();
 
@@ -172,7 +172,7 @@ ecma_builtin_global_object_eval (ecma_value_t this_arg __attr_unused___, /**< th
   if (!ecma_is_value_string (x))
   {
     /* step 1 */
-    ret_value = ecma_make_normal_completion_value (ecma_copy_value (x, true));
+    ret_value = ecma_copy_value (x, true);
   }
   else
   {
@@ -191,15 +191,15 @@ ecma_builtin_global_object_eval (ecma_value_t this_arg __attr_unused___, /**< th
  * See also:
  *          ECMA-262 v5, 15.1.2.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                       ecma_value_t string, /**< routine's first argument */
                                       ecma_value_t radix) /**< routine's second argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (string_var, ecma_op_to_string (string), ret_value);
@@ -273,7 +273,7 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
         {
           ecma_number_t *ret_num_p = ecma_alloc_number ();
           *ret_num_p = ecma_number_make_nan ();
-          ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+          ret_value = ecma_make_number_value (ret_num_p);
         }
         /* 8.b */
         else if (rad != 16)
@@ -287,7 +287,7 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
         rad = 10;
       }
 
-      if (ecma_is_completion_value_empty (ret_value))
+      if (ecma_is_value_empty (ret_value))
       {
         /* 10. */
         if (strip_prefix)
@@ -341,11 +341,11 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
         {
           ecma_number_t *ret_num_p = ecma_alloc_number ();
           *ret_num_p = ecma_number_make_nan ();
-          ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+          ret_value = ecma_make_number_value (ret_num_p);
         }
       }
 
-      if (ecma_is_completion_value_empty (ret_value))
+      if (ecma_is_value_empty (ret_value))
       {
         ecma_number_t *value_p = ecma_alloc_number ();
         *value_p = 0;
@@ -386,7 +386,7 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
           *value_p *= (ecma_number_t) sign;
         }
 
-        ret_value = ecma_make_normal_completion_value (ecma_make_number_value (value_p));
+        ret_value = ecma_make_number_value (value_p);
       }
 
       ECMA_OP_TO_NUMBER_FINALIZE (radix_num);
@@ -395,7 +395,7 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
     {
       ecma_number_t *ret_num_p = ecma_alloc_number ();
       *ret_num_p = ecma_number_make_nan ();
-      ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+      ret_value = ecma_make_number_value (ret_num_p);
     }
 
     MEM_FINALIZE_LOCAL_ARRAY (string_buff);
@@ -404,7 +404,7 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
   {
     ecma_number_t *ret_num_p = ecma_alloc_number ();
     *ret_num_p = ecma_number_make_nan ();
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+    ret_value = ecma_make_number_value (ret_num_p);
   }
 
   ECMA_FINALIZE (string_var);
@@ -417,14 +417,14 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
  * See also:
  *          ECMA-262 v5, 15.1.2.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                         ecma_value_t string) /**< routine's first argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (string_var, ecma_op_to_string (string), ret_value);
@@ -494,7 +494,7 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
       {
         /* String matched Infinity. */
         *ret_num_p = ecma_number_make_infinity (sign);
-        ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+        ret_value = ecma_make_number_value (ret_num_p);
         break;
       }
     }
@@ -502,7 +502,7 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
     /* Reset to starting position. */
     str_curr_p = start_p;
 
-    if (ecma_is_completion_value_empty (ret_value) && str_curr_p < str_end_p)
+    if (ecma_is_value_empty (ret_value) && str_curr_p < str_end_p)
     {
       current = *str_curr_p;
 
@@ -606,7 +606,7 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
       if (start_p == end_p)
       {
         *ret_num_p = ecma_number_make_nan ();
-        ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+        ret_value = ecma_make_number_value (ret_num_p);
       }
       else
       {
@@ -619,14 +619,14 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
           *ret_num_p *= -1;
         }
 
-        ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+        ret_value = ecma_make_number_value (ret_num_p);
       }
     }
     /* String ended after sign character, or was empty after removing leading whitespace. */
-    else if (ecma_is_completion_value_empty (ret_value))
+    else if (ecma_is_value_empty (ret_value))
     {
       *ret_num_p = ecma_number_make_nan ();
-      ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+      ret_value = ecma_make_number_value (ret_num_p);
     }
     MEM_FINALIZE_LOCAL_ARRAY (string_buff);
   }
@@ -635,7 +635,7 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
   {
     ecma_number_t *ret_num_p = ecma_alloc_number ();
     *ret_num_p = ecma_number_make_nan ();
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+    ret_value = ecma_make_number_value (ret_num_p);
   }
 
   ECMA_FINALIZE (string_var);
@@ -649,21 +649,21 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
  * See also:
  *          ECMA-262 v5, 15.1.2.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_is_nan (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                    ecma_value_t arg) /**< routine's first argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
   bool is_nan = ecma_number_is_nan (arg_num);
 
-  ret_value = ecma_make_simple_completion_value (is_nan ? ECMA_SIMPLE_VALUE_TRUE
-                                                        : ECMA_SIMPLE_VALUE_FALSE);
+  ret_value = ecma_make_simple_value (is_nan ? ECMA_SIMPLE_VALUE_TRUE
+                                             : ECMA_SIMPLE_VALUE_FALSE);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
 
@@ -676,22 +676,22 @@ ecma_builtin_global_object_is_nan (ecma_value_t this_arg __attr_unused___, /**< 
  * See also:
  *          ECMA-262 v5, 15.1.2.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_is_finite (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                       ecma_value_t arg) /**< routine's first argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
   bool is_finite = !(ecma_number_is_nan (arg_num)
                      || ecma_number_is_infinity (arg_num));
 
-  ret_value = ecma_make_simple_completion_value (is_finite ? ECMA_SIMPLE_VALUE_TRUE
-                                                           : ECMA_SIMPLE_VALUE_FALSE);
+  ret_value = ecma_make_simple_value (is_finite ? ECMA_SIMPLE_VALUE_TRUE
+                                                : ECMA_SIMPLE_VALUE_FALSE);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
 
@@ -708,7 +708,7 @@ ecma_builtin_global_object_character_is_in (uint32_t character, /**< character *
                                             const uint8_t *bitset) /**< character set */
 {
   JERRY_ASSERT (character < 128);
-  return (bitset[character >> 3] & (1 << (character & 0x7))) != 0;
+  return (bitset[character >> 3] & (1u << (character & 0x7))) != 0;
 } /* ecma_builtin_global_object_character_is_in */
 
 /*
@@ -748,14 +748,14 @@ static const uint8_t unescaped_uri_component_set[16] =
 /**
  * Helper function to decode URI.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_decode_uri_helper (ecma_value_t uri __attr_unused___, /**< uri argument */
                                               const uint8_t *reserved_uri_bitset) /**< reserved characters bitset */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (string,
                   ecma_op_to_string (uri),
@@ -804,7 +804,7 @@ ecma_builtin_global_object_decode_uri_helper (ecma_value_t uri __attr_unused___,
 
     if (!lit_read_code_point_from_hex (input_char_p + 1, 2, &decoded_byte))
     {
-      ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_URI));
+      ret_value = ecma_raise_uri_error ("");
       break;
     }
 
@@ -836,7 +836,7 @@ ecma_builtin_global_object_decode_uri_helper (ecma_value_t uri __attr_unused___,
     }
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     MEM_DEFINE_LOCAL_ARRAY (output_start_p,
                             output_size,
@@ -860,7 +860,7 @@ ecma_builtin_global_object_decode_uri_helper (ecma_value_t uri __attr_unused___,
 
       if (!lit_read_code_point_from_hex (input_char_p + 1, 2, &decoded_byte))
       {
-        ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_URI));
+        ret_value = ecma_raise_uri_error ("");
         break;
       }
 
@@ -898,7 +898,7 @@ ecma_builtin_global_object_decode_uri_helper (ecma_value_t uri __attr_unused___,
         }
         else
         {
-          ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_URI));
+          ret_value = ecma_raise_uri_error ("");
           break;
         }
 
@@ -932,7 +932,7 @@ ecma_builtin_global_object_decode_uri_helper (ecma_value_t uri __attr_unused___,
         if (!is_valid
             || !lit_is_utf8_string_valid (octets, bytes_count))
         {
-          ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_URI));
+          ret_value = ecma_raise_uri_error ("");
           break;
         }
 
@@ -942,7 +942,7 @@ ecma_builtin_global_object_decode_uri_helper (ecma_value_t uri __attr_unused___,
         if (lit_is_code_point_utf16_high_surrogate (cp)
             || lit_is_code_point_utf16_low_surrogate (cp))
         {
-          ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_URI));
+          ret_value = ecma_raise_uri_error ("");
           break;
         }
 
@@ -950,18 +950,18 @@ ecma_builtin_global_object_decode_uri_helper (ecma_value_t uri __attr_unused___,
       }
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       JERRY_ASSERT (output_start_p + output_size == output_char_p);
 
       if (lit_is_cesu8_string_valid (output_start_p, output_size))
       {
         ecma_string_t *output_string_p = ecma_new_ecma_string_from_utf8 (output_start_p, output_size);
-        ret_value = ecma_make_normal_completion_value (ecma_make_string_value (output_string_p));
+        ret_value = ecma_make_string_value (output_string_p);
       }
       else
       {
-        ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_URI));
+        ret_value = ecma_raise_uri_error ("");
       }
     }
 
@@ -980,10 +980,10 @@ ecma_builtin_global_object_decode_uri_helper (ecma_value_t uri __attr_unused___,
  * See also:
  *          ECMA-262 v5, 15.1.3.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_decode_uri (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                        ecma_value_t encoded_uri) /**< routine's first argument */
 {
@@ -996,10 +996,10 @@ ecma_builtin_global_object_decode_uri (ecma_value_t this_arg __attr_unused___, /
  * See also:
  *          ECMA-262 v5, 15.1.3.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_decode_uri_component (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                                  ecma_value_t encoded_uri_component) /**< routine's
                                                                                       *   first argument */
@@ -1026,14 +1026,14 @@ ecma_builtin_global_object_byte_to_hex (lit_utf8_byte_t *dest_p, /**< destinatio
 /**
  * Helper function to encode URI.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_encode_uri_helper (ecma_value_t uri, /**< uri argument */
                                               const uint8_t *unescaped_uri_bitset_p) /**< unescaped bitset */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (string,
                   ecma_op_to_string (uri),
@@ -1073,7 +1073,7 @@ ecma_builtin_global_object_encode_uri_helper (ecma_value_t uri, /**< uri argumen
 
     if (lit_is_code_point_utf16_low_surrogate (ch))
     {
-      ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_URI));
+      ret_value = ecma_raise_uri_error ("");
       break;
     }
 
@@ -1083,7 +1083,7 @@ ecma_builtin_global_object_encode_uri_helper (ecma_value_t uri, /**< uri argumen
     {
       if (input_char_p == input_end_p)
       {
-        ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_URI));
+        ret_value = ecma_raise_uri_error ("");
         break;
       }
 
@@ -1097,7 +1097,7 @@ ecma_builtin_global_object_encode_uri_helper (ecma_value_t uri, /**< uri argumen
       }
       else
       {
-        ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_URI));
+        ret_value = ecma_raise_uri_error ("");
         break;
       }
     }
@@ -1121,7 +1121,7 @@ ecma_builtin_global_object_encode_uri_helper (ecma_value_t uri, /**< uri argumen
     }
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     MEM_DEFINE_LOCAL_ARRAY (output_start_p,
                             output_length,
@@ -1176,7 +1176,7 @@ ecma_builtin_global_object_encode_uri_helper (ecma_value_t uri, /**< uri argumen
 
     ecma_string_t *output_string_p = ecma_new_ecma_string_from_utf8 (output_start_p, output_length);
 
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (output_string_p));
+    ret_value = ecma_make_string_value (output_string_p);
 
     MEM_FINALIZE_LOCAL_ARRAY (output_start_p);
   }
@@ -1193,10 +1193,10 @@ ecma_builtin_global_object_encode_uri_helper (ecma_value_t uri, /**< uri argumen
  * See also:
  *          ECMA-262 v5, 15.1.3.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_encode_uri (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                        ecma_value_t uri) /**< routine's first argument */
 {
@@ -1209,10 +1209,10 @@ ecma_builtin_global_object_encode_uri (ecma_value_t this_arg __attr_unused___, /
  * See also:
  *          ECMA-262 v5, 15.1.3.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_encode_uri_component (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                                  ecma_value_t uri_component) /**< routine's first argument */
 {
@@ -1249,14 +1249,14 @@ static const uint8_t ecma_escape_set[16] =
  * See also:
  *          ECMA-262 v5, B.2.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_escape (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                    ecma_value_t arg) /**< routine's first argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (string,
                   ecma_op_to_string (arg),
@@ -1356,7 +1356,7 @@ ecma_builtin_global_object_escape (ecma_value_t this_arg __attr_unused___, /**< 
 
   ecma_string_t *output_string_p = ecma_new_ecma_string_from_utf8 (output_start_p, output_length);
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_string_value (output_string_p));
+  ret_value = ecma_make_string_value (output_string_p);
 
   MEM_FINALIZE_LOCAL_ARRAY (output_start_p);
 
@@ -1372,14 +1372,14 @@ ecma_builtin_global_object_escape (ecma_value_t this_arg __attr_unused___, /**< 
  * See also:
  *          ECMA-262 v5, B.2.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_global_object_unescape (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                      ecma_value_t arg) /**< routine's first argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (string, ecma_op_to_string (arg), ret_value);
@@ -1455,7 +1455,7 @@ ecma_builtin_global_object_unescape (ecma_value_t this_arg __attr_unused___, /**
 
   lit_utf8_size_t output_length = (lit_utf8_size_t) (output_char_p - input_start_p);
   ecma_string_t *output_string_p = ecma_new_ecma_string_from_utf8 (input_start_p, output_length);
-  ret_value = ecma_make_normal_completion_value (ecma_make_string_value (output_string_p));
+  ret_value = ecma_make_string_value (output_string_p);
 
   MEM_FINALIZE_LOCAL_ARRAY (input_start_p);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -1,5 +1,5 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -875,10 +875,10 @@ ecma_date_timezone_offset (ecma_number_t time) /**< time value */
  * Used by:
  *         - All Date.prototype.set *routine except Date.prototype.setTime.
  *
- * @return completion value containing the new internal time value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value containing the new internal time value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_date_set_internal_property (ecma_value_t this_arg, /**< this argument */
                                  ecma_number_t day, /**< day */
                                  ecma_number_t time, /**< time */
@@ -903,7 +903,7 @@ ecma_date_set_internal_property (ecma_value_t this_arg, /**< this argument */
                                                                prim_value_prop_p->u.internal_property.value);
   *prim_value_num_p = *value_p;
 
-  return ecma_make_normal_completion_value (ecma_make_number_value (value_p));
+  return ecma_make_number_value (value_p);
 } /* ecma_date_set_internal_property */
 
 /**
@@ -1053,10 +1053,10 @@ ecma_date_value_to_string_common (lit_utf8_byte_t *dest_p, /**< destination buff
  *        - The Date routine.
  *        - The Date.prototype.toString routine.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_date_value_to_string (ecma_number_t datetime_number) /**< datetime */
 {
   /*
@@ -1092,7 +1092,7 @@ ecma_date_value_to_string (ecma_number_t datetime_number) /**< datetime */
   ecma_string_t *date_string_p = ecma_new_ecma_string_from_utf8 (character_buffer,
                                                                  result_string_length);
 
-  return ecma_make_normal_completion_value (ecma_make_string_value (date_string_p));
+  return ecma_make_string_value (date_string_p);
 } /* ecma_date_value_to_string */
 
 /**
@@ -1101,10 +1101,10 @@ ecma_date_value_to_string (ecma_number_t datetime_number) /**< datetime */
  * Used by:
  *        - The Date.prototype.toUTCString routine.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_date_value_to_utc_string (ecma_number_t datetime_number) /**< datetime */
 {
   /*
@@ -1133,7 +1133,7 @@ ecma_date_value_to_utc_string (ecma_number_t datetime_number) /**< datetime */
   ecma_string_t *date_string_p = ecma_new_ecma_string_from_utf8 (character_buffer,
                                                                  result_string_length);
 
-  return ecma_make_normal_completion_value (ecma_make_string_value (date_string_p));
+  return ecma_make_string_value (date_string_p);
 } /* ecma_date_value_to_utc_string */
 
 /**
@@ -1142,10 +1142,10 @@ ecma_date_value_to_utc_string (ecma_number_t datetime_number) /**< datetime */
  * Used by:
  *        - The Date.prototype.toISOString routine.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_date_value_to_iso_string (ecma_number_t datetime_number) /**<datetime */
 {
   /*
@@ -1194,7 +1194,7 @@ ecma_date_value_to_iso_string (ecma_number_t datetime_number) /**<datetime */
   ecma_string_t *date_string_p = ecma_new_ecma_string_from_utf8 (character_buffer,
                                                                  result_string_length);
 
-  return ecma_make_normal_completion_value (ecma_make_string_value (date_string_p));
+  return ecma_make_string_value (date_string_p);
 } /* ecma_date_value_to_iso_string */
 
 /**
@@ -1203,10 +1203,10 @@ ecma_date_value_to_iso_string (ecma_number_t datetime_number) /**<datetime */
  * Used by:
  *        - The Date.prototype.toDateString routine.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_date_value_to_date_string (ecma_number_t datetime_number) /**<datetime */
 {
   /*
@@ -1238,7 +1238,7 @@ ecma_date_value_to_date_string (ecma_number_t datetime_number) /**<datetime */
   ecma_string_t *date_string_p = ecma_new_ecma_string_from_utf8 (character_buffer,
                                                                  result_string_length);
 
-  return ecma_make_normal_completion_value (ecma_make_string_value (date_string_p));
+  return ecma_make_string_value (date_string_p);
 } /* ecma_date_value_to_date_string */
 
 /**
@@ -1247,10 +1247,10 @@ ecma_date_value_to_date_string (ecma_number_t datetime_number) /**<datetime */
  * Used by:
  *        - The Date.prototype.toTimeString routine.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_date_value_to_time_string (ecma_number_t datetime_number) /**<datetime */
 {
   /*
@@ -1281,7 +1281,7 @@ ecma_date_value_to_time_string (ecma_number_t datetime_number) /**<datetime */
   ecma_string_t *time_string_p = ecma_new_ecma_string_from_utf8 (character_buffer,
                                                                  result_string_length);
 
-  return ecma_make_normal_completion_value (ecma_make_string_value (time_string_p));
+  return ecma_make_string_value (time_string_p);
 } /* ecma_date_value_to_time_string */
 
 /**
@@ -1292,13 +1292,13 @@ ecma_date_value_to_time_string (ecma_number_t datetime_number) /**<datetime */
  *        - The Date.prototype.toISOString routine.
  *        - The Date.prototype.toUTCString routine.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_date_get_primitive_value (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (this_arg)
       || ecma_object_get_class_name (ecma_get_object_from_value (this_arg)) != LIT_MAGIC_STRING_DATE_UL)
@@ -1315,7 +1315,7 @@ ecma_date_get_primitive_value (ecma_value_t this_arg) /**< this argument */
     ecma_number_t *prim_value_num_p = ecma_alloc_number ();
     *prim_value_num_p = *ECMA_GET_NON_NULL_POINTER (ecma_number_t,
                                                     prim_value_prop_p->u.internal_property.value);
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (prim_value_num_p));
+    ret_value = ecma_make_number_value (prim_value_num_p);
   }
 
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
@@ -1,5 +1,5 @@
 /* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,10 +155,10 @@ ecma_builtin_helper_json_create_separated_properties (ecma_collection_header_t *
  *         - ecma_builtin_json_object step 10.b
  *         - ecma_builtin_json_array step 10.b
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_helper_json_create_formatted_json (ecma_string_t *left_bracket_p, /**< left bracket*/
                                                 ecma_string_t *right_bracket_p, /**< right bracket*/
                                                 ecma_string_t *stepback_p, /**< stepback*/
@@ -212,7 +212,7 @@ ecma_builtin_helper_json_create_formatted_json (ecma_string_t *left_bracket_p, /
   ecma_deref_ecma_string (final_str_p);
   final_str_p = tmp_str_p;
 
-  return ecma_make_normal_completion_value (ecma_make_string_value (final_str_p));
+  return ecma_make_string_value (final_str_p);
 } /* ecma_builtin_helper_json_create_formatted_json */
 
 /**
@@ -225,10 +225,10 @@ ecma_builtin_helper_json_create_formatted_json (ecma_string_t *left_bracket_p, /
  *         - ecma_builtin_json_object step 10.a
  *         - ecma_builtin_json_array step 10.a
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_helper_json_create_non_formatted_json (ecma_string_t *left_bracket_p, /**< left bracket*/
                                                     ecma_string_t *right_bracket_p, /**< right bracket*/
                                                     ecma_collection_header_t *partial_p) /**< key-value pairs*/
@@ -251,7 +251,7 @@ ecma_builtin_helper_json_create_non_formatted_json (ecma_string_t *left_bracket_
   ecma_deref_ecma_string (properties_str_p);
   properties_str_p = tmp_str_p;
 
-  return ecma_make_normal_completion_value (ecma_make_string_value (properties_str_p));
+  return ecma_make_string_value (properties_str_p);
 } /* ecma_builtin_helper_json_create_non_formatted_json */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -1,5 +1,5 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,24 +26,24 @@
  * @{
  */
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_builtin_helper_object_to_string (const ecma_value_t);
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *, uint32_t);
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_builtin_helper_object_get_properties (ecma_object_t *, bool);
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_builtin_helper_array_concat_value (ecma_object_t *, uint32_t *, ecma_value_t);
 extern uint32_t
 ecma_builtin_helper_array_index_normalize (ecma_number_t, uint32_t);
 extern uint32_t
 ecma_builtin_helper_string_index_normalize (ecma_number_t, uint32_t, bool);
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_builtin_helper_string_prototype_object_index_of (ecma_value_t, ecma_value_t,
                                                       ecma_value_t, bool);
 extern bool
 ecma_builtin_helper_string_find_index (ecma_string_t *, ecma_string_t *, bool, ecma_length_t, ecma_length_t *);
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_builtin_helper_def_prop (ecma_object_t *, ecma_string_t *, ecma_value_t,
                               bool, bool, bool, bool);
 
@@ -108,16 +108,16 @@ extern ecma_number_t ecma_date_make_day (ecma_number_t, ecma_number_t, ecma_numb
 extern ecma_number_t ecma_date_make_date (ecma_number_t, ecma_number_t);
 extern ecma_number_t ecma_date_time_clip (ecma_number_t);
 extern ecma_number_t ecma_date_timezone_offset (ecma_number_t);
-extern ecma_completion_value_t ecma_date_set_internal_property (ecma_value_t, ecma_number_t,
+extern ecma_value_t ecma_date_set_internal_property (ecma_value_t, ecma_number_t,
                                                                 ecma_number_t, ecma_date_timezone_t);
 extern void ecma_date_insert_leading_zeros (ecma_string_t **, ecma_number_t, uint32_t);
 
-extern ecma_completion_value_t ecma_date_value_to_string (ecma_number_t);
-extern ecma_completion_value_t ecma_date_value_to_utc_string (ecma_number_t);
-extern ecma_completion_value_t ecma_date_value_to_iso_string (ecma_number_t);
-extern ecma_completion_value_t ecma_date_value_to_date_string (ecma_number_t);
-extern ecma_completion_value_t ecma_date_value_to_time_string (ecma_number_t);
-extern ecma_completion_value_t ecma_date_get_primitive_value (ecma_value_t);
+extern ecma_value_t ecma_date_value_to_string (ecma_number_t);
+extern ecma_value_t ecma_date_value_to_utc_string (ecma_number_t);
+extern ecma_value_t ecma_date_value_to_iso_string (ecma_number_t);
+extern ecma_value_t ecma_date_value_to_date_string (ecma_number_t);
+extern ecma_value_t ecma_date_value_to_time_string (ecma_number_t);
+extern ecma_value_t ecma_date_get_primitive_value (ecma_value_t);
 
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_DATE_BUILTIN */
 
@@ -147,14 +147,14 @@ typedef struct
 extern bool ecma_has_object_value_in_collection (ecma_collection_header_t *, ecma_value_t);
 extern bool ecma_has_string_value_in_collection (ecma_collection_header_t *, ecma_value_t);
 
-extern ecma_string_t *ecma_builtin_helper_json_create_hex_digit_ecma_string (uint8_t);
-
+extern ecma_string_t *
+ecma_builtin_helper_json_create_hex_digit_ecma_string (uint8_t);
 extern ecma_string_t *
 ecma_builtin_helper_json_create_separated_properties (ecma_collection_header_t *, ecma_string_t *);
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_builtin_helper_json_create_formatted_json (ecma_string_t *, ecma_string_t *, ecma_string_t *,
                                                 ecma_collection_header_t *, ecma_json_stringify_context_t *);
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_builtin_helper_json_create_non_formatted_json (ecma_string_t *, ecma_string_t *, ecma_collection_header_t *);
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
@@ -44,7 +44,7 @@
 #define ROUTINE_ARG_LIST_NON_FIXED ROUTINE_ARG_LIST_0, \
   const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len
 #define ROUTINE(name, c_function_name, args_number, length_prop_value) \
-  static ecma_completion_value_t c_function_name (ROUTINE_ARG_LIST_ ## args_number);
+  static ecma_value_t c_function_name (ROUTINE_ARG_LIST_ ## args_number);
 #include BUILTIN_INC_HEADER_NAME
 #undef ROUTINE_ARG_LIST_NON_FIXED
 #undef ROUTINE_ARG_LIST_3
@@ -270,7 +270,7 @@ TRY_TO_INSTANTIATE_PROPERTY_ROUTINE_NAME (BUILTIN_UNDERSCORED_ID) (ecma_object_t
 
   ecma_named_data_property_assign_value (obj_p, prop_p, value);
 
-  ecma_free_value (value, true);
+  ecma_free_value (value);
 
   return prop_p;
 } /* TRY_TO_INSTANTIATE_PROPERTY_ROUTINE_NAME */
@@ -394,10 +394,10 @@ LIST_LAZY_PROPERTY_NAMES_ROUTINE_NAME (BUILTIN_UNDERSCORED_ID) (ecma_object_t *o
 /**
  * Dispatcher of the built-in's routines
  *
- * @return completion-value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 DISPATCH_ROUTINE_ROUTINE_NAME (BUILTIN_UNDERSCORED_ID) (uint16_t builtin_routine_id, /**< built-in wide routine
                                                                                           identifier */
                                                         ecma_value_t this_arg_value, /**< 'this' argument

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
@@ -1,5 +1,5 @@
 /* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,14 +54,14 @@
  * See also:
  *          ECMA-262 v5, 15.8.2.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_abs (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                               ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
@@ -69,7 +69,7 @@ ecma_builtin_math_object_abs (ecma_value_t this_arg __attr_unused___, /**< 'this
 
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (fabs (arg_num));
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
 
@@ -82,21 +82,21 @@ ecma_builtin_math_object_abs (ecma_value_t this_arg __attr_unused___, /**< 'this
  * See also:
  *          ECMA-262 v5, 15.8.2.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_acos (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
   ecma_number_t *num_p = ecma_alloc_number ();
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (acos (arg_num));
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -108,21 +108,21 @@ ecma_builtin_math_object_acos (ecma_value_t this_arg __attr_unused___, /**< 'thi
  * See also:
  *          ECMA-262 v5, 15.8.2.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_asin (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
   ecma_number_t *num_p = ecma_alloc_number ();
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (asin (arg_num));
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -134,21 +134,21 @@ ecma_builtin_math_object_asin (ecma_value_t this_arg __attr_unused___, /**< 'thi
  * See also:
  *          ECMA-262 v5, 15.8.2.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_atan (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
   ecma_number_t *num_p = ecma_alloc_number ();
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (atan (arg_num));
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -160,15 +160,15 @@ ecma_builtin_math_object_atan (ecma_value_t this_arg __attr_unused___, /**< 'thi
  * See also:
  *          ECMA-262 v5, 15.8.2.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_atan2 (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                 ecma_value_t arg1, /**< first routine's argument */
                                 ecma_value_t arg2) /**< second routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (x, arg1, ret_value);
   ECMA_OP_TO_NUMBER_TRY_CATCH (y, arg2, ret_value);
@@ -176,7 +176,7 @@ ecma_builtin_math_object_atan2 (ecma_value_t this_arg __attr_unused___, /**< 'th
   ecma_number_t *num_p = ecma_alloc_number ();
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (atan2 (x, y));
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (y);
   ECMA_OP_TO_NUMBER_FINALIZE (x);
@@ -189,20 +189,20 @@ ecma_builtin_math_object_atan2 (ecma_value_t this_arg __attr_unused___, /**< 'th
  * See also:
  *          ECMA-262 v5, 15.8.2.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_ceil (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
   ecma_number_t *num_p = ecma_alloc_number ();
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (ceil (arg_num));
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -214,20 +214,20 @@ ecma_builtin_math_object_ceil (ecma_value_t this_arg __attr_unused___, /**< 'thi
  * See also:
  *          ECMA-262 v5, 15.8.2.7
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_cos (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                               ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
   ecma_number_t *num_p = ecma_alloc_number ();
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (cos (arg_num));
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -239,14 +239,14 @@ ecma_builtin_math_object_cos (ecma_value_t this_arg __attr_unused___, /**< 'this
  * See also:
  *          ECMA-262 v5, 15.8.2.8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_exp (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                               ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
@@ -254,7 +254,7 @@ ecma_builtin_math_object_exp (ecma_value_t this_arg __attr_unused___, /**< 'this
 
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (exp (arg_num));
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
 
@@ -267,20 +267,20 @@ ecma_builtin_math_object_exp (ecma_value_t this_arg __attr_unused___, /**< 'this
  * See also:
  *          ECMA-262 v5, 15.8.2.9
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_floor (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                 ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
   ecma_number_t *num_p = ecma_alloc_number ();
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (floor (arg_num));
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -292,14 +292,14 @@ ecma_builtin_math_object_floor (ecma_value_t this_arg __attr_unused___, /**< 'th
  * See also:
  *          ECMA-262 v5, 15.8.2.10
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_log (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                               ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
@@ -307,7 +307,7 @@ ecma_builtin_math_object_log (ecma_value_t this_arg __attr_unused___, /**< 'this
 
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (log (arg_num));
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
 
@@ -320,22 +320,22 @@ ecma_builtin_math_object_log (ecma_value_t this_arg __attr_unused___, /**< 'this
  * See also:
  *          ECMA-262 v5, 15.8.2.11
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_max (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                               const ecma_value_t args[], /**< arguments list */
                               ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ecma_number_t ret_num = ecma_number_make_infinity (true);
 
   bool is_NaN = false;
 
   for (ecma_length_t arg_index = 0;
-       arg_index < args_number && ecma_is_completion_value_empty (ret_value);
+       arg_index < args_number && ecma_is_value_empty (ret_value);
        arg_index++)
   {
     ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, args[arg_index], ret_value);
@@ -386,11 +386,11 @@ ecma_builtin_math_object_max (ecma_value_t this_arg __attr_unused___, /**< 'this
     ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     ecma_number_t *num_p = ecma_alloc_number ();
     *num_p = ret_num;
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+    ret_value = ecma_make_number_value (num_p);
   }
 
   return ret_value;
@@ -402,22 +402,22 @@ ecma_builtin_math_object_max (ecma_value_t this_arg __attr_unused___, /**< 'this
  * See also:
  *          ECMA-262 v5, 15.8.2.12
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_min (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                               const ecma_value_t args[], /**< arguments list */
                               ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ecma_number_t ret_num = ecma_number_make_infinity (false);
 
   bool is_NaN = false;
 
   for (ecma_length_t arg_index = 0;
-       arg_index < args_number && ecma_is_completion_value_empty (ret_value);
+       arg_index < args_number && ecma_is_value_empty (ret_value);
        arg_index++)
   {
     ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, args[arg_index], ret_value);
@@ -468,11 +468,11 @@ ecma_builtin_math_object_min (ecma_value_t this_arg __attr_unused___, /**< 'this
     ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     ecma_number_t *num_p = ecma_alloc_number ();
     *num_p = ret_num;
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+    ret_value = ecma_make_number_value (num_p);
   }
 
   return ret_value;
@@ -484,22 +484,22 @@ ecma_builtin_math_object_min (ecma_value_t this_arg __attr_unused___, /**< 'this
  * See also:
  *          ECMA-262 v5, 15.8.2.13
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_pow (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                               ecma_value_t arg1, /**< first routine's argument */
                               ecma_value_t arg2) /**< second routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (x, arg1, ret_value);
   ECMA_OP_TO_NUMBER_TRY_CATCH (y, arg2, ret_value);
 
   ecma_number_t *num_p = ecma_alloc_number ();
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (pow (x, y));
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (y);
   ECMA_OP_TO_NUMBER_FINALIZE (x);
@@ -513,10 +513,10 @@ ecma_builtin_math_object_pow (ecma_value_t this_arg __attr_unused___, /**< 'this
  * See also:
  *          ECMA-262 v5, 15.8.2.14
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_random (ecma_value_t this_arg __attr_unused___) /**< 'this' argument */
 {
   uint32_t rnd = 1;
@@ -543,7 +543,7 @@ ecma_builtin_math_object_random (ecma_value_t this_arg __attr_unused___) /**< 't
   ecma_number_t *rand_p = ecma_alloc_number ();
   *rand_p = rand;
 
-  return ecma_make_normal_completion_value (ecma_make_number_value (rand_p));
+  return ecma_make_number_value (rand_p);
 } /* ecma_builtin_math_object_random */
 
 /**
@@ -552,14 +552,14 @@ ecma_builtin_math_object_random (ecma_value_t this_arg __attr_unused___) /**< 't
  * See also:
  *          ECMA-262 v5, 15.8.2.15
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_round (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                 ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
@@ -593,7 +593,7 @@ ecma_builtin_math_object_round (ecma_value_t this_arg __attr_unused___, /**< 'th
     }
   }
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
 
@@ -606,20 +606,20 @@ ecma_builtin_math_object_round (ecma_value_t this_arg __attr_unused___, /**< 'th
  * See also:
  *          ECMA-262 v5, 15.8.2.16
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_sin (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                               ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
   ecma_number_t *num_p = ecma_alloc_number ();
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (sin (arg_num));
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -631,20 +631,20 @@ ecma_builtin_math_object_sin (ecma_value_t this_arg __attr_unused___, /**< 'this
  * See also:
  *          ECMA-262 v5, 15.8.2.17
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_sqrt (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
   ecma_number_t *num_p = ecma_alloc_number ();
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (sqrt (arg_num));
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -656,21 +656,21 @@ ecma_builtin_math_object_sqrt (ecma_value_t this_arg __attr_unused___, /**< 'thi
  * See also:
  *          ECMA-262 v5, 15.8.2.18
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_math_object_tan (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                               ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
   ecma_number_t *num_p = ecma_alloc_number ();
   *num_p = DOUBLE_TO_ECMA_NUMBER_T (tan (arg_num));
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+  ret_value = ecma_make_number_value (num_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -1,5 +1,5 @@
 /* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,15 +81,15 @@ ecma_builtin_number_prototype_helper_round (uint64_t digits, /**< actual number 
  * See also:
  *          ECMA-262 v5, 15.7.4.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_number_prototype_object_to_string (ecma_value_t this_arg, /**< this argument */
                                                 const ecma_value_t *arguments_list_p, /**< arguments list */
                                                 ecma_length_t arguments_list_len) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (this_value, ecma_builtin_number_prototype_object_value_of (this_arg), ret_value);
   ecma_number_t this_arg_number = *ecma_get_number_from_value (this_value);
@@ -102,7 +102,7 @@ ecma_builtin_number_prototype_object_to_string (ecma_value_t this_arg, /**< this
   {
     ecma_string_t *ret_str_p = ecma_new_ecma_string_from_number (this_arg_number);
 
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (ret_str_p));
+    ret_value = ecma_make_string_value (ret_str_p);
   }
   else
   {
@@ -120,13 +120,13 @@ ecma_builtin_number_prototype_object_to_string (ecma_value_t this_arg, /**< this
 
     if (radix < 2 || radix > 36)
     {
-      ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_RANGE));
+      ret_value = ecma_raise_range_error ("");
     }
     else if (radix == 10)
     {
       ecma_string_t *ret_str_p = ecma_new_ecma_string_from_number (this_arg_number);
 
-      ret_value = ecma_make_normal_completion_value (ecma_make_string_value (ret_str_p));
+      ret_value = ecma_make_string_value (ret_str_p);
     }
     else
     {
@@ -308,7 +308,7 @@ ecma_builtin_number_prototype_object_to_string (ecma_value_t this_arg, /**< this
 
       JERRY_ASSERT (buff_index <= buff_size);
       ecma_string_t *str_p = ecma_new_ecma_string_from_utf8 (buff, (lit_utf8_size_t) buff_index);
-      ret_value = ecma_make_normal_completion_value (ecma_make_string_value (str_p));
+      ret_value = ecma_make_string_value (str_p);
       MEM_FINALIZE_LOCAL_ARRAY (buff);
     }
     ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
@@ -323,10 +323,10 @@ ecma_builtin_number_prototype_object_to_string (ecma_value_t this_arg, /**< this
  * See also:
  *          ECMA-262 v5, 15.7.4.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_number_prototype_object_to_locale_string (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_builtin_number_prototype_object_to_string (this_arg, NULL, 0);
@@ -338,15 +338,15 @@ ecma_builtin_number_prototype_object_to_locale_string (ecma_value_t this_arg) /*
  * See also:
  *          ECMA-262 v5, 15.7.4.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_number_prototype_object_value_of (ecma_value_t this_arg) /**< this argument */
 {
   if (ecma_is_value_number (this_arg))
   {
-    return ecma_make_normal_completion_value (ecma_copy_value (this_arg, true));
+    return ecma_copy_value (this_arg, true);
   }
   else if (ecma_is_value_object (this_arg))
   {
@@ -363,11 +363,11 @@ ecma_builtin_number_prototype_object_value_of (ecma_value_t this_arg) /**< this 
       ecma_number_t *ret_num_p = ecma_alloc_number ();
       *ret_num_p = *prim_value_num_p;
 
-      return ecma_make_normal_completion_value (ecma_make_number_value (ret_num_p));
+      return ecma_make_number_value (ret_num_p);
     }
   }
 
-  return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+  return ecma_raise_type_error ("");
 } /* ecma_builtin_number_prototype_object_value_of */
 
 /**
@@ -376,14 +376,14 @@ ecma_builtin_number_prototype_object_value_of (ecma_value_t this_arg) /**< this 
  * See also:
  *          ECMA-262 v5, 15.7.4.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this argument */
                                                ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (this_value, ecma_builtin_number_prototype_object_value_of (this_arg), ret_value);
   ecma_number_t this_num = *ecma_get_number_from_value (this_value);
@@ -393,7 +393,7 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
   /* 2. */
   if (arg_num <= -1 || arg_num >= 21)
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_RANGE));
+    ret_value = ecma_raise_range_error ("");
   }
   else
   {
@@ -401,7 +401,7 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
     if (ecma_number_is_nan (this_num))
     {
       ecma_string_t *nan_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAN);
-      ret_value = ecma_make_normal_completion_value (ecma_make_string_value (nan_str_p));
+      ret_value = ecma_make_string_value (nan_str_p);
     }
     else
     {
@@ -425,11 +425,11 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
           ecma_string_t *neg_inf_str_p = ecma_concat_ecma_strings (neg_str_p, infinity_str_p);
           ecma_deref_ecma_string (infinity_str_p);
           ecma_deref_ecma_string (neg_str_p);
-          ret_value = ecma_make_normal_completion_value (ecma_make_string_value (neg_inf_str_p));
+          ret_value = ecma_make_string_value (neg_inf_str_p);
         }
         else
         {
-          ret_value = ecma_make_normal_completion_value (ecma_make_string_value (infinity_str_p));
+          ret_value = ecma_make_string_value (infinity_str_p);
         }
       }
       else
@@ -561,7 +561,7 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
           *p = 0;
           ecma_string_t *str = ecma_new_ecma_string_from_utf8 (buff, (lit_utf8_size_t) (p - buff));
 
-          ret_value = ecma_make_normal_completion_value (ecma_make_string_value (str));
+          ret_value = ecma_make_string_value (str);
           MEM_FINALIZE_LOCAL_ARRAY (buff);
         }
       }
@@ -579,14 +579,14 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
  * See also:
  *          ECMA-262 v5, 15.7.4.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**< this argument */
                                                      ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_value, ecma_builtin_number_prototype_object_value_of (this_arg), ret_value);
@@ -597,7 +597,7 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
   /* 7. */
   if (arg_num <= -1.0 || arg_num >= 21.0)
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_RANGE));
+    ret_value = ecma_raise_range_error ("");
   }
   else
   {
@@ -605,7 +605,7 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
     if (ecma_number_is_nan (this_num))
     {
       ecma_string_t *nan_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAN);
-      ret_value = ecma_make_normal_completion_value (ecma_make_string_value (nan_str_p));
+      ret_value = ecma_make_string_value (nan_str_p);
     }
     else
     {
@@ -629,11 +629,11 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
           ecma_string_t *neg_inf_str_p = ecma_concat_ecma_strings (neg_str_p, infinity_str_p);
           ecma_deref_ecma_string (infinity_str_p);
           ecma_deref_ecma_string (neg_str_p);
-          ret_value = ecma_make_normal_completion_value (ecma_make_string_value (neg_inf_str_p));
+          ret_value = ecma_make_string_value (neg_inf_str_p);
         }
         else
         {
-          ret_value = ecma_make_normal_completion_value (ecma_make_string_value (infinity_str_p));
+          ret_value = ecma_make_string_value (infinity_str_p);
         }
       }
       else
@@ -747,7 +747,7 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
         JERRY_ASSERT (actual_char_p - buff < buffer_size);
         *actual_char_p = '\0';
         ecma_string_t *str = ecma_new_ecma_string_from_utf8 (buff, (lit_utf8_size_t) (actual_char_p - buff));
-        ret_value = ecma_make_normal_completion_value (ecma_make_string_value (str));
+        ret_value = ecma_make_string_value (str);
         MEM_FINALIZE_LOCAL_ARRAY (buff);
       }
     }
@@ -764,14 +764,14 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
  * See also:
  *          ECMA-262 v5, 15.7.4.7
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< this argument */
                                                    ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_value, ecma_builtin_number_prototype_object_value_of (this_arg), ret_value);
@@ -791,7 +791,7 @@ ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< t
     if (ecma_number_is_nan (this_num))
     {
       ecma_string_t *nan_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAN);
-      ret_value = ecma_make_normal_completion_value (ecma_make_string_value (nan_str_p));
+      ret_value = ecma_make_string_value (nan_str_p);
     }
     else
     {
@@ -815,17 +815,17 @@ ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< t
           ecma_string_t *neg_inf_str_p = ecma_concat_ecma_strings (neg_str_p, infinity_str_p);
           ecma_deref_ecma_string (infinity_str_p);
           ecma_deref_ecma_string (neg_str_p);
-          ret_value = ecma_make_normal_completion_value (ecma_make_string_value (neg_inf_str_p));
+          ret_value = ecma_make_string_value (neg_inf_str_p);
         }
         else
         {
-          ret_value = ecma_make_normal_completion_value (ecma_make_string_value (infinity_str_p));
+          ret_value = ecma_make_string_value (infinity_str_p);
         }
       }
       /* 8. */
       else if (arg_num < 1.0 || arg_num >= 22.0)
       {
-        ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_RANGE));
+        ret_value = ecma_raise_range_error ("");
       }
       else
       {
@@ -980,7 +980,7 @@ ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< t
         *actual_char_p = '\0';
         ecma_string_t *str_p = ecma_new_ecma_string_from_utf8 (buff, (lit_utf8_size_t) (actual_char_p - buff));
 
-        ret_value = ecma_make_normal_completion_value (ecma_make_string_value (str_p));
+        ret_value = ecma_make_string_value (str_p);
         MEM_FINALIZE_LOCAL_ARRAY (buff);
       }
     }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
@@ -47,22 +47,22 @@
 /**
  * Handle calling [[Call]] of built-in Number object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_number_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                    ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (arguments_list_len == 0)
   {
     ecma_number_t *zero_num_p = ecma_alloc_number ();
     *zero_num_p = ECMA_NUMBER_ZERO;
 
-    ret_value = ecma_make_normal_completion_value (ecma_make_number_value (zero_num_p));
+    ret_value = ecma_make_number_value (zero_num_p);
   }
   else
   {
@@ -75,9 +75,9 @@ ecma_builtin_number_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
 /**
  * Handle calling [[Construct]] of built-in Number object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_number_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                         ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -88,7 +88,7 @@ ecma_builtin_number_dispatch_construct (const ecma_value_t *arguments_list_p, /*
     ecma_number_t *zero_num_p = ecma_alloc_number ();
     *zero_num_p = ECMA_NUMBER_ZERO;
 
-    ecma_completion_value_t completion = ecma_op_create_number_object (ecma_make_number_value (zero_num_p));
+    ecma_value_t completion = ecma_op_create_number_object (ecma_make_number_value (zero_num_p));
 
     ecma_dealloc_number (zero_num_p);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
@@ -1,5 +1,5 @@
 /* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,10 +51,10 @@
  * See also:
  *          ECMA-262 v5, 15.2.4.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_prototype_object_to_string (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_builtin_helper_object_to_string (this_arg);
@@ -66,10 +66,10 @@ ecma_builtin_object_prototype_object_to_string (ecma_value_t this_arg) /**< this
  * See also:
  *          ECMA-262 v5, 15.2.4.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_prototype_object_value_of (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_op_to_object (this_arg);
@@ -81,13 +81,13 @@ ecma_builtin_object_prototype_object_value_of (ecma_value_t this_arg) /**< this 
  * See also:
  *          ECMA-262 v5, 15.2.4.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_prototype_object_to_locale_string (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t return_value = ecma_make_empty_completion_value ();
+  ecma_value_t return_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   /* 1. */
   ECMA_TRY_CATCH (obj_val,
                   ecma_op_to_object (this_arg),
@@ -104,7 +104,7 @@ ecma_builtin_object_prototype_object_to_locale_string (ecma_value_t this_arg) /*
   /* 3. */
   if (!ecma_op_is_callable (to_string_val))
   {
-    return_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    return_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -127,14 +127,14 @@ ecma_builtin_object_prototype_object_to_locale_string (ecma_value_t this_arg) /*
  * See also:
  *          ECMA-262 v5, 15.2.4.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_prototype_object_has_own_property (ecma_value_t this_arg, /**< this argument */
                                                        ecma_value_t arg) /**< first argument */
 {
-  ecma_completion_value_t return_value = ecma_make_empty_completion_value ();
+  ecma_value_t return_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (to_string_val,
@@ -155,11 +155,11 @@ ecma_builtin_object_prototype_object_has_own_property (ecma_value_t this_arg, /*
 
   if (property_p != NULL)
   {
-    return_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    return_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
   else
   {
-    return_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
+    return_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
   ECMA_FINALIZE (obj_val);
 
@@ -174,20 +174,20 @@ ecma_builtin_object_prototype_object_has_own_property (ecma_value_t this_arg, /*
  * See also:
  *          ECMA-262 v5, 15.2.4.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_prototype_object_is_prototype_of (ecma_value_t this_arg, /**< this argument */
                                                       ecma_value_t arg) /**< routine's first argument */
 {
   /* 1. Is the argument an object? */
   if (!ecma_is_value_object (arg))
   {
-    return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
+    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
 
-  ecma_completion_value_t return_value = ecma_make_empty_completion_value ();
+  ecma_value_t return_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 2. ToObject(this) */
   ECMA_TRY_CATCH (obj_value,
@@ -204,9 +204,8 @@ ecma_builtin_object_prototype_object_is_prototype_of (ecma_value_t this_arg, /**
   ecma_object_t *v_obj_p = ecma_get_object_from_value (v_obj_value);
 
   bool is_prototype_of = ecma_op_object_is_prototype_of (obj_p, v_obj_p);
-  return_value = ecma_make_simple_completion_value (is_prototype_of
-                                                    ? ECMA_SIMPLE_VALUE_TRUE
-                                                    : ECMA_SIMPLE_VALUE_FALSE);
+  return_value = ecma_make_simple_value (is_prototype_of ? ECMA_SIMPLE_VALUE_TRUE
+                                                         : ECMA_SIMPLE_VALUE_FALSE);
   ECMA_FINALIZE (v_obj_value);
 
   ECMA_FINALIZE (obj_value);
@@ -220,14 +219,14 @@ ecma_builtin_object_prototype_object_is_prototype_of (ecma_value_t this_arg, /**
  * See also:
  *          ECMA-262 v5, 15.2.4.7
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_prototype_object_property_is_enumerable (ecma_value_t this_arg, /**< this argument */
                                                              ecma_value_t arg) /**< routine's first argument */
 {
-  ecma_completion_value_t return_value = ecma_make_empty_completion_value ();
+  ecma_value_t return_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (to_string_val,
@@ -251,13 +250,12 @@ ecma_builtin_object_prototype_object_property_is_enumerable (ecma_value_t this_a
   {
     bool is_enumerable = ecma_is_property_enumerable (property_p);
 
-    return_value = ecma_make_simple_completion_value (is_enumerable
-                                                      ? ECMA_SIMPLE_VALUE_TRUE
-                                                      : ECMA_SIMPLE_VALUE_FALSE);
+    return_value = ecma_make_simple_value (is_enumerable ? ECMA_SIMPLE_VALUE_TRUE
+                                                         : ECMA_SIMPLE_VALUE_FALSE);
   }
   else
   {
-    return_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
+    return_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
 
   ECMA_FINALIZE (obj_val);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -1,5 +1,5 @@
 /* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,15 +48,15 @@
 /**
  * Handle calling [[Call]] of built-in Object object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_object_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                    ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (arguments_list_len == 0
       || ecma_is_value_undefined (arguments_list_p[0])
@@ -75,9 +75,9 @@ ecma_builtin_object_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
 /**
  * Handle calling [[Construct]] of built-in Object object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_object_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                         ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -87,20 +87,11 @@ ecma_builtin_object_dispatch_construct (const ecma_value_t *arguments_list_p, /*
   {
     ecma_object_t *obj_p = ecma_op_create_object_object_noarg ();
 
-    return ecma_make_normal_completion_value (ecma_make_object_value (obj_p));
+    return ecma_make_object_value (obj_p);
   }
   else
   {
-    ecma_completion_value_t new_obj_value = ecma_op_create_object_object_arg (arguments_list_p[0]);
-
-    if (!ecma_is_completion_value_normal (new_obj_value))
-    {
-      return new_obj_value;
-    }
-    else
-    {
-      return ecma_make_normal_completion_value (ecma_get_completion_value_value (new_obj_value));
-    }
+    return ecma_op_create_object_object_arg (arguments_list_p[0]);
   }
 } /* ecma_builtin_object_dispatch_construct */
 
@@ -110,19 +101,19 @@ ecma_builtin_object_dispatch_construct (const ecma_value_t *arguments_list_p, /*
  * See also:
  *          ECMA-262 v5, 15.2.3.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_get_prototype_of (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                              ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   if (!ecma_is_value_object (arg))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -132,12 +123,12 @@ ecma_builtin_object_object_get_prototype_of (ecma_value_t this_arg __attr_unused
 
     if (prototype_p)
     {
-      ret_value = ecma_make_normal_completion_value (ecma_make_object_value (prototype_p));
+      ret_value = ecma_make_object_value (prototype_p);
       ecma_ref_object (prototype_p);
     }
     else
     {
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_NULL);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_NULL);
     }
   }
 
@@ -150,19 +141,19 @@ ecma_builtin_object_object_get_prototype_of (ecma_value_t this_arg __attr_unused
  * See also:
  *          ECMA-262 v5, 15.2.3.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_get_own_property_names (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                                    ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (arg))
   {
     /* 1. */
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -180,19 +171,19 @@ ecma_builtin_object_object_get_own_property_names (ecma_value_t this_arg __attr_
  * See also:
  *          ECMA-262 v5, 15.2.3.8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_seal (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                  ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   // 1.
   if (!ecma_is_value_object (arg))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -205,7 +196,7 @@ ecma_builtin_object_object_seal (ecma_value_t this_arg __attr_unused___, /**< 't
     ecma_collection_iterator_init (&iter, props_p);
 
     while (ecma_collection_iterator_next (&iter)
-           && ecma_is_completion_value_empty (ret_value))
+           && ecma_is_value_empty (ret_value))
     {
       ecma_string_t *property_name_p = ecma_get_string_from_value (*iter.current_value_p);
       ecma_property_t *property_p = ecma_op_object_get_own_property (obj_p, property_name_p);
@@ -233,13 +224,13 @@ ecma_builtin_object_object_seal (ecma_value_t this_arg __attr_unused___, /**< 't
 
     ecma_free_values_collection (props_p, true);
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       // 3.
       ecma_set_object_extensible (obj_p, false);
 
       // 4.
-      ret_value = ecma_make_normal_completion_value (ecma_copy_value (arg, true));
+      ret_value = ecma_copy_value (arg, true);
     }
   }
 
@@ -252,19 +243,19 @@ ecma_builtin_object_object_seal (ecma_value_t this_arg __attr_unused___, /**< 't
  * See also:
  *          ECMA-262 v5, 15.2.3.9
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_freeze (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                    ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   // 1.
   if (!ecma_is_value_object (arg))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -278,7 +269,7 @@ ecma_builtin_object_object_freeze (ecma_value_t this_arg __attr_unused___, /**< 
     ecma_collection_iterator_init (&iter, props_p);
 
     while (ecma_collection_iterator_next (&iter)
-           && ecma_is_completion_value_empty (ret_value))
+           && ecma_is_value_empty (ret_value))
     {
       ecma_string_t *property_name_p = ecma_get_string_from_value (*iter.current_value_p);
       ecma_property_t *property_p = ecma_op_object_get_own_property (obj_p, property_name_p);
@@ -312,13 +303,13 @@ ecma_builtin_object_object_freeze (ecma_value_t this_arg __attr_unused___, /**< 
 
     ecma_free_values_collection (props_p, true);
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       // 3.
       ecma_set_object_extensible (obj_p, false);
 
       // 4.
-      ret_value = ecma_make_normal_completion_value (ecma_copy_value (arg, true));
+      ret_value = ecma_copy_value (arg, true);
     }
   }
 
@@ -331,25 +322,25 @@ ecma_builtin_object_object_freeze (ecma_value_t this_arg __attr_unused___, /**< 
  * See also:
  *          ECMA-262 v5, 15.2.3.10
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_prevent_extensions (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                                ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (arg))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
     ecma_object_t *obj_p = ecma_get_object_from_value (arg);
     ecma_set_object_extensible (obj_p, false);
 
-    ret_value = ecma_make_normal_completion_value (ecma_copy_value (arg, true));
+    ret_value = ecma_copy_value (arg, true);
   }
 
   return ret_value;
@@ -361,19 +352,19 @@ ecma_builtin_object_object_prevent_extensions (ecma_value_t this_arg __attr_unus
  * See also:
  *          ECMA-262 v5, 15.2.3.11
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_is_sealed (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                       ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   // 1.
   if (!ecma_is_value_object (arg))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -416,9 +407,8 @@ ecma_builtin_object_object_is_sealed (ecma_value_t this_arg __attr_unused___, /*
     }
 
     // 4.
-    ret_value = ecma_make_simple_completion_value (is_sealed
-                                                   ? ECMA_SIMPLE_VALUE_TRUE
-                                                   : ECMA_SIMPLE_VALUE_FALSE);
+    ret_value = ecma_make_simple_value (is_sealed ? ECMA_SIMPLE_VALUE_TRUE
+                                                  : ECMA_SIMPLE_VALUE_FALSE);
   }
 
   return ret_value;
@@ -430,19 +420,19 @@ ecma_builtin_object_object_is_sealed (ecma_value_t this_arg __attr_unused___, /*
  * See also:
  *          ECMA-262 v5, 15.2.3.12
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_is_frozen (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                       ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   // 1.
   if (!ecma_is_value_object (arg))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -493,9 +483,8 @@ ecma_builtin_object_object_is_frozen (ecma_value_t this_arg __attr_unused___, /*
     }
 
     // 4.
-    ret_value = ecma_make_simple_completion_value (is_frozen
-                                                   ? ECMA_SIMPLE_VALUE_TRUE
-                                                   : ECMA_SIMPLE_VALUE_FALSE);
+    ret_value = ecma_make_simple_value (is_frozen ? ECMA_SIMPLE_VALUE_TRUE
+                                                  : ECMA_SIMPLE_VALUE_FALSE);
   }
 
   return ret_value;
@@ -507,18 +496,18 @@ ecma_builtin_object_object_is_frozen (ecma_value_t this_arg __attr_unused___, /*
  * See also:
  *          ECMA-262 v5, 15.2.3.13
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_is_extensible (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                           ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (arg))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -526,8 +515,7 @@ ecma_builtin_object_object_is_extensible (ecma_value_t this_arg __attr_unused___
 
     bool extensible = ecma_get_object_extensible (obj_p);
 
-    ret_value = ecma_make_simple_completion_value (extensible
-                                                   ? ECMA_SIMPLE_VALUE_TRUE
+    ret_value = ecma_make_simple_value (extensible ? ECMA_SIMPLE_VALUE_TRUE
                                                    : ECMA_SIMPLE_VALUE_FALSE);
   }
 
@@ -540,19 +528,19 @@ ecma_builtin_object_object_is_extensible (ecma_value_t this_arg __attr_unused___
  * See also:
  *          ECMA-262 v5, 15.2.3.14
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_keys (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                  ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (arg))
   {
     /* 1. */
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -570,20 +558,20 @@ ecma_builtin_object_object_keys (ecma_value_t this_arg __attr_unused___, /**< 't
  * See also:
  *          ECMA-262 v5, 15.2.3.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_get_own_property_descriptor (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                                         ecma_value_t arg1, /**< routine's first argument */
                                                         ecma_value_t arg2) /**< routine's second argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   // 1.
   if (!ecma_is_value_object (arg1))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
     return ret_value;
   }
 
@@ -608,11 +596,11 @@ ecma_builtin_object_object_get_own_property_descriptor (ecma_value_t this_arg __
 
     ecma_free_property_descriptor (&prop_desc);
 
-    ret_value = ecma_make_normal_completion_value (ecma_make_object_value (desc_obj_p));
+    ret_value = ecma_make_object_value (desc_obj_p);
   }
   else
   {
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
   }
 
   ECMA_FINALIZE (name_str_value);
@@ -626,20 +614,20 @@ ecma_builtin_object_object_get_own_property_descriptor (ecma_value_t this_arg __
  * See also:
  *          ECMA-262 v5, 15.2.3.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_create (ecma_value_t this_arg, /**< 'this' argument */
                                    ecma_value_t arg1, /**< routine's first argument */
                                    ecma_value_t arg2) /**< routine's second argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   // 1.
   if (!ecma_is_value_object (arg1) && !ecma_is_value_null (arg1))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -664,10 +652,9 @@ ecma_builtin_object_object_create (ecma_value_t this_arg, /**< 'this' argument *
     }
 
     // 5.
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
-      ret_value = ecma_make_normal_completion_value (ecma_copy_value (ecma_make_object_value (result_obj_p),
-                                                                      true));
+      ret_value = ecma_copy_value (ecma_make_object_value (result_obj_p), true);
     }
 
     ecma_deref_object (result_obj_p);
@@ -682,20 +669,20 @@ ecma_builtin_object_object_create (ecma_value_t this_arg, /**< 'this' argument *
  * See also:
  *          ECMA-262 v5, 15.2.3.7
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_define_properties (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                               ecma_value_t arg1, /**< routine's first argument */
                                               ecma_value_t arg2) /**< routine's second argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   // 1.
   if (!ecma_is_value_object (arg1))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -720,7 +707,7 @@ ecma_builtin_object_object_define_properties (ecma_value_t this_arg __attr_unuse
     uint32_t property_descriptor_number = 0;
 
     while (ecma_collection_iterator_next (&iter)
-           && ecma_is_completion_value_empty (ret_value))
+           && ecma_is_value_empty (ret_value))
     {
       // 5.a
       ECMA_TRY_CATCH (desc_obj,
@@ -742,7 +729,7 @@ ecma_builtin_object_object_define_properties (ecma_value_t this_arg __attr_unuse
     // 6.
     ecma_collection_iterator_init (&iter, prop_names_p);
     for (uint32_t index = 0;
-         index < property_number && ecma_is_completion_value_empty (ret_value);
+         index < property_number && ecma_is_value_empty (ret_value);
          index++)
     {
       bool is_next = ecma_collection_iterator_next (&iter);
@@ -771,9 +758,9 @@ ecma_builtin_object_object_define_properties (ecma_value_t this_arg __attr_unuse
     ecma_free_values_collection (prop_names_p, true);
 
     // 7.
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
-      ret_value = ecma_make_normal_completion_value (ecma_copy_value (arg1, true));
+      ret_value = ecma_copy_value (arg1, true);
     }
 
     ECMA_FINALIZE (props);
@@ -788,20 +775,20 @@ ecma_builtin_object_object_define_properties (ecma_value_t this_arg __attr_unuse
  * See also:
  *          ECMA-262 v5, 15.2.3.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_object_object_define_property (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                             ecma_value_t arg1, /**< routine's first argument */
                                             ecma_value_t arg2, /**< routine's second argument */
                                             ecma_value_t arg3) /**< routine's third argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (arg1))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -826,7 +813,7 @@ ecma_builtin_object_object_define_property (ecma_value_t this_arg __attr_unused_
                                                         true),
                     ret_value);
 
-    ret_value = ecma_make_normal_completion_value (ecma_copy_value (arg1, true));
+    ret_value = ecma_copy_value (arg1, true);
 
     ECMA_FINALIZE (define_own_prop_ret);
     ecma_free_property_descriptor (&prop_desc);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror.c
@@ -46,9 +46,9 @@
 /**
  * Handle calling [[Call]] of built-in RangeError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_range_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                         ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -57,7 +57,7 @@ ecma_builtin_range_error_dispatch_call (const ecma_value_t *arguments_list_p, /*
   if (arguments_list_len != 0
       && !ecma_is_value_undefined (arguments_list_p[0]))
   {
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (msg_str_value,
                     ecma_op_to_string (arguments_list_p[0]),
@@ -66,7 +66,7 @@ ecma_builtin_range_error_dispatch_call (const ecma_value_t *arguments_list_p, /*
     ecma_string_t *message_string_p = ecma_get_string_from_value (msg_str_value);
     ecma_object_t *new_error_object_p = ecma_new_standard_error_with_message (ECMA_ERROR_RANGE,
                                                                               message_string_p);
-    ret_value = ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    ret_value = ecma_make_object_value (new_error_object_p);
 
     ECMA_FINALIZE (msg_str_value);
 
@@ -76,16 +76,16 @@ ecma_builtin_range_error_dispatch_call (const ecma_value_t *arguments_list_p, /*
   {
     ecma_object_t *new_error_object_p = ecma_new_standard_error (ECMA_ERROR_RANGE);
 
-    return ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    return ecma_make_object_value (new_error_object_p);
   }
 } /* ecma_builtin_range_error_dispatch_call */
 
 /**
  * Handle calling [[Construct]] of built-in RangeError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_range_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                              ecma_length_t arguments_list_len) /**< number of arguments */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror.c
@@ -46,9 +46,9 @@
 /**
  * Handle calling [[Call]] of built-in ReferenceError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_reference_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                             ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -57,7 +57,7 @@ ecma_builtin_reference_error_dispatch_call (const ecma_value_t *arguments_list_p
   if (arguments_list_len != 0
       && !ecma_is_value_undefined (arguments_list_p[0]))
   {
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (msg_str_value,
                     ecma_op_to_string (arguments_list_p[0]),
@@ -66,7 +66,7 @@ ecma_builtin_reference_error_dispatch_call (const ecma_value_t *arguments_list_p
     ecma_string_t *message_string_p = ecma_get_string_from_value (msg_str_value);
     ecma_object_t *new_error_object_p = ecma_new_standard_error_with_message (ECMA_ERROR_REFERENCE,
                                                                               message_string_p);
-    ret_value = ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    ret_value = ecma_make_object_value (new_error_object_p);
 
     ECMA_FINALIZE (msg_str_value);
 
@@ -76,16 +76,16 @@ ecma_builtin_reference_error_dispatch_call (const ecma_value_t *arguments_list_p
   {
     ecma_object_t *new_error_object_p = ecma_new_standard_error (ECMA_ERROR_REFERENCE);
 
-    return ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    return ecma_make_object_value (new_error_object_p);
   }
 } /* ecma_builtin_reference_error_dispatch_call */
 
 /**
  * Handle calling [[Construct]] of built-in ReferenceError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_reference_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                                  ecma_length_t arguments_list_len) /**< number of arguments */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -53,15 +53,15 @@
  * See also:
  *          ECMA-262 v5, B.2.5.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument */
                                        ecma_value_t pattern_arg, /**< pattern or RegExp object */
                                        ecma_value_t flags_arg) /**< flags */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (this_arg)
       || ecma_object_get_class_name (ecma_get_object_from_value (this_arg)) != LIT_MAGIC_STRING_REGEXP_UL)
@@ -131,9 +131,9 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
          * we can't copy it without knowing its length."
          */
         re_compiled_code_t *new_bc_p = NULL;
-        ecma_completion_value_t bc_comp = re_compile_bytecode (&new_bc_p, pattern_string_p, flags);
+        ecma_value_t bc_comp = re_compile_bytecode (&new_bc_p, pattern_string_p, flags);
         /* Should always succeed, since we're compiling from a source that has been compiled previously. */
-        JERRY_ASSERT (ecma_is_completion_value_empty (bc_comp));
+        JERRY_ASSERT (ecma_is_value_empty (bc_comp));
 
         re_compiled_code_t *old_bc_p = ECMA_GET_POINTER (re_compiled_code_t,
                                                          bc_prop_p->u.internal_property.value);
@@ -147,7 +147,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
 
         re_initialize_props (this_obj_p, pattern_string_p, flags);
 
-        ret_value = ecma_make_normal_completion_value (ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED));
+        ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 
         ECMA_FINALIZE (obj_this);
       }
@@ -178,7 +178,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
       }
 
       /* Parse flags. */
-      if (ecma_is_completion_value_empty (ret_value) && !ecma_is_value_undefined (flags_arg))
+      if (ecma_is_value_empty (ret_value) && !ecma_is_value_undefined (flags_arg))
       {
         ECMA_TRY_CATCH (flags_str_value,
                         ecma_op_to_string (flags_arg),
@@ -191,7 +191,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
         ECMA_FINALIZE (flags_str_value);
       }
 
-      if (ecma_is_completion_value_empty (ret_value))
+      if (ecma_is_value_empty (ret_value))
       {
         ECMA_TRY_CATCH (obj_this, ecma_op_to_object (this_arg), ret_value);
         ecma_object_t *this_obj_p = ecma_get_object_from_value (obj_this);
@@ -215,7 +215,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
 
         ECMA_SET_POINTER (bc_prop_p->u.internal_property.value, new_bc_p);
         re_initialize_props (this_obj_p, pattern_string_p, flags);
-        ret_value = ecma_make_normal_completion_value (ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED));
+        ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 
         ECMA_FINALIZE (bc_dummy);
 
@@ -240,14 +240,14 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
  * See also:
  *          ECMA-262 v5, 15.10.6.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_regexp_prototype_exec (ecma_value_t this_arg, /**< this argument */
                                     ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (this_arg)
       || ecma_object_get_class_name (ecma_get_object_from_value (this_arg)) != LIT_MAGIC_STRING_REGEXP_UL)
@@ -271,8 +271,8 @@ ecma_builtin_regexp_prototype_exec (ecma_value_t this_arg, /**< this argument */
     if (bytecode_p == NULL)
     {
       /* Missing bytecode means empty RegExp: '/(?:)/', so always return empty string. */
-      ecma_completion_value_t result_array = ecma_op_create_array_object (0, 0, false);
-      ecma_object_t *result_array_obj_p = ecma_get_object_from_completion_value (result_array);
+      ecma_value_t result_array = ecma_op_create_array_object (0, 0, false);
+      ecma_object_t *result_array_obj_p = ecma_get_object_from_value (result_array);
       ecma_string_t *input_str_p = ecma_get_string_from_value (input_str_value);
       re_set_result_array_properties (result_array_obj_p,
                                       input_str_p,
@@ -314,14 +314,14 @@ ecma_builtin_regexp_prototype_exec (ecma_value_t this_arg, /**< this argument */
  * See also:
  *          ECMA-262 v5, 15.10.6.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_regexp_prototype_test (ecma_value_t this_arg, /**< this argument */
                                     ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (match_value,
                   ecma_builtin_regexp_prototype_exec (this_arg, arg),
@@ -329,11 +329,11 @@ ecma_builtin_regexp_prototype_test (ecma_value_t this_arg, /**< this argument */
 
   if (ecma_is_value_null (match_value))
   {
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
   else
   {
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
 
   ECMA_FINALIZE (match_value);
@@ -347,13 +347,13 @@ ecma_builtin_regexp_prototype_test (ecma_value_t this_arg, /**< this argument */
  * See also:
  *          ECMA-262 v5, 15.10.6.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (this_arg)
       || ecma_object_get_class_name (ecma_get_object_from_value (this_arg)) != LIT_MAGIC_STRING_REGEXP_UL)
@@ -425,7 +425,7 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
       output_str_p = concat_p;
     }
 
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (output_str_p));
+    ret_value = ecma_make_string_value (output_str_p);
 
     ECMA_FINALIZE (obj_this);
   }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
@@ -1,5 +1,5 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,9 +45,9 @@
 /**
  * Handle calling [[Call]] of built-in RegExp object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_regexp_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                    ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -57,13 +57,13 @@ ecma_builtin_regexp_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
 /**
  * Handle calling [[Construct]] of built-in RegExp object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_regexp_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                         ecma_length_t arguments_list_len) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_value_t pattern_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
   ecma_value_t flags_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 
@@ -83,7 +83,7 @@ ecma_builtin_regexp_dispatch_construct (const ecma_value_t *arguments_list_p, /*
   {
     if (ecma_is_value_undefined (flags_value))
     {
-      ret_value = ecma_make_normal_completion_value (ecma_copy_value (pattern_value, true));
+      ret_value = ecma_copy_value (pattern_value, true);
     }
     else
     {
@@ -117,7 +117,7 @@ ecma_builtin_regexp_dispatch_construct (const ecma_value_t *arguments_list_p, /*
       pattern_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_EMPTY_NON_CAPTURE_GROUP);
     }
 
-    if (ecma_is_completion_value_empty (ret_value) && !ecma_is_value_undefined (flags_value))
+    if (ecma_is_value_empty (ret_value) && !ecma_is_value_undefined (flags_value))
     {
       ECMA_TRY_CATCH (flags_str_value,
                       ecma_op_to_string (flags_value),
@@ -127,7 +127,7 @@ ecma_builtin_regexp_dispatch_construct (const ecma_value_t *arguments_list_p, /*
       ECMA_FINALIZE (flags_str_value);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       ret_value = ecma_op_create_regexp_object (pattern_string_p, flags_string_p);
     }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1,5 +1,5 @@
 /* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,15 +60,15 @@
  * See also:
  *          ECMA-262 v5, 15.5.4.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_to_string (ecma_value_t this_arg) /**< this argument */
 {
   if (ecma_is_value_string (this_arg))
   {
-    return ecma_make_normal_completion_value (ecma_copy_value (this_arg, true));
+    return ecma_copy_value (this_arg, true);
   }
   else if (ecma_is_value_object (this_arg))
   {
@@ -84,11 +84,11 @@ ecma_builtin_string_prototype_object_to_string (ecma_value_t this_arg) /**< this
 
       prim_value_str_p = ecma_copy_or_ref_ecma_string (prim_value_str_p);
 
-      return ecma_make_normal_completion_value (ecma_make_string_value (prim_value_str_p));
+      return ecma_make_string_value (prim_value_str_p);
     }
   }
 
-  return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+  return ecma_raise_type_error ("");
 } /* ecma_builtin_string_prototype_object_to_string */
 
 /**
@@ -97,10 +97,10 @@ ecma_builtin_string_prototype_object_to_string (ecma_value_t this_arg) /**< this
  * See also:
  *          ECMA-262 v5, 15.5.4.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_value_of (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_builtin_string_prototype_object_to_string (this_arg);
@@ -112,14 +112,14 @@ ecma_builtin_string_prototype_object_value_of (ecma_value_t this_arg) /**< this 
  * See also:
  *          ECMA-262 v5, 15.5.4.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_char_at (ecma_value_t this_arg, /**< this argument */
                                               ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1 */
   ECMA_TRY_CATCH (check_coercible_val,
@@ -143,15 +143,13 @@ ecma_builtin_string_prototype_object_char_at (ecma_value_t this_arg, /**< this a
   /* 5 */
   if (index_num < 0 || index_num >= len || !len)
   {
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (
-                                                   ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY)));
+    ret_value = ecma_make_string_value (ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY));
   }
   else
   {
     /* 6 */
     ecma_char_t new_ecma_char = ecma_string_get_char_at_pos (original_string_p, ecma_number_to_uint32 (index_num));
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (
-                                                   ecma_new_ecma_string_from_code_unit (new_ecma_char)));
+    ret_value = ecma_make_string_value (ecma_new_ecma_string_from_code_unit (new_ecma_char));
   }
 
   ECMA_OP_TO_NUMBER_FINALIZE (index_num);
@@ -168,14 +166,14 @@ ecma_builtin_string_prototype_object_char_at (ecma_value_t this_arg, /**< this a
  * See also:
  *          ECMA-262 v5, 15.5.4.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_char_code_at (ecma_value_t this_arg, /**< this argument */
                                                    ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1 */
   ECMA_TRY_CATCH (check_coercible_val,
@@ -220,7 +218,7 @@ ecma_builtin_string_prototype_object_char_code_at (ecma_value_t this_arg, /**< t
   }
 
   ecma_value_t new_value = ecma_make_number_value (ret_num_p);
-  ret_value = ecma_make_normal_completion_value (new_value);
+  ret_value = new_value;
 
   ECMA_OP_TO_NUMBER_FINALIZE (index_num);
 
@@ -236,15 +234,15 @@ ecma_builtin_string_prototype_object_char_code_at (ecma_value_t this_arg, /**< t
  * See also:
  *          ECMA-262 v5, 15.5.4.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_concat (ecma_value_t this_arg, /**< this argument */
                                              const ecma_value_t *argument_list_p, /**< arguments list */
                                              ecma_length_t arguments_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1 */
   ECMA_TRY_CATCH (check_coercible_val,
@@ -264,7 +262,7 @@ ecma_builtin_string_prototype_object_concat (ecma_value_t this_arg, /**< this ar
 
   /* 5 */
   for (uint32_t arg_index = 0;
-       arg_index < arguments_number && ecma_is_completion_value_empty (ret_value);
+       arg_index < arguments_number && ecma_is_value_empty (ret_value);
        ++arg_index)
   {
     /* 5a */
@@ -283,9 +281,9 @@ ecma_builtin_string_prototype_object_concat (ecma_value_t this_arg, /**< this ar
   }
 
   /* 6 */
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (string_to_return));
+    ret_value = ecma_make_string_value (string_to_return);
   }
   else
   {
@@ -304,10 +302,10 @@ ecma_builtin_string_prototype_object_concat (ecma_value_t this_arg, /**< this ar
  * See also:
  *          ECMA-262 v5, 15.5.4.7
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_index_of (ecma_value_t this_arg, /**< this argument */
                                                ecma_value_t arg1, /**< routine's first argument */
                                                ecma_value_t arg2) /**< routine's second argument */
@@ -321,10 +319,10 @@ ecma_builtin_string_prototype_object_index_of (ecma_value_t this_arg, /**< this 
  * See also:
  *          ECMA-262 v5, 15.5.4.8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_last_index_of (ecma_value_t this_arg, /**< this argument */
                                                     ecma_value_t arg1, /**< routine's first argument */
                                                     ecma_value_t arg2) /**< routine's second argument */
@@ -338,14 +336,14 @@ ecma_builtin_string_prototype_object_last_index_of (ecma_value_t this_arg, /**< 
  * See also:
  *          ECMA-262 v5, 15.5.4.9
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_locale_compare (ecma_value_t this_arg, /**< this argument */
                                                      ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_check_coercible_val,
@@ -380,7 +378,7 @@ ecma_builtin_string_prototype_object_locale_compare (ecma_value_t this_arg, /**<
     *result_p = ecma_int32_to_number (0);
   }
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (result_p));
+  ret_value = ecma_make_number_value (result_p);
 
   ECMA_FINALIZE (arg_to_string_val);
   ECMA_FINALIZE (this_to_string_val);
@@ -397,14 +395,14 @@ ecma_builtin_string_prototype_object_locale_compare (ecma_value_t this_arg, /**<
  * See also:
  *          ECMA-262 v5, 15.5.4.10
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this argument */
                                             ecma_value_t arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_check_coercible_value,
@@ -436,7 +434,7 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
     ECMA_FINALIZE (new_regexp_value);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     JERRY_ASSERT (!ecma_is_value_empty (regexp_value));
     ecma_object_t *regexp_obj_p = ecma_get_object_from_value (regexp_value);
@@ -449,7 +447,7 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
 
     JERRY_ASSERT (ecma_is_value_boolean (global_value));
 
-    if (!ecma_is_value_true (global_value))
+    if (ecma_is_value_false (global_value))
     {
       /* 7. */
       ret_value = ecma_regexp_exec_helper (regexp_value, this_to_string_value, false);
@@ -485,10 +483,8 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
       /* 8.e. */
       bool last_match = true;
 
-      //ecma_completion_value_t exec_result = ecma_make_empty_completion_value ();
-
       /* 8.f. */
-      while (last_match && ecma_is_completion_value_empty (ret_value))
+      while (last_match && ecma_is_value_empty (ret_value))
       {
         /* 8.f.i. */
         ECMA_TRY_CATCH (exec_value,
@@ -539,7 +535,7 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
             previous_last_index = this_index;
           }
 
-          if (ecma_is_completion_value_empty (ret_value))
+          if (ecma_is_value_empty (ret_value))
           {
             /* 8.f.iii.4. */
             JERRY_ASSERT (ecma_is_value_object (exec_value));
@@ -552,15 +548,15 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
             ecma_string_t *current_index_str_p = ecma_new_ecma_string_from_uint32 (n);
 
             /* 8.f.iii.5. */
-            ecma_completion_value_t completion = ecma_builtin_helper_def_prop (new_array_obj_p,
-                                                                               current_index_str_p,
-                                                                               match_string_value,
-                                                                               true, /* Writable */
-                                                                               true, /* Enumerable */
-                                                                               true, /* Configurable */
-                                                                               false); /* Failure handling */
+            ecma_value_t completion = ecma_builtin_helper_def_prop (new_array_obj_p,
+                                                                    current_index_str_p,
+                                                                    match_string_value,
+                                                                    true, /* Writable */
+                                                                    true, /* Enumerable */
+                                                                    true, /* Configurable */
+                                                                    false); /* Failure handling */
 
-            JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+            JERRY_ASSERT (ecma_is_value_true (completion));
 
             ecma_deref_ecma_string (current_index_str_p);
 
@@ -578,17 +574,17 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
         ECMA_FINALIZE (exec_value);
       }
 
-      if (ecma_is_completion_value_empty (ret_value))
+      if (ecma_is_value_empty (ret_value))
       {
         if (n == 0)
         {
           /* 8.g. */
-          ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_NULL);
+          ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_NULL);
         }
         else
         {
           /* 8.h. */
-          ret_value = ecma_make_normal_completion_value (ecma_copy_value (new_array_value, true));
+          ret_value = ecma_copy_value (new_array_value, true);
         }
       }
 
@@ -605,7 +601,7 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
 
     ecma_deref_ecma_string (global_string_p);
 
-    ecma_free_value (regexp_value, true);
+    ecma_free_value (regexp_value);
   }
 
   ECMA_FINALIZE (this_to_string_value);
@@ -685,14 +681,14 @@ ecma_builtin_string_prototype_object_replace_append_substr (ecma_string_t *base_
 /**
  * Generic helper function to perform the find the next match
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_replace_match (ecma_builtin_replace_search_ctx_t *context_p) /**< search
                                                                                                    * context */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   context_p->match_start = 0;
   context_p->match_end = 0;
@@ -737,7 +733,7 @@ ecma_builtin_string_prototype_object_replace_match (ecma_builtin_replace_search_
 
       JERRY_ASSERT ((ecma_length_t) ecma_number_to_uint32 (*index_number_p) == context_p->match_start);
 
-      ret_value = ecma_make_normal_completion_value (ecma_copy_value (match_value, true));
+      ret_value = ecma_copy_value (match_value, true);
 
       ECMA_FINALIZE (result_string_value);
       ECMA_FINALIZE (index_value);
@@ -746,7 +742,7 @@ ecma_builtin_string_prototype_object_replace_match (ecma_builtin_replace_search_
     }
     else
     {
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_NULL);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_NULL);
     }
 
     ECMA_FINALIZE (match_value);
@@ -769,13 +765,13 @@ ecma_builtin_string_prototype_object_replace_match (ecma_builtin_replace_search_
       context_p->match_start = index_of;
       context_p->match_end = index_of + ecma_string_get_length (search_string_p);
 
-      ret_value = ecma_make_normal_completion_value (ecma_copy_value (new_array_value, true));
+      ret_value = ecma_copy_value (new_array_value, true);
 
       ECMA_FINALIZE (new_array_value);
     }
     else
     {
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_NULL);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_NULL);
     }
   }
 
@@ -785,15 +781,15 @@ ecma_builtin_string_prototype_object_replace_match (ecma_builtin_replace_search_
 /**
  * Generic helper function to construct the string which replaces the matched part
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_search_ctx_t *context_p, /**< search
                                                                                                         * context */
                                                          ecma_value_t match_value) /**< returned match value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_string_t *length_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
   ecma_object_t *match_object_p = ecma_get_object_from_value (match_value);
 
@@ -820,7 +816,7 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
     ecma_length_t values_copied = 0;
 
     for (ecma_length_t i = 0;
-         (i < match_length) && ecma_is_completion_value_empty (ret_value);
+         (i < match_length) && ecma_is_value_empty (ret_value);
          i++)
     {
       ecma_string_t *index_p = ecma_new_ecma_string_from_uint32 (i);
@@ -835,7 +831,7 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
       ecma_deref_ecma_string (index_p);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       ecma_number_t *index_number_p = ecma_alloc_number ();
 
@@ -854,18 +850,18 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
                       ecma_op_to_string (result_value),
                       ret_value);
 
-      ret_value = ecma_make_normal_completion_value (ecma_copy_value (to_string_value, true));
+      ret_value = ecma_copy_value (to_string_value, true);
 
       ECMA_FINALIZE (to_string_value);
       ECMA_FINALIZE (result_value);
 
-      ecma_free_value (arguments_list[match_length + 1], true);
+      ecma_free_value (arguments_list[match_length + 1]);
       ecma_dealloc_number (index_number_p);
     }
 
     for (ecma_length_t i = 0; i < values_copied; i++)
     {
-      ecma_free_value (arguments_list[i], true);
+      ecma_free_value (arguments_list[i]);
     }
 
     MEM_FINALIZE_LOCAL_ARRAY (arguments_list);
@@ -1031,7 +1027,7 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
           ECMA_FINALIZE (submatch_value);
           ecma_deref_ecma_string (index_string_p);
 
-          if (!ecma_is_completion_value_empty (ret_value))
+          if (!ecma_is_value_empty (ret_value))
           {
             break;
           }
@@ -1044,7 +1040,7 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
       current_position++;
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       result_string_p = ecma_builtin_string_prototype_object_replace_append_substr (result_string_p,
                                                                                     context_p->replace_string_p,
@@ -1052,7 +1048,7 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
                                                                                     current_position,
                                                                                     true);
 
-      ret_value = ecma_make_normal_completion_value (ecma_make_string_value (result_string_p));
+      ret_value = ecma_make_string_value (result_string_p);
     }
   }
 
@@ -1065,14 +1061,14 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
 /**
  * Generic helper function to do the string replace
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_replace_loop (ecma_builtin_replace_search_ctx_t *context_p) /**< search
                                                                                                   * context */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_length_t previous_start = 0;
   bool continue_match = true;
 
@@ -1111,7 +1107,7 @@ ecma_builtin_string_prototype_object_replace_loop (ecma_builtin_replace_search_c
       previous_start = context_p->match_end;
 
       if (context_p->is_global
-          && ecma_is_completion_value_empty (ret_value)
+          && ecma_is_value_empty (ret_value)
           && context_p->match_start == context_p->match_end)
       {
         JERRY_ASSERT (context_p->is_regexp);
@@ -1143,7 +1139,7 @@ ecma_builtin_string_prototype_object_replace_loop (ecma_builtin_replace_search_c
       }
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       if (!context_p->is_global || ecma_is_value_null (match_value))
       {
@@ -1155,7 +1151,7 @@ ecma_builtin_string_prototype_object_replace_loop (ecma_builtin_replace_search_c
                                                                                         context_p->input_length,
                                                                                         false);
 
-        ret_value = ecma_make_normal_completion_value (ecma_make_string_value (appended_string_p));
+        ret_value = ecma_make_string_value (appended_string_p);
       }
       else
       {
@@ -1176,15 +1172,15 @@ ecma_builtin_string_prototype_object_replace_loop (ecma_builtin_replace_search_c
  * appropriate fields of the context were filled as well and the search
  * loop is run afterwards.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_replace_main (ecma_builtin_replace_search_ctx_t *context_p, /**< search
                                                                                                   * context */
                                                    ecma_value_t replace_value) /**< replacement for a match */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (ecma_op_is_callable (replace_value))
   {
@@ -1254,15 +1250,15 @@ ecma_builtin_string_prototype_object_replace_main (ecma_builtin_replace_search_c
  * See also:
  *          ECMA-262 v5, 15.5.4.11
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_replace (ecma_value_t this_arg, /**< this argument */
                                               ecma_value_t search_value, /**< routine's first argument */
                                               ecma_value_t replace_value) /**< routine's second argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (check_coercible_val,
@@ -1312,7 +1308,7 @@ ecma_builtin_string_prototype_object_replace (ecma_value_t this_arg, /**< this a
       ecma_deref_ecma_string (last_index_string_p);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       ret_value = ecma_builtin_string_prototype_object_replace_main (&context, replace_value);
     }
@@ -1349,14 +1345,14 @@ ecma_builtin_string_prototype_object_replace (ecma_value_t this_arg, /**< this a
  * See also:
  *          ECMA-262 v5, 15.5.4.12
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_search (ecma_value_t this_arg, /**< this argument */
                                              ecma_value_t regexp_arg) /**< routine's argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (check_coercible_value,
@@ -1391,7 +1387,7 @@ ecma_builtin_string_prototype_object_search (ecma_value_t this_arg, /**< this ar
   }
 
   /* 5. */
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (match_result,
                     ecma_regexp_exec_helper (regexp_value, to_string_value, true),
@@ -1418,16 +1414,16 @@ ecma_builtin_string_prototype_object_search (ecma_value_t this_arg, /**< this ar
       ecma_deref_ecma_string (index_string_p);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       ecma_number_t *offset_number_p = ecma_alloc_number ();
       *offset_number_p = offset;
 
-      ret_value = ecma_make_normal_completion_value (ecma_make_number_value (offset_number_p));
+      ret_value = ecma_make_number_value (offset_number_p);
     }
 
     ECMA_FINALIZE (match_result);
-    ecma_free_value (regexp_value, true);
+    ecma_free_value (regexp_value);
   }
 
   ECMA_FINALIZE (to_string_value);
@@ -1445,15 +1441,15 @@ ecma_builtin_string_prototype_object_search (ecma_value_t this_arg, /**< this ar
  * See also:
  *          ECMA-262 v5, 15.5.4.13
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_slice (ecma_value_t this_arg, /**< this argument */
                                             ecma_value_t arg1, /**< routine's first argument */
                                             ecma_value_t arg2) /**< routine's second argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (check_coercible_val,
@@ -1499,11 +1495,11 @@ ecma_builtin_string_prototype_object_slice (ecma_value_t this_arg, /**< this arg
 
   JERRY_ASSERT (start <= len && end <= len);
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /* 8-9. */
     ecma_string_t *new_str_p = ecma_string_substr (get_string_val, start, end);
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (new_str_p));
+    ret_value = ecma_make_string_value (new_str_p);
   }
 
   ECMA_FINALIZE (to_string_val);
@@ -1523,18 +1519,18 @@ ecma_builtin_string_prototype_object_slice (ecma_value_t this_arg, /**< this arg
  * Used by:
  *        - The String.prototype.split routine.
  *
- * @return completion value - contains the value of the match
+ * @return ecma value - contains the value of the match
  *                          - the index property of the completion value indicates the position of the
  *                            first character in the input_string that matched
  *
- *         Returned value must be freed with ecma_free_completion_value.
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_helper_split_match (ecma_value_t input_string, /**< first argument */
                                  ecma_length_t start_idx, /**< second argument */
                                  ecma_value_t separator) /**< third argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   if (ecma_is_value_object (separator)
@@ -1551,9 +1547,9 @@ ecma_builtin_helper_split_match (ecma_value_t input_string, /**< first argument 
 
     ret_value = ecma_regexp_exec_helper (regexp_value, ecma_make_string_value (substr_str_p), true);
 
-    if (!ecma_is_value_null (ecma_get_completion_value_value (ret_value)))
+    if (!ecma_is_value_null (ret_value))
     {
-      ecma_object_t *obj_p = ecma_get_object_from_completion_value (ret_value);
+      ecma_object_t *obj_p = ecma_get_object_from_value (ret_value);
       ecma_string_t *magic_index_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
       ecma_property_t *index_prop_p = ecma_get_named_property (obj_p, magic_index_str_p);
 
@@ -1581,7 +1577,7 @@ ecma_builtin_helper_split_match (ecma_value_t input_string, /**< first argument 
     /* 4. */
     if (start_idx + separator_length > string_length)
     {
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_NULL);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_NULL);
     }
     else
     {
@@ -1602,8 +1598,8 @@ ecma_builtin_helper_split_match (ecma_value_t input_string, /**< first argument 
       if (!is_different)
       {
         /* 6-7. */
-        ecma_completion_value_t match_array = ecma_op_create_array_object (0, 0, false);
-        ecma_object_t *match_array_p = ecma_get_object_from_completion_value (match_array);
+        ecma_value_t match_array = ecma_op_create_array_object (0, 0, false);
+        ecma_object_t *match_array_p = ecma_get_object_from_value (match_array);
         ecma_string_t *zero_str_p = ecma_new_ecma_string_from_number (ECMA_NUMBER_ZERO);
 
         ecma_op_object_put (match_array_p, zero_str_p, ecma_make_string_value (separator_str_p), true);
@@ -1626,7 +1622,7 @@ ecma_builtin_helper_split_match (ecma_value_t input_string, /**< first argument 
       }
       else
       {
-        ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_NULL);
+        ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_NULL);
       }
     }
   }
@@ -1640,15 +1636,15 @@ ecma_builtin_helper_split_match (ecma_value_t input_string, /**< first argument 
  * See also:
  *          ECMA-262 v5, 15.5.4.14
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this argument */
                                             ecma_value_t arg1, /**< separator */
                                             ecma_value_t arg2) /**< limit */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (this_check_coercible_val,
@@ -1661,7 +1657,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
                   ret_value);
 
   /* 3. */
-  ecma_completion_value_t new_array = ecma_op_create_array_object (0, 0, false);
+  ecma_value_t new_array = ecma_op_create_array_object (0, 0, false);
 
   /* 5. */
   ecma_length_t limit = 0;
@@ -1679,7 +1675,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
     ECMA_OP_TO_NUMBER_FINALIZE (limit_num);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /* This variable indicates that we should return with the current array, to avoid another operation. */
     bool should_return = false;
@@ -1691,22 +1687,22 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
     }
     else /* if (limit != 0) */
     {
-      ecma_object_t *new_array_p = ecma_get_object_from_completion_value (new_array);
+      ecma_object_t *new_array_p = ecma_get_object_from_value (new_array);
 
       /* 10. */
       if (ecma_is_value_undefined (arg1))
       {
         ecma_string_t *zero_str_p = ecma_new_ecma_string_from_number (ECMA_NUMBER_ZERO);
 
-        ecma_completion_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
-                                                                         zero_str_p,
-                                                                         this_to_string_val,
-                                                                         true,
-                                                                         true,
-                                                                         true,
-                                                                         false);
+        ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
+                                                              zero_str_p,
+                                                              this_to_string_val,
+                                                              true,
+                                                              true,
+                                                              true,
+                                                              false);
 
-        JERRY_ASSERT (ecma_is_completion_value_normal_true (put_comp));
+        JERRY_ASSERT (ecma_is_value_true (put_comp));
 
         should_return = true;
 
@@ -1737,15 +1733,15 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
         }
 
         /* 11. */
-        if (string_length == 0 && ecma_is_completion_value_empty (ret_value))
+        if (string_length == 0 && ecma_is_value_empty (ret_value))
         {
           /* 11.a */
-          ecma_completion_value_t match_result = ecma_builtin_helper_split_match (this_to_string_val,
-                                                                                  0,
-                                                                                  separator);
+          ecma_value_t match_result = ecma_builtin_helper_split_match (this_to_string_val,
+                                                                       0,
+                                                                       separator);
 
           /* 11.b */
-          if (!ecma_is_value_null (ecma_get_completion_value_value (match_result)))
+          if (!ecma_is_value_null (match_result))
           {
             should_return = true;
           }
@@ -1754,15 +1750,15 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
             /* 11.c */
             ecma_string_t *zero_str_p = ecma_new_ecma_string_from_number (ECMA_NUMBER_ZERO);
 
-            ecma_completion_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
-                                                                             zero_str_p,
-                                                                             this_to_string_val,
-                                                                             true,
-                                                                             true,
-                                                                             true,
-                                                                             false);
+            ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
+                                                                  zero_str_p,
+                                                                  this_to_string_val,
+                                                                  true,
+                                                                  true,
+                                                                  true,
+                                                                  false);
 
-            JERRY_ASSERT (ecma_is_completion_value_normal_true (put_comp));
+            JERRY_ASSERT (ecma_is_value_true (put_comp));
 
             /* 11.d */
             should_return = true;
@@ -1770,9 +1766,9 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
             ecma_deref_ecma_string (zero_str_p);
           }
 
-          ecma_free_completion_value (match_result);
+          ecma_free_value (match_result);
         }
-        else /* if (string_length != 0) || !ecma_is_completion_value_empty (ret_value) */
+        else /* if (string_length != 0) || !ecma_is_value_empty (ret_value) */
         {
           /* 4. */
           ecma_length_t new_array_length = 0;
@@ -1786,34 +1782,34 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
           bool separator_is_empty = false;
 
           /* 13. */
-          while (curr_pos < string_length && !should_return && ecma_is_completion_value_empty (ret_value))
+          while (curr_pos < string_length && !should_return && ecma_is_value_empty (ret_value))
           {
-            ecma_completion_value_t match_result = ecma_builtin_helper_split_match (this_to_string_val,
-                                                                                    curr_pos,
-                                                                                    separator);
+            ecma_value_t match_result = ecma_builtin_helper_split_match (this_to_string_val,
+                                                                         curr_pos,
+                                                                         separator);
 
             /* 13.b */
-            if (ecma_is_value_null (ecma_get_completion_value_value (match_result)))
+            if (ecma_is_value_null (match_result))
             {
               curr_pos++;
             }
-            else /* if (!ecma_is_value_null (ecma_get_completion_value_value (match_result))) */
+            else /* if (!ecma_is_value_null (match_result)) */
             {
-              ecma_object_t *match_array_obj_p = ecma_get_object_from_completion_value (match_result);
+              ecma_object_t *match_array_obj_p = ecma_get_object_from_value (match_result);
 
               ecma_string_t *zero_str_p = ecma_new_ecma_string_from_number (ECMA_NUMBER_ZERO);
-              ecma_completion_value_t match_comp_value = ecma_op_object_get (match_array_obj_p, zero_str_p);
+              ecma_value_t match_comp_value = ecma_op_object_get (match_array_obj_p, zero_str_p);
 
-              JERRY_ASSERT (ecma_is_completion_value_normal (match_comp_value));
+              JERRY_ASSERT (!ecma_is_value_error (match_comp_value));
 
-              ecma_string_t *match_str_p = ecma_get_string_from_completion_value (match_comp_value);
+              ecma_string_t *match_str_p = ecma_get_string_from_value (match_comp_value);
               ecma_length_t match_str_length = ecma_string_get_length (match_str_p);
 
               ecma_string_t *magic_empty_str_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING__EMPTY);
               separator_is_empty = ecma_compare_ecma_strings (magic_empty_str_p, match_str_p);
 
               ecma_deref_ecma_string (magic_empty_str_p);
-              ecma_free_completion_value (match_comp_value);
+              ecma_free_value (match_comp_value);
               ecma_deref_ecma_string (zero_str_p);
 
               ecma_string_t *magic_index_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
@@ -1836,21 +1832,21 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
 
               ecma_string_t *array_length_str_p = ecma_new_ecma_string_from_uint32 (new_array_length);
 
-              ecma_completion_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
-                                                                               array_length_str_p,
-                                                                               ecma_make_string_value (substr_str_p),
-                                                                               true,
-                                                                               true,
-                                                                               true,
-                                                                               false);
+              ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
+                                                                    array_length_str_p,
+                                                                    ecma_make_string_value (substr_str_p),
+                                                                    true,
+                                                                    true,
+                                                                    true,
+                                                                    false);
 
-              JERRY_ASSERT (ecma_is_completion_value_normal_true (put_comp));
+              JERRY_ASSERT (ecma_is_value_true (put_comp));
 
               /* 13.c.iii.3 */
               new_array_length++;
 
               /* 13.c.iii.4 */
-              if (new_array_length == limit && ecma_is_completion_value_empty (ret_value))
+              if (new_array_length == limit && ecma_is_value_empty (ret_value))
               {
                 should_return = true;
               }
@@ -1873,40 +1869,38 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
               uint32_t i = 0;
 
               /* 13.c.iii.7 */
-              while (i < match_result_array_length && ecma_is_completion_value_empty (ret_value))
+              while (i < match_result_array_length && ecma_is_value_empty (ret_value))
               {
                 /* 13.c.iii.7.a */
                 i++;
                 ecma_string_t *idx_str_p = ecma_new_ecma_string_from_uint32 (i);
                 ecma_string_t *new_array_idx_str_p = ecma_new_ecma_string_from_uint32 (new_array_length);
 
-                ecma_completion_value_t match_comp_value = ecma_op_object_get (match_array_obj_p, idx_str_p);
+                ecma_value_t match_comp_value = ecma_op_object_get (match_array_obj_p, idx_str_p);
 
-                JERRY_ASSERT (ecma_is_completion_value_normal (match_comp_value));
-
-                ecma_value_t match_result_value = ecma_get_completion_value_value (match_comp_value);
+                JERRY_ASSERT (!ecma_is_value_error (match_comp_value));
 
                 /* 13.c.iii.7.b */
-                ecma_completion_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
-                                                                                 new_array_idx_str_p,
-                                                                                 match_result_value,
-                                                                                 true,
-                                                                                 true,
-                                                                                 true,
-                                                                                 false);
+                ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
+                                                                      new_array_idx_str_p,
+                                                                      match_comp_value,
+                                                                      true,
+                                                                      true,
+                                                                      true,
+                                                                      false);
 
-                JERRY_ASSERT (ecma_is_completion_value_normal_true (put_comp));
+                JERRY_ASSERT (ecma_is_value_true (put_comp));
 
                 /* 13.c.iii.7.c */
                 new_array_length++;
 
                 /* 13.c.iii.7.d */
-                if (new_array_length == limit && ecma_is_completion_value_empty (ret_value))
+                if (new_array_length == limit && ecma_is_value_empty (ret_value))
                 {
                   should_return = true;
                 }
 
-                ecma_free_completion_value (match_comp_value);
+                ecma_free_value (match_comp_value);
                 ecma_deref_ecma_string (new_array_idx_str_p);
                 ecma_deref_ecma_string (idx_str_p);
               }
@@ -1920,13 +1914,13 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
               ecma_deref_ecma_string (array_length_str_p);
               ecma_deref_ecma_string (substr_str_p);
               ecma_deref_ecma_string (magic_index_str_p);
-            } /* if (!ecma_is_value_null (ecma_get_completion_value_value (match_result))) */
+            } /* if (!ecma_is_value_null (match_result)) */
 
-            ecma_free_completion_value (match_result);
+            ecma_free_value (match_result);
 
-          } /* while (curr_pos < string_length && !should_return && ecma_is_completion_value_empty (ret_value)) */
+          } /* while (curr_pos < string_length && !should_return && ecma_is_value_empty (ret_value)) */
 
-          if (!should_return && !separator_is_empty && ecma_is_completion_value_empty (ret_value))
+          if (!should_return && !separator_is_empty && ecma_is_value_empty (ret_value))
           {
             /* 14. */
             ecma_string_t *substr_str_p;
@@ -1937,33 +1931,33 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
             /* 15. */
             ecma_string_t *array_length_string_p = ecma_new_ecma_string_from_uint32 (new_array_length);
 
-            ecma_completion_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
-                                                                             array_length_string_p,
-                                                                             ecma_make_string_value (substr_str_p),
-                                                                             true,
-                                                                             true,
-                                                                             true,
-                                                                             false);
+            ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
+                                                                  array_length_string_p,
+                                                                  ecma_make_string_value (substr_str_p),
+                                                                  true,
+                                                                  true,
+                                                                  true,
+                                                                  false);
 
-            JERRY_ASSERT (ecma_is_completion_value_normal_true (put_comp));
+            JERRY_ASSERT (ecma_is_value_true (put_comp));
 
             ecma_deref_ecma_string (array_length_string_p);
             ecma_deref_ecma_string (substr_str_p);
           }
-        } /* if (string_length != 0) || !ecma_is_completion_value_empty (ret_value) */
+        } /* if (string_length != 0) || !ecma_is_value_empty (ret_value) */
 
-        ecma_free_value (separator, true);
+        ecma_free_value (separator);
       } /* if (!ecma_is_value_undefined (arg1)) */
     } /* if (limit != 0) */
-  } /* if (ecma_is_completion_value_empty (ret_value)) */
+  } /* if (ecma_is_value_empty (ret_value)) */
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     ret_value = new_array;
   }
   else
   {
-    ecma_free_completion_value (new_array);
+    ecma_free_value (new_array);
   }
 
   ECMA_FINALIZE (this_to_string_val);
@@ -1980,15 +1974,15 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
  * See also:
  *          ECMA-262 v5, 15.5.4.15
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_substring (ecma_value_t this_arg, /**< this argument */
                                                 ecma_value_t arg1, /**< routine's first argument */
                                                 ecma_value_t arg2) /**< routine's second argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1 */
   ECMA_TRY_CATCH (check_coercible_val,
@@ -2030,7 +2024,7 @@ ecma_builtin_string_prototype_object_substring (ecma_value_t this_arg, /**< this
     ECMA_OP_TO_NUMBER_FINALIZE (end_num);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     JERRY_ASSERT (start <= len && end <= len);
 
@@ -2042,7 +2036,7 @@ ecma_builtin_string_prototype_object_substring (ecma_value_t this_arg, /**< this
 
     /* 10 */
     ecma_string_t *new_str_p = ecma_string_substr (original_string_p, from, to);
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (new_str_p));
+    ret_value = ecma_make_string_value (new_str_p);
   }
 
   ECMA_OP_TO_NUMBER_FINALIZE (start_num);
@@ -2056,15 +2050,15 @@ ecma_builtin_string_prototype_object_substring (ecma_value_t this_arg, /**< this
 /**
  * Helper function to convert a string to upper or lower case.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_conversion_helper (ecma_value_t this_arg, /**< this argument */
                                                         bool lower_case) /**< convert to lower (true)
                                                                           *   or upper (false) case */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1. */
   ECMA_TRY_CATCH (check_coercible_val,
@@ -2168,7 +2162,7 @@ ecma_builtin_string_prototype_object_conversion_helper (ecma_value_t this_arg, /
 
   ecma_string_t *output_string_p = ecma_new_ecma_string_from_utf8 (output_start_p, output_length);
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_string_value (output_string_p));
+  ret_value = ecma_make_string_value (output_string_p);
 
   MEM_FINALIZE_LOCAL_ARRAY (output_start_p);
   MEM_FINALIZE_LOCAL_ARRAY (input_start_p);
@@ -2185,10 +2179,10 @@ ecma_builtin_string_prototype_object_conversion_helper (ecma_value_t this_arg, /
  * See also:
  *          ECMA-262 v5, 15.5.4.16
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_to_lower_case (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_builtin_string_prototype_object_conversion_helper (this_arg, true);
@@ -2200,10 +2194,10 @@ ecma_builtin_string_prototype_object_to_lower_case (ecma_value_t this_arg) /**< 
  * See also:
  *          ECMA-262 v5, 15.5.4.17
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_to_locale_lower_case (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_builtin_string_prototype_object_conversion_helper (this_arg, true);
@@ -2215,10 +2209,10 @@ ecma_builtin_string_prototype_object_to_locale_lower_case (ecma_value_t this_arg
  * See also:
  *          ECMA-262 v5, 15.5.4.18
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_to_upper_case (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_builtin_string_prototype_object_conversion_helper (this_arg, false);
@@ -2230,10 +2224,10 @@ ecma_builtin_string_prototype_object_to_upper_case (ecma_value_t this_arg) /**< 
  * See also:
  *          ECMA-262 v5, 15.5.4.19
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_to_locale_upper_case (ecma_value_t this_arg) /**< this argument */
 {
   return ecma_builtin_string_prototype_object_conversion_helper (this_arg, false);
@@ -2245,13 +2239,13 @@ ecma_builtin_string_prototype_object_to_locale_upper_case (ecma_value_t this_arg
  * See also:
  *          ECMA-262 v5, 15.5.4.20
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_trim (ecma_value_t this_arg) /**< this argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   /* 1 */
   ECMA_TRY_CATCH (check_coercible_val,
@@ -2266,7 +2260,7 @@ ecma_builtin_string_prototype_object_trim (ecma_value_t this_arg) /**< this argu
   ecma_string_t *original_string_p = ecma_get_string_from_value (to_string_val);
 
   ecma_string_t *trimmed_string_p = ecma_string_trim (original_string_p);
-  ret_value = ecma_make_normal_completion_value (ecma_make_string_value (trimmed_string_p));
+  ret_value = ecma_make_string_value (trimmed_string_p);
 
   ECMA_FINALIZE (to_string_val);
   ECMA_FINALIZE (check_coercible_val);
@@ -2282,15 +2276,15 @@ ecma_builtin_string_prototype_object_trim (ecma_value_t this_arg) /**< this argu
  * See also:
  *          ECMA-262 v5, B.2.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_prototype_object_substr (ecma_value_t this_arg, /**< this argument */
                                              ecma_value_t start, /**< routine's first argument */
                                              ecma_value_t length) /**< routine's second argument */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (check_coercible_val,
                   ecma_op_check_object_coercible (this_arg),
@@ -2317,7 +2311,7 @@ ecma_builtin_string_prototype_object_substr (ecma_value_t this_arg, /**< this ar
     ECMA_OP_TO_NUMBER_FINALIZE (len);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     /* 4. */
     ecma_number_t this_len = (ecma_number_t) ecma_string_get_length (this_string_p);
@@ -2332,7 +2326,7 @@ ecma_builtin_string_prototype_object_substr (ecma_value_t this_arg, /**< this ar
 
     /* 8. */
     ecma_string_t *new_str_p = ecma_string_substr (this_string_p, from, to);
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (new_str_p));
+    ret_value = ecma_make_string_value (new_str_p);
   }
 
   ECMA_OP_TO_NUMBER_FINALIZE (start_num);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
@@ -50,15 +50,15 @@
  * See also:
  *          ECMA-262 v5, 15.5.3.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_string_object_from_char_code (ecma_value_t this_arg __attr_unused___, /**< 'this' argument */
                                            const ecma_value_t args[], /**< arguments list */
                                            ecma_length_t args_number) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_string_t *ret_string_p = NULL;
 
   if (args_number == 0)
@@ -76,7 +76,7 @@ ecma_builtin_string_object_from_char_code (ecma_value_t this_arg __attr_unused__
     lit_utf8_size_t utf8_buf_used = 0;
 
     for (ecma_length_t arg_index = 0;
-         arg_index < args_number && ecma_is_completion_value_empty (ret_value);
+         arg_index < args_number && ecma_is_value_empty (ret_value);
          arg_index++)
     {
       ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, args[arg_index], ret_value);
@@ -91,7 +91,7 @@ ecma_builtin_string_object_from_char_code (ecma_value_t this_arg __attr_unused__
       ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
     }
 
-    if (ecma_is_completion_value_empty (ret_value))
+    if (ecma_is_value_empty (ret_value))
     {
       ret_string_p = ecma_new_ecma_string_from_utf8 (utf8_buf_p, utf8_buf_used);
     }
@@ -99,9 +99,9 @@ ecma_builtin_string_object_from_char_code (ecma_value_t this_arg __attr_unused__
     MEM_FINALIZE_LOCAL_ARRAY (utf8_buf_p);
   }
 
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
-    ret_value = ecma_make_normal_completion_value (ecma_make_string_value (ret_string_p));
+    ret_value = ecma_make_string_value (ret_string_p);
   }
 
   return ret_value;
@@ -110,22 +110,22 @@ ecma_builtin_string_object_from_char_code (ecma_value_t this_arg __attr_unused__
 /**
  * Handle calling [[Call]] of built-in String object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_string_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                    ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (arguments_list_len == 0)
   {
     ecma_string_t *str_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING__EMPTY);
     ecma_value_t str_value = ecma_make_string_value (str_p);
 
-    ret_value = ecma_make_normal_completion_value (str_value);
+    ret_value = str_value;
   }
   else
   {
@@ -138,9 +138,9 @@ ecma_builtin_string_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
 /**
  * Handle calling [[Construct]] of built-in String object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_string_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                         ecma_length_t arguments_list_len) /**< number of arguments */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror.c
@@ -46,9 +46,9 @@
 /**
  * Handle calling [[Call]] of built-in SyntaxError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_syntax_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                          ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -57,7 +57,7 @@ ecma_builtin_syntax_error_dispatch_call (const ecma_value_t *arguments_list_p, /
   if (arguments_list_len != 0
       && !ecma_is_value_undefined (arguments_list_p[0]))
   {
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (msg_str_value,
                     ecma_op_to_string (arguments_list_p[0]),
@@ -66,7 +66,7 @@ ecma_builtin_syntax_error_dispatch_call (const ecma_value_t *arguments_list_p, /
     ecma_string_t *message_string_p = ecma_get_string_from_value (msg_str_value);
     ecma_object_t *new_error_object_p = ecma_new_standard_error_with_message (ECMA_ERROR_SYNTAX,
                                                                               message_string_p);
-    ret_value = ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    ret_value = ecma_make_object_value (new_error_object_p);
 
     ECMA_FINALIZE (msg_str_value);
 
@@ -76,16 +76,16 @@ ecma_builtin_syntax_error_dispatch_call (const ecma_value_t *arguments_list_p, /
   {
     ecma_object_t *new_error_object_p = ecma_new_standard_error (ECMA_ERROR_SYNTAX);
 
-    return ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    return ecma_make_object_value (new_error_object_p);
   }
 } /* ecma_builtin_syntax_error_dispatch_call */
 
 /**
  * Handle calling [[Construct]] of built-in SyntaxError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_syntax_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                               ecma_length_t arguments_list_len) /**< number of arguments */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-type-error-thrower.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-type-error-thrower.c
@@ -47,16 +47,16 @@
  * See also:
  *          ECMA-262 v5, 13.2.3
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_type_error_thrower_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                                ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
   /* The object should throw TypeError */
-  return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+  return ecma_raise_type_error ("");
 } /* ecma_builtin_type_error_thrower_dispatch_call */
 
 /**
@@ -65,16 +65,16 @@ ecma_builtin_type_error_thrower_dispatch_call (const ecma_value_t *arguments_lis
  * See also:
  *          ECMA-262 v5, 13.2.3
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_type_error_thrower_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                                     ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
   /* The object is not a constructor */
-  return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+  return ecma_raise_type_error ("");
 } /* ecma_builtin_type_error_thrower_dispatch_construct */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror.c
@@ -46,9 +46,9 @@
 /**
  * Handle calling [[Call]] of built-in TypeError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_type_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                        ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -57,7 +57,7 @@ ecma_builtin_type_error_dispatch_call (const ecma_value_t *arguments_list_p, /**
   if (arguments_list_len != 0
       && !ecma_is_value_undefined (arguments_list_p[0]))
   {
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (msg_str_value,
                     ecma_op_to_string (arguments_list_p[0]),
@@ -66,7 +66,7 @@ ecma_builtin_type_error_dispatch_call (const ecma_value_t *arguments_list_p, /**
     ecma_string_t *message_string_p = ecma_get_string_from_value (msg_str_value);
     ecma_object_t *new_error_object_p = ecma_new_standard_error_with_message (ECMA_ERROR_TYPE,
                                                                               message_string_p);
-    ret_value = ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    ret_value = ecma_make_object_value (new_error_object_p);
 
     ECMA_FINALIZE (msg_str_value);
 
@@ -76,16 +76,16 @@ ecma_builtin_type_error_dispatch_call (const ecma_value_t *arguments_list_p, /**
   {
     ecma_object_t *new_error_object_p = ecma_new_standard_error (ECMA_ERROR_TYPE);
 
-    return ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    return ecma_make_object_value (new_error_object_p);
   }
 } /* ecma_builtin_type_error_dispatch_call */
 
 /**
  * Handle calling [[Construct]] of built-in TypeError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_type_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                             ecma_length_t arguments_list_len) /**< number of arguments */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-urierror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-urierror.c
@@ -46,9 +46,9 @@
 /**
  * Handle calling [[Call]] of built-in UriError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_uri_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
                                       ecma_length_t arguments_list_len) /**< number of arguments */
 {
@@ -57,7 +57,7 @@ ecma_builtin_uri_error_dispatch_call (const ecma_value_t *arguments_list_p, /**<
   if (arguments_list_len != 0
       && !ecma_is_value_undefined (arguments_list_p[0]))
   {
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (msg_str_value,
                     ecma_op_to_string (arguments_list_p[0]),
@@ -66,7 +66,7 @@ ecma_builtin_uri_error_dispatch_call (const ecma_value_t *arguments_list_p, /**<
     ecma_string_t *message_string_p = ecma_get_string_from_value (msg_str_value);
     ecma_object_t *new_error_object_p = ecma_new_standard_error_with_message (ECMA_ERROR_URI,
                                                                               message_string_p);
-    ret_value = ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    ret_value = ecma_make_object_value (new_error_object_p);
 
     ECMA_FINALIZE (msg_str_value);
 
@@ -76,16 +76,16 @@ ecma_builtin_uri_error_dispatch_call (const ecma_value_t *arguments_list_p, /**<
   {
     ecma_object_t *new_error_object_p = ecma_new_standard_error (ECMA_ERROR_URI);
 
-    return ecma_make_normal_completion_value (ecma_make_object_value (new_error_object_p));
+    return ecma_make_object_value (new_error_object_p);
   }
 } /* ecma_builtin_uri_error_dispatch_call */
 
 /**
  * Handle calling [[Construct]] of built-in UriError object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_uri_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
                                            ecma_length_t arguments_list_len) /**< number of arguments */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
@@ -70,13 +70,13 @@ ecma_builtin_bin_search_for_magic_string_id_in_array (const lit_magic_string_id_
                 is_extensible, \
                 is_static, \
                 lowercase_name) \
-extern ecma_completion_value_t \
+extern ecma_value_t \
 ecma_builtin_ ## lowercase_name ## _dispatch_call (const ecma_value_t *, \
                                                    ecma_length_t); \
-extern ecma_completion_value_t \
+extern ecma_value_t \
 ecma_builtin_ ## lowercase_name ## _dispatch_construct (const ecma_value_t *, \
                                                         ecma_length_t); \
-extern ecma_completion_value_t \
+extern ecma_value_t \
 ecma_builtin_ ## lowercase_name ## _dispatch_routine (uint16_t builtin_routine_id, \
                                                       ecma_value_t this_arg_value, \
                                                       const ecma_value_t [], \

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -31,7 +31,7 @@
  * @{
  */
 
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_dispatch_routine (ecma_builtin_id_t builtin_object_id,
                                uint16_t builtin_routine_id,
                                ecma_value_t this_arg_value,
@@ -503,9 +503,9 @@ ecma_builtin_make_function_object_for_routine (ecma_builtin_id_t builtin_id, /**
 /**
  * Handle calling [[Call]] of built-in object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_dispatch_call (ecma_object_t *obj_p, /**< built-in object */
                             ecma_value_t this_arg_value, /**< 'this' argument value */
                             const ecma_value_t *arguments_list_p, /**< arguments list */
@@ -513,7 +513,7 @@ ecma_builtin_dispatch_call (ecma_object_t *obj_p, /**< built-in object */
 {
   JERRY_ASSERT (ecma_get_object_is_builtin (obj_p));
 
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION)
   {
@@ -585,7 +585,7 @@ ecma_builtin_dispatch_call (ecma_object_t *obj_p, /**< built-in object */
     }
   }
 
-  JERRY_ASSERT (!ecma_is_completion_value_empty (ret_value));
+  JERRY_ASSERT (!ecma_is_value_empty (ret_value));
 
   return ret_value;
 } /* ecma_builtin_dispatch_call */
@@ -593,9 +593,9 @@ ecma_builtin_dispatch_call (ecma_object_t *obj_p, /**< built-in object */
 /**
  * Handle calling [[Construct]] of built-in object
  *
- * @return completion-value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_builtin_dispatch_construct (ecma_object_t *obj_p, /**< built-in object */
                                  const ecma_value_t *arguments_list_p, /**< arguments list */
                                  ecma_length_t arguments_list_len) /**< arguments list length */
@@ -603,7 +603,7 @@ ecma_builtin_dispatch_construct (ecma_object_t *obj_p, /**< built-in object */
   JERRY_ASSERT (ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_FUNCTION);
   JERRY_ASSERT (ecma_get_object_is_builtin (obj_p));
 
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ecma_property_t *built_in_id_prop_p = ecma_get_internal_property (obj_p,
                                                                     ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
@@ -646,7 +646,7 @@ ecma_builtin_dispatch_construct (ecma_object_t *obj_p, /**< built-in object */
     }
   }
 
-  JERRY_ASSERT (!ecma_is_completion_value_empty (ret_value));
+  JERRY_ASSERT (!ecma_is_value_empty (ret_value));
 
   return ret_value;
 } /* ecma_builtin_dispatch_construct */
@@ -654,10 +654,10 @@ ecma_builtin_dispatch_construct (ecma_object_t *obj_p, /**< built-in object */
 /**
  * Dispatcher of built-in routines
  *
- * @return completion-value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_builtin_dispatch_routine (ecma_builtin_id_t builtin_object_id, /**< built-in object' identifier */
                                uint16_t builtin_routine_id, /**< builtin-wide identifier
                                                              *   of the built-in object's

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -38,10 +38,10 @@ typedef enum
 extern void ecma_init_builtins (void);
 extern void ecma_finalize_builtins (void);
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_builtin_dispatch_call (ecma_object_t *, ecma_value_t,
                             const ecma_value_t *, ecma_length_t);
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_builtin_dispatch_construct (ecma_object_t *,
                                  const ecma_value_t *, ecma_length_t);
 extern ecma_property_t *

--- a/jerry-core/ecma/operations/ecma-array-object.h
+++ b/jerry-core/ecma/operations/ecma-array-object.h
@@ -25,10 +25,10 @@
  * @{
  */
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_create_array_object (const ecma_value_t *, ecma_length_t, bool);
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_array_object_define_own_property (ecma_object_t *, ecma_string_t *, const ecma_property_descriptor_t *, bool);
 
 /**

--- a/jerry-core/ecma/operations/ecma-boolean-object.c
+++ b/jerry-core/ecma/operations/ecma-boolean-object.c
@@ -35,21 +35,21 @@
  *
  * See also: ECMA-262 v5, 15.6.2.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boolean constructor */
 {
-  ecma_completion_value_t conv_to_boolean_completion = ecma_op_to_boolean (arg);
+  ecma_value_t conv_to_boolean_completion = ecma_op_to_boolean (arg);
 
-  if (!ecma_is_completion_value_normal (conv_to_boolean_completion))
+  if (ecma_is_value_error (conv_to_boolean_completion))
   {
     return conv_to_boolean_completion;
   }
 
-  ecma_simple_value_t bool_value = (ecma_is_value_true (ecma_get_completion_value_value (conv_to_boolean_completion)) ?
-                                    ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+  ecma_simple_value_t bool_value = (ecma_is_value_true (conv_to_boolean_completion) ? ECMA_SIMPLE_VALUE_TRUE
+                                                                                    : ECMA_SIMPLE_VALUE_FALSE);
 
 #ifndef CONFIG_ECMA_COMPACT_PROFILE_DISABLE_BOOLEAN_BUILTIN
   ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_BOOLEAN_PROTOTYPE);
@@ -69,7 +69,7 @@ ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boo
                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_BOOLEAN_VALUE);
   prim_value_prop_p->u.internal_property.value = bool_value;
 
-  return ecma_make_normal_completion_value (ecma_make_object_value (obj_p));
+  return ecma_make_object_value (obj_p);
 } /* ecma_op_create_boolean_object */
 
 /**

--- a/jerry-core/ecma/operations/ecma-boolean-object.h
+++ b/jerry-core/ecma/operations/ecma-boolean-object.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-extern ecma_completion_value_t ecma_op_create_boolean_object (ecma_value_t);
+extern ecma_value_t ecma_op_create_boolean_object (ecma_value_t);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-comparison.c
+++ b/jerry-core/ecma/operations/ecma-comparison.c
@@ -34,7 +34,7 @@
  * @return true - if values are equal,
  *         false - otherwise.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
                                    ecma_value_t y) /**< second operand */
 {
@@ -59,7 +59,7 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
                                || (is_x_string && is_y_string)
                                || (is_x_object && is_y_object));
 
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (is_types_equal)
   {
@@ -69,7 +69,7 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
         || is_x_null)
     {
       // a., b.
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
     }
     else if (is_x_number)
     { // c.
@@ -100,8 +100,7 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
       JERRY_ASSERT (is_x_equal_to_y == is_x_equal_to_y_check);
 #endif /* !JERRY_NDEBUG */
 
-      ret_value = ecma_make_simple_completion_value (is_x_equal_to_y ?
-                                                     ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+      ret_value = ecma_make_simple_value (is_x_equal_to_y ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
     }
     else if (is_x_string)
     { // d.
@@ -110,13 +109,13 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
 
       bool is_equal = ecma_compare_ecma_strings (x_str_p, y_str_p);
 
-      ret_value = ecma_make_simple_completion_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+      ret_value = ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
     }
     else if (is_x_boolean)
     { // e.
       bool is_equal = (ecma_is_value_true (x) == ecma_is_value_true (y));
 
-      ret_value = ecma_make_simple_completion_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+      ret_value = ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
     }
     else
     { // f.
@@ -124,13 +123,13 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
 
       bool is_equal = (ecma_get_object_from_value (x) == ecma_get_object_from_value (y));
 
-      ret_value = ecma_make_simple_completion_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+      ret_value = ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
     }
   }
   else if ((is_x_null && is_y_undefined)
            || (is_x_undefined && is_y_null))
   { // 2., 3.
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
   else if (is_x_number && is_y_string)
   {
@@ -202,7 +201,7 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
   }
   else
   {
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
 
   return ret_value;
@@ -325,15 +324,15 @@ ecma_op_strict_equality_compare (ecma_value_t x, /**< first operand */
  *
  * See also: ECMA-262 v5, 11.8.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_abstract_relational_compare (ecma_value_t x, /**< first operand */
                                      ecma_value_t y, /**< second operand */
                                      bool left_first) /**< 'LeftFirst' flag */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ecma_value_t first_converted_value = left_first ? x : y;
   ecma_value_t second_converted_value = left_first ? y : x;
@@ -365,7 +364,7 @@ ecma_op_abstract_relational_compare (ecma_value_t x, /**< first operand */
         || ecma_number_is_nan (ny))
     {
       // c., d.
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
     }
     else
     {
@@ -428,8 +427,7 @@ ecma_op_abstract_relational_compare (ecma_value_t x, /**< first operand */
       JERRY_ASSERT (is_x_less_than_y_check == is_x_less_than_y);
 #endif /* !JERRY_NDEBUG */
 
-      ret_value = ecma_make_simple_completion_value (is_x_less_than_y ?
-                                                     ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+      ret_value = ecma_make_simple_value (is_x_less_than_y ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
     }
 
     ECMA_OP_TO_NUMBER_FINALIZE (ny);
@@ -444,8 +442,7 @@ ecma_op_abstract_relational_compare (ecma_value_t x, /**< first operand */
 
     bool is_px_less = ecma_compare_ecma_strings_relational (str_x_p, str_y_p);
 
-    ret_value = ecma_make_simple_completion_value (is_px_less ? ECMA_SIMPLE_VALUE_TRUE
-                                                              : ECMA_SIMPLE_VALUE_FALSE);
+    ret_value = ecma_make_simple_value (is_px_less ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
   }
 
   ECMA_FINALIZE (prim_second_converted_value);

--- a/jerry-core/ecma/operations/ecma-comparison.h
+++ b/jerry-core/ecma/operations/ecma-comparison.h
@@ -26,9 +26,9 @@
  * @{
  */
 
-extern ecma_completion_value_t ecma_op_abstract_equality_compare (ecma_value_t, ecma_value_t);
+extern ecma_value_t ecma_op_abstract_equality_compare (ecma_value_t, ecma_value_t);
 extern bool ecma_op_strict_equality_compare (ecma_value_t, ecma_value_t);
-extern ecma_completion_value_t ecma_op_abstract_relational_compare (ecma_value_t, ecma_value_t, bool);
+extern ecma_value_t ecma_op_abstract_relational_compare (ecma_value_t, ecma_value_t, bool);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -45,22 +45,22 @@
  * See also:
  *          ECMA-262 v5, 9.10
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
-ecma_op_check_object_coercible (ecma_value_t value) /**< ecma-value */
+ecma_value_t
+ecma_op_check_object_coercible (ecma_value_t value) /**< ecma value */
 {
   ecma_check_value_type_is_spec_defined (value);
 
   if (ecma_is_value_undefined (value)
       || ecma_is_value_null (value))
   {
-    return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    return ecma_raise_type_error ("");
   }
   else
   {
-    return ecma_make_empty_completion_value ();
+    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   }
 } /* ecma_op_check_object_coercible */
 
@@ -74,8 +74,8 @@ ecma_op_check_object_coercible (ecma_value_t value) /**< ecma-value */
  *         false - otherwise.
  */
 bool
-ecma_op_same_value (ecma_value_t x, /**< ecma-value */
-                    ecma_value_t y) /**< ecma-value */
+ecma_op_same_value (ecma_value_t x, /**< ecma value */
+                    ecma_value_t y) /**< ecma value */
 {
   const bool is_x_undefined = ecma_is_value_undefined (x);
   const bool is_x_null = ecma_is_value_null (x);
@@ -161,11 +161,11 @@ ecma_op_same_value (ecma_value_t x, /**< ecma-value */
  * See also:
  *          ECMA-262 v5, 9.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
-ecma_op_to_primitive (ecma_value_t value, /**< ecma-value */
+ecma_value_t
+ecma_op_to_primitive (ecma_value_t value, /**< ecma value */
                       ecma_preferred_type_hint_t preferred_type) /**< preferred type hint */
 {
   ecma_check_value_type_is_spec_defined (value);
@@ -178,7 +178,7 @@ ecma_op_to_primitive (ecma_value_t value, /**< ecma-value */
   }
   else
   {
-    return ecma_make_normal_completion_value (ecma_copy_value (value, true));
+    return ecma_copy_value (value, true);
   }
 } /* ecma_op_to_primitive */
 
@@ -188,12 +188,12 @@ ecma_op_to_primitive (ecma_value_t value, /**< ecma-value */
  * See also:
  *          ECMA-262 v5, 9.2
  *
- * @return completion value
+ * @return ecma value
  *         Returned value is simple and so need not be freed.
- *         However, ecma_free_completion_value may be called for it, but it is a no-op.
+ *         However, ecma_free_value may be called for it, but it is a no-op.
  */
-ecma_completion_value_t
-ecma_op_to_boolean (ecma_value_t value) /**< ecma-value */
+ecma_value_t
+ecma_op_to_boolean (ecma_value_t value) /**< ecma value */
 {
   ecma_check_value_type_is_spec_defined (value);
 
@@ -243,7 +243,7 @@ ecma_op_to_boolean (ecma_value_t value) /**< ecma-value */
     ret_value = ECMA_SIMPLE_VALUE_TRUE;
   }
 
-  return ecma_make_simple_completion_value (ret_value);
+  return ecma_make_simple_value (ret_value);
 } /* ecma_op_to_boolean */
 
 /**
@@ -252,17 +252,17 @@ ecma_op_to_boolean (ecma_value_t value) /**< ecma-value */
  * See also:
  *          ECMA-262 v5, 9.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
-ecma_op_to_number (ecma_value_t value) /**< ecma-value */
+ecma_value_t
+ecma_op_to_number (ecma_value_t value) /**< ecma value */
 {
   ecma_check_value_type_is_spec_defined (value);
 
   if (ecma_is_value_number (value))
   {
-    return ecma_make_normal_completion_value (ecma_copy_value (value, true));
+    return ecma_copy_value (value, true);
   }
   else if (ecma_is_value_string (value))
   {
@@ -271,11 +271,11 @@ ecma_op_to_number (ecma_value_t value) /**< ecma-value */
     ecma_number_t *num_p = ecma_alloc_number ();
     *num_p = ecma_string_to_number (str_p);
 
-    return ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+    return ecma_make_number_value (num_p);
   }
   else if (ecma_is_value_object (value))
   {
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (primitive_value,
                     ecma_op_to_primitive (value, ECMA_PREFERRED_TYPE_NUMBER),
@@ -313,7 +313,7 @@ ecma_op_to_number (ecma_value_t value) /**< ecma-value */
       }
     }
 
-    return ecma_make_normal_completion_value (ecma_make_number_value (num_p));
+    return ecma_make_number_value (num_p);
   }
 } /* ecma_op_to_number */
 
@@ -323,17 +323,17 @@ ecma_op_to_number (ecma_value_t value) /**< ecma-value */
  * See also:
  *          ECMA-262 v5, 9.8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
-ecma_op_to_string (ecma_value_t value) /**< ecma-value */
+ecma_value_t
+ecma_op_to_string (ecma_value_t value) /**< ecma value */
 {
   ecma_check_value_type_is_spec_defined (value);
 
   if (unlikely (ecma_is_value_object (value)))
   {
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (prim_value,
                     ecma_op_to_primitive (value, ECMA_PREFERRED_TYPE_STRING),
@@ -381,7 +381,7 @@ ecma_op_to_string (ecma_value_t value) /**< ecma-value */
       }
     }
 
-    return ecma_make_normal_completion_value (ecma_make_string_value (res_p));
+    return ecma_make_string_value (res_p);
   }
 } /* ecma_op_to_string */
 
@@ -391,11 +391,11 @@ ecma_op_to_string (ecma_value_t value) /**< ecma-value */
  * See also:
  *          ECMA-262 v5, 9.9
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
-ecma_op_to_object (ecma_value_t value) /**< ecma-value */
+ecma_value_t
+ecma_op_to_object (ecma_value_t value) /**< ecma value */
 {
   ecma_check_value_type_is_spec_defined (value);
 
@@ -409,14 +409,14 @@ ecma_op_to_object (ecma_value_t value) /**< ecma-value */
   }
   else if (ecma_is_value_object (value))
   {
-    return ecma_make_normal_completion_value (ecma_copy_value (value, true));
+    return ecma_copy_value (value, true);
   }
   else
   {
     if (ecma_is_value_undefined (value)
         || ecma_is_value_null (value))
     {
-      return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+      return ecma_raise_type_error ("");
     }
     else
     {
@@ -441,7 +441,7 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
   // 2.
   ecma_object_t *obj_p = ecma_op_create_object_object_noarg ();
 
-  ecma_completion_value_t completion;
+  ecma_value_t completion;
   ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
   {
     prop_desc.is_value_defined = true;
@@ -471,7 +471,7 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
                                                      &prop_desc,
                                                      false);
     ecma_deref_ecma_string (value_magic_string_p);
-    JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+    JERRY_ASSERT (ecma_is_value_true (completion));
 
     // b.
     const bool is_writable = (src_prop_desc_p->is_writable);
@@ -484,7 +484,7 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
                                                      &prop_desc,
                                                      false);
     ecma_deref_ecma_string (writable_magic_string_p);
-    JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+    JERRY_ASSERT (ecma_is_value_true (completion));
   }
   else
   {
@@ -508,7 +508,7 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
                                                      &prop_desc,
                                                      false);
     ecma_deref_ecma_string (get_magic_string_p);
-    JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+    JERRY_ASSERT (ecma_is_value_true (completion));
 
     // b.
     if (src_prop_desc_p->set_p == NULL)
@@ -526,7 +526,7 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
                                                      &prop_desc,
                                                      false);
     ecma_deref_ecma_string (set_magic_string_p);
-    JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+    JERRY_ASSERT (ecma_is_value_true (completion));
   }
 
   const bool is_enumerable = src_prop_desc_p->is_enumerable;
@@ -539,7 +539,7 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
                                                    &prop_desc,
                                                    false);
   ecma_deref_ecma_string (enumerable_magic_string_p);
-  JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+  JERRY_ASSERT (ecma_is_value_true (completion));
 
   const bool is_configurable = src_prop_desc_p->is_configurable;
   prop_desc.value = ecma_make_simple_value (is_configurable ? ECMA_SIMPLE_VALUE_TRUE
@@ -551,7 +551,7 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
                                                    &prop_desc,
                                                    false);
   ecma_deref_ecma_string (configurable_magic_string_p);
-  JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+  JERRY_ASSERT (ecma_is_value_true (completion));
 
   return obj_p;
 } /* ecma_op_from_property_descriptor */
@@ -562,21 +562,21 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
  * See also:
  *          ECMA-262 v5, 8.10.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
                                 ecma_property_descriptor_t *out_prop_desc_p) /**< out: filled property descriptor
                                                                                   if return value is normal
                                                                                   empty completion value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   // 1.
   if (!ecma_is_value_object (obj_value))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -615,9 +615,9 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
 
     ecma_deref_ecma_string (enumerable_magic_string_p);
 
-    if (!ecma_is_completion_value_throw (ret_value))
+    if (!ecma_is_value_error (ret_value))
     {
-      JERRY_ASSERT (ecma_is_completion_value_empty (ret_value));
+      JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       // 4.
       ecma_string_t *configurable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CONFIGURABLE);
@@ -650,9 +650,9 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       ecma_deref_ecma_string (configurable_magic_string_p);
     }
 
-    if (!ecma_is_completion_value_throw (ret_value))
+    if (!ecma_is_value_error (ret_value))
     {
-      JERRY_ASSERT (ecma_is_completion_value_empty (ret_value));
+      JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       // 5.
       ecma_string_t *value_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_VALUE);
@@ -672,9 +672,9 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       ecma_deref_ecma_string (value_magic_string_p);
     }
 
-    if (!ecma_is_completion_value_throw (ret_value))
+    if (!ecma_is_value_error (ret_value))
     {
-      JERRY_ASSERT (ecma_is_completion_value_empty (ret_value));
+      JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       // 6.
       ecma_string_t *writable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_WRITABLE);
@@ -707,9 +707,9 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       ecma_deref_ecma_string (writable_magic_string_p);
     }
 
-    if (!ecma_is_completion_value_throw (ret_value))
+    if (!ecma_is_value_error (ret_value))
     {
-      JERRY_ASSERT (ecma_is_completion_value_empty (ret_value));
+      JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       // 7.
       ecma_string_t *get_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GET);
@@ -723,7 +723,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
         if (!ecma_op_is_callable (get_prop_value)
             && !ecma_is_value_undefined (get_prop_value))
         {
-          ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+          ret_value = ecma_raise_type_error ("");
         }
         else
         {
@@ -750,9 +750,9 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       ecma_deref_ecma_string (get_magic_string_p);
     }
 
-    if (!ecma_is_completion_value_throw (ret_value))
+    if (!ecma_is_value_error (ret_value))
     {
-      JERRY_ASSERT (ecma_is_completion_value_empty (ret_value));
+      JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       // 8.
 
@@ -767,7 +767,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
         if (!ecma_op_is_callable (set_prop_value)
             && !ecma_is_value_undefined (set_prop_value))
         {
-          ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+          ret_value = ecma_raise_type_error ("");
         }
         else
         {
@@ -794,9 +794,9 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       ecma_deref_ecma_string (set_magic_string_p);
     }
 
-    if (!ecma_is_completion_value_throw (ret_value))
+    if (!ecma_is_value_error (ret_value))
     {
-      JERRY_ASSERT (ecma_is_completion_value_empty (ret_value));
+      JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       // 9.
       if (prop_desc.is_get_defined
@@ -805,14 +805,14 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
         if (prop_desc.is_value_defined
             || prop_desc.is_writable_defined)
         {
-          ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+          ret_value = ecma_raise_type_error ("");
         }
       }
     }
 
-    if (!ecma_is_completion_value_throw (ret_value))
+    if (!ecma_is_value_error (ret_value))
     {
-      JERRY_ASSERT (ecma_is_completion_value_empty (ret_value));
+      JERRY_ASSERT (ecma_is_value_empty (ret_value));
     }
     else
     {

--- a/jerry-core/ecma/operations/ecma-conversion.h
+++ b/jerry-core/ecma/operations/ecma-conversion.h
@@ -37,16 +37,16 @@ typedef enum
   ECMA_PREFERRED_TYPE_STRING /**< String */
 } ecma_preferred_type_hint_t;
 
-extern ecma_completion_value_t ecma_op_check_object_coercible (ecma_value_t);
+extern ecma_value_t ecma_op_check_object_coercible (ecma_value_t);
 extern bool ecma_op_same_value (ecma_value_t, ecma_value_t);
-extern ecma_completion_value_t ecma_op_to_primitive (ecma_value_t, ecma_preferred_type_hint_t);
-extern ecma_completion_value_t ecma_op_to_boolean (ecma_value_t);
-extern ecma_completion_value_t ecma_op_to_number (ecma_value_t);
-extern ecma_completion_value_t ecma_op_to_string (ecma_value_t);
-extern ecma_completion_value_t ecma_op_to_object (ecma_value_t);
+extern ecma_value_t ecma_op_to_primitive (ecma_value_t, ecma_preferred_type_hint_t);
+extern ecma_value_t ecma_op_to_boolean (ecma_value_t);
+extern ecma_value_t ecma_op_to_number (ecma_value_t);
+extern ecma_value_t ecma_op_to_string (ecma_value_t);
+extern ecma_value_t ecma_op_to_object (ecma_value_t);
 
 extern ecma_object_t *ecma_op_from_property_descriptor (const ecma_property_descriptor_t *);
-extern ecma_completion_value_t ecma_op_to_property_descriptor (ecma_value_t, ecma_property_descriptor_t *);
+extern ecma_value_t ecma_op_to_property_descriptor (ecma_value_t, ecma_property_descriptor_t *);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-eval.c
+++ b/jerry-core/ecma/operations/ecma-eval.c
@@ -36,19 +36,19 @@
  *          ecma_op_eval_chars_buffer
  *          ECMA-262 v5, 15.1.2.1 (steps 2 to 8)
  *
- * @return completion value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_eval (ecma_string_t *code_p, /**< code string */
               bool is_direct, /**< is eval called directly (ECMA-262 v5, 15.1.2.1.1) */
               bool is_called_from_strict_mode_code) /**< is eval is called from strict mode code */
 {
-  ecma_completion_value_t ret_value;
+  ecma_value_t ret_value;
 
   lit_utf8_size_t chars_num = ecma_string_get_size (code_p);
   if (chars_num == 0)
   {
-    ret_value = ecma_make_normal_completion_value (ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED));
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
   }
   else
   {
@@ -80,9 +80,9 @@ ecma_op_eval (ecma_string_t *code_p, /**< code string */
  *          ecma_op_eval
  *          ECMA-262 v5, 15.1.2.1 (steps 2 to 8)
  *
- * @return completion value
+ * @return ecma value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_eval_chars_buffer (const jerry_api_char_t *code_p, /**< code characters buffer */
                            size_t code_buffer_size, /**< size of the buffer */
                            bool is_direct, /**< is eval called directly (ECMA-262 v5, 15.1.2.1.1) */
@@ -90,7 +90,7 @@ ecma_op_eval_chars_buffer (const jerry_api_char_t *code_p, /**< code characters 
 {
   JERRY_ASSERT (code_p != NULL);
 
-  ecma_completion_value_t completion;
+  ecma_value_t completion;
 
   ecma_compiled_code_t *bytecode_data_p;
   jsp_status_t parse_status;
@@ -104,11 +104,11 @@ ecma_op_eval_chars_buffer (const jerry_api_char_t *code_p, /**< code characters 
 
   if (parse_status == JSP_STATUS_SYNTAX_ERROR)
   {
-    completion = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_SYNTAX));
+    completion = ecma_raise_syntax_error ("");
   }
   else if (parse_status == JSP_STATUS_REFERENCE_ERROR)
   {
-    completion = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_REFERENCE));
+    completion = ecma_raise_reference_error ("");
   }
   else
   {

--- a/jerry-core/ecma/operations/ecma-eval.h
+++ b/jerry-core/ecma/operations/ecma-eval.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,10 @@
  * \addtogroup eval eval
  */
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_eval (ecma_string_t *, bool, bool);
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_eval_chars_buffer (const jerry_api_char_t *, size_t, bool, bool);
 
 /**

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -133,10 +133,10 @@ ecma_new_standard_error_with_message (ecma_standard_error_t error_type, /**< nat
 /**
  * Raise a standard ecma-error with the given type and message.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_raise_standard_error (ecma_standard_error_t error_type, /**< error type */
                            const lit_utf8_byte_t *msg_p) /**< error message */
 {
@@ -144,16 +144,16 @@ ecma_raise_standard_error (ecma_standard_error_t error_type, /**< error type */
                                                                lit_zt_utf8_string_size (msg_p));
   ecma_object_t *error_obj_p = ecma_new_standard_error_with_message (error_type, error_msg_p);
   ecma_deref_ecma_string (error_msg_p);
-  return ecma_make_throw_obj_completion_value (error_obj_p);
+  return ecma_make_error_obj_value (error_obj_p);
 } /* ecma_raise_standard_error */
 
 /**
  * Raise a common error with the given message.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_raise_common_error (const char *msg_p) /**< error message */
 {
   return ecma_raise_standard_error (ECMA_ERROR_COMMON, (const lit_utf8_byte_t *) msg_p);
@@ -164,10 +164,10 @@ ecma_raise_common_error (const char *msg_p) /**< error message */
  *
  * See also: ECMA-262 v5, 15.11.6.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_raise_eval_error (const char *msg_p) /**< error message */
 {
   return ecma_raise_standard_error (ECMA_ERROR_EVAL, (const lit_utf8_byte_t *) msg_p);
@@ -178,10 +178,10 @@ ecma_raise_eval_error (const char *msg_p) /**< error message */
  *
  * See also: ECMA-262 v5, 15.11.6.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_raise_range_error (const char *msg_p) /**< error message */
 {
   return ecma_raise_standard_error (ECMA_ERROR_RANGE, (const lit_utf8_byte_t *) msg_p);
@@ -192,10 +192,10 @@ ecma_raise_range_error (const char *msg_p) /**< error message */
  *
  * See also: ECMA-262 v5, 15.11.6.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_raise_reference_error (const char *msg_p) /**< error message */
 {
   return ecma_raise_standard_error (ECMA_ERROR_REFERENCE, (const lit_utf8_byte_t *) msg_p);
@@ -206,10 +206,10 @@ ecma_raise_reference_error (const char *msg_p) /**< error message */
  *
  * See also: ECMA-262 v5, 15.11.6.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_raise_syntax_error (const char *msg_p) /**< error message */
 {
   return ecma_raise_standard_error (ECMA_ERROR_SYNTAX, (const lit_utf8_byte_t *) msg_p);
@@ -220,10 +220,10 @@ ecma_raise_syntax_error (const char *msg_p) /**< error message */
  *
 * See also: ECMA-262 v5, 15.11.6.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_raise_type_error (const char *msg_p) /**< error message */
 {
   return ecma_raise_standard_error (ECMA_ERROR_TYPE, (const lit_utf8_byte_t *) msg_p);
@@ -234,10 +234,10 @@ ecma_raise_type_error (const char *msg_p) /**< error message */
  *
 * See also: ECMA-262 v5, 15.11.6.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_raise_uri_error (const char *msg_p) /**< error message */
 {
   return ecma_raise_standard_error (ECMA_ERROR_URI, (const lit_utf8_byte_t *) msg_p);

--- a/jerry-core/ecma/operations/ecma-exceptions.h
+++ b/jerry-core/ecma/operations/ecma-exceptions.h
@@ -46,14 +46,14 @@ typedef enum
 
 extern ecma_object_t *ecma_new_standard_error (ecma_standard_error_t);
 extern ecma_object_t *ecma_new_standard_error_with_message (ecma_standard_error_t, ecma_string_t *);
-extern ecma_completion_value_t ecma_raise_standard_error (ecma_standard_error_t, const lit_utf8_byte_t *);
-extern ecma_completion_value_t ecma_raise_common_error (const char *);
-extern ecma_completion_value_t ecma_raise_eval_error (const char *);
-extern ecma_completion_value_t ecma_raise_range_error (const char *);
-extern ecma_completion_value_t ecma_raise_reference_error (const char *);
-extern ecma_completion_value_t ecma_raise_syntax_error (const char *);
-extern ecma_completion_value_t ecma_raise_type_error (const char *);
-extern ecma_completion_value_t ecma_raise_uri_error (const char *);
+extern ecma_value_t ecma_raise_standard_error (ecma_standard_error_t, const lit_utf8_byte_t *);
+extern ecma_value_t ecma_raise_common_error (const char *);
+extern ecma_value_t ecma_raise_eval_error (const char *);
+extern ecma_value_t ecma_raise_range_error (const char *);
+extern ecma_value_t ecma_raise_reference_error (const char *);
+extern ecma_value_t ecma_raise_syntax_error (const char *);
+extern ecma_value_t ecma_raise_type_error (const char *);
+extern ecma_value_t ecma_raise_uri_error (const char *);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -40,20 +40,20 @@ ecma_op_function_list_lazy_property_names (bool,
 extern ecma_object_t *
 ecma_op_create_external_function_object (ecma_external_pointer_t);
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_function_call (ecma_object_t *, ecma_value_t,
                        const ecma_value_t *, ecma_length_t);
 
 extern ecma_property_t *
 ecma_op_function_object_get_own_property (ecma_object_t *, ecma_string_t *);
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_function_construct (ecma_object_t *, const ecma_value_t *, ecma_length_t);
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_function_has_instance (ecma_object_t *, ecma_value_t);
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_function_declaration (ecma_object_t *, ecma_string_t *,
                               const ecma_compiled_code_t *, bool, bool);
 

--- a/jerry-core/ecma/operations/ecma-get-put-value.c
+++ b/jerry-core/ecma/operations/ecma-get-put-value.c
@@ -39,10 +39,10 @@
  *
  * See also: ECMA-262 v5, 8.7.1, sections 3 and 5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_get_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, /**< reference's base (lexical environment) */
                                 ecma_string_t *var_name_string_p, /**< variable name */
                                 bool is_strict) /**< flag indicating strict mode */
@@ -52,7 +52,7 @@ ecma_op_get_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, /**< referenc
   // 3.
   if (unlikely (is_unresolvable_reference))
   {
-    return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_REFERENCE));
+    return ecma_raise_reference_error ("");
   }
 
   // 5.
@@ -70,10 +70,10 @@ ecma_op_get_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, /**< referenc
  *
  * See also: ECMA-262 v5, 8.7.1, section 4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_get_value_object_base (ecma_reference_t ref) /**< ECMA-reference */
 {
   const ecma_value_t base = ref.base;
@@ -105,7 +105,7 @@ ecma_op_get_value_object_base (ecma_reference_t ref) /**< ECMA-reference */
   else
   {
     // 4.b case 2
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     // 1.
     ECMA_TRY_CATCH (obj_base, ecma_op_to_object (base), ret_value);
@@ -121,13 +121,12 @@ ecma_op_get_value_object_base (ecma_reference_t ref) /**< ECMA-reference */
     if (prop_p == NULL)
     {
       // 3.
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
     }
     else if (prop_p->type == ECMA_PROPERTY_NAMEDDATA)
     {
       // 4.
-      ecma_value_t prop_value = ecma_copy_value (ecma_get_named_data_property_value (prop_p), true);
-      ret_value = ecma_make_normal_completion_value (prop_value);
+      ret_value = ecma_copy_value (ecma_get_named_data_property_value (prop_p), true);
     }
     else
     {
@@ -139,7 +138,7 @@ ecma_op_get_value_object_base (ecma_reference_t ref) /**< ECMA-reference */
       // 6.
       if (obj_p == NULL)
       {
-        ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+        ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
       }
       else
       {
@@ -159,10 +158,10 @@ ecma_op_get_value_object_base (ecma_reference_t ref) /**< ECMA-reference */
  *
  * See also: ECMA-262 v5, 8.7.2, sections 3 and 5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_put_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, /**< reference's base (lexical environment) */
                                 ecma_string_t *var_name_string_p, /**< variable name */
                                 bool is_strict, /**< flag indicating strict mode */
@@ -176,24 +175,23 @@ ecma_op_put_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, /**< referenc
     // 3.a.
     if (is_strict)
     {
-      return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_REFERENCE));
+      return ecma_raise_reference_error ("");
     }
     else
     {
       // 3.b.
       ecma_object_t *global_object_p = ecma_builtin_get (ECMA_BUILTIN_ID_GLOBAL);
 
-      ecma_completion_value_t completion = ecma_op_object_put (global_object_p,
-                                                               var_name_string_p,
-                                                               value,
-                                                               false);
+      ecma_value_t completion = ecma_op_object_put (global_object_p,
+                                                    var_name_string_p,
+                                                    value,
+                                                    false);
 
       ecma_deref_object (global_object_p);
 
-      JERRY_ASSERT (ecma_is_completion_value_normal_true (completion)
-                    || ecma_is_completion_value_normal_false (completion));
+      JERRY_ASSERT (ecma_is_value_boolean (completion));
 
-      return ecma_make_empty_completion_value ();
+      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
     }
   }
 
@@ -211,19 +209,19 @@ ecma_op_put_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, /**< referenc
 /**
  * Reject sequence for PutValue
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_reject_put (bool is_throw) /**< Throw flag */
 {
   if (is_throw)
   {
-    return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    return ecma_raise_type_error ("");
   }
   else
   {
-    return ecma_make_empty_completion_value ();
+    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   }
 } /* ecma_reject_put */
 
@@ -232,10 +230,10 @@ ecma_reject_put (bool is_throw) /**< Throw flag */
  *
  * See also: ECMA-262 v5, 8.7.2, section 4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_put_value_object_base (ecma_reference_t ref, /**< ECMA-reference */
                                ecma_value_t value) /**< ECMA-value */
 {
@@ -260,7 +258,7 @@ ecma_op_put_value_object_base (ecma_reference_t ref, /**< ECMA-reference */
     JERRY_ASSERT (obj_p != NULL
                   && !ecma_is_lexical_environment (obj_p));
 
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (put_ret_value,
                     ecma_op_object_put (obj_p,
@@ -270,7 +268,7 @@ ecma_op_put_value_object_base (ecma_reference_t ref, /**< ECMA-reference */
                                         ref.is_strict),
                     ret_value);
 
-    ret_value = ecma_make_empty_completion_value ();
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_FINALIZE (put_ret_value);
 
@@ -279,7 +277,7 @@ ecma_op_put_value_object_base (ecma_reference_t ref, /**< ECMA-reference */
   else
   {
     // 4.b case 2
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     // sub_1.
     ECMA_TRY_CATCH (obj_base, ecma_op_to_object (base), ret_value);
@@ -324,7 +322,7 @@ ecma_op_put_value_object_base (ecma_reference_t ref, /**< ECMA-reference */
                         ecma_op_function_call (setter_p, base, &value, 1),
                         ret_value);
 
-        ret_value = ecma_make_empty_completion_value ();
+        ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
         ECMA_FINALIZE (call_ret);
       }

--- a/jerry-core/ecma/operations/ecma-lex-env.h
+++ b/jerry-core/ecma/operations/ecma-lex-env.h
@@ -44,18 +44,18 @@ extern bool ecma_is_lexical_environment_global (ecma_object_t *);
  */
 
 /* ECMA-262 v5, 8.7.1 and 8.7.2 */
-extern ecma_completion_value_t ecma_op_get_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_completion_value_t ecma_op_get_value_object_base (ecma_reference_t);
-extern ecma_completion_value_t ecma_op_put_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool, ecma_value_t);
-extern ecma_completion_value_t ecma_op_put_value_object_base (ecma_reference_t, ecma_value_t);
+extern ecma_value_t ecma_op_get_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool);
+extern ecma_value_t ecma_op_get_value_object_base (ecma_reference_t);
+extern ecma_value_t ecma_op_put_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool, ecma_value_t);
+extern ecma_value_t ecma_op_put_value_object_base (ecma_reference_t, ecma_value_t);
 
 /* ECMA-262 v5, Table 17. Abstract methods of Environment Records */
 extern bool ecma_op_has_binding (ecma_object_t *, ecma_string_t *);
-extern ecma_completion_value_t ecma_op_create_mutable_binding (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_completion_value_t ecma_op_set_mutable_binding (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
-extern ecma_completion_value_t ecma_op_get_binding_value (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_completion_value_t ecma_op_delete_binding (ecma_object_t *, ecma_string_t *);
-extern ecma_completion_value_t ecma_op_implicit_this_value (ecma_object_t *);
+extern ecma_value_t ecma_op_create_mutable_binding (ecma_object_t *, ecma_string_t *, bool);
+extern ecma_value_t ecma_op_set_mutable_binding (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
+extern ecma_value_t ecma_op_get_binding_value (ecma_object_t *, ecma_string_t *, bool);
+extern ecma_value_t ecma_op_delete_binding (ecma_object_t *, ecma_string_t *);
+extern ecma_value_t ecma_op_implicit_this_value (ecma_object_t *);
 
 /* ECMA-262 v5, Table 18. Additional methods of Declarative Environment Records */
 extern void ecma_op_create_immutable_binding (ecma_object_t *, ecma_string_t *);

--- a/jerry-core/ecma/operations/ecma-number-object.c
+++ b/jerry-core/ecma/operations/ecma-number-object.c
@@ -35,20 +35,20 @@
  *
  * See also: ECMA-262 v5, 15.7.2.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Number constructor */
 {
-  ecma_completion_value_t conv_to_num_completion = ecma_op_to_number (arg);
+  ecma_value_t conv_to_num_completion = ecma_op_to_number (arg);
 
-  if (!ecma_is_completion_value_normal (conv_to_num_completion))
+  if (ecma_is_value_error (conv_to_num_completion))
   {
     return conv_to_num_completion;
   }
 
-  ecma_number_t *prim_value_p = ecma_get_number_from_completion_value (conv_to_num_completion);
+  ecma_number_t *prim_value_p = ecma_get_number_from_value (conv_to_num_completion);
 
 #ifndef CONFIG_ECMA_COMPACT_PROFILE_DISABLE_NUMBER_BUILTIN
   ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_NUMBER_PROTOTYPE);
@@ -68,7 +68,7 @@ ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Numb
                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
   ECMA_SET_POINTER (prim_value_prop_p->u.internal_property.value, prim_value_p);
 
-  return ecma_make_normal_completion_value (ecma_make_object_value (obj_p));
+  return ecma_make_object_value (obj_p);
 } /* ecma_op_create_number_object */
 
 /**

--- a/jerry-core/ecma/operations/ecma-number-object.h
+++ b/jerry-core/ecma/operations/ecma-number-object.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-extern ecma_completion_value_t ecma_op_create_number_object (ecma_value_t);
+extern ecma_value_t ecma_op_create_number_object (ecma_value_t);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -60,7 +60,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
        indx < arguments_number;
        indx++)
   {
-    ecma_completion_value_t completion;
+    ecma_value_t completion;
     ecma_string_t *indx_string_p = ecma_new_ecma_string_from_uint32 (indx);
 
     completion = ecma_builtin_helper_def_prop (obj_p,
@@ -71,7 +71,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
                                                true, /* Configurable */
                                                false); /* Failure handling */
 
-    JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+    JERRY_ASSERT (ecma_is_value_true (completion));
 
     ecma_deref_ecma_string (indx_string_p);
   }
@@ -88,15 +88,15 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
 
   // 7.
   ecma_string_t *length_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
-  ecma_completion_value_t completion = ecma_builtin_helper_def_prop (obj_p,
-                                                                     length_magic_string_p,
-                                                                     ecma_make_number_value (len_p),
-                                                                     true, /* Writable */
-                                                                     false, /* Enumerable */
-                                                                     true, /* Configurable */
-                                                                     false); /* Failure handling */
+  ecma_value_t completion = ecma_builtin_helper_def_prop (obj_p,
+                                                          length_magic_string_p,
+                                                          ecma_make_number_value (len_p),
+                                                          true, /* Writable */
+                                                          false, /* Enumerable */
+                                                          true, /* Configurable */
+                                                          false); /* Failure handling */
 
-  JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+  JERRY_ASSERT (ecma_is_value_true (completion));
   ecma_deref_ecma_string (length_magic_string_p);
 
   ecma_dealloc_number (len_p);
@@ -156,7 +156,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
                                                          indx_string_p,
                                                          &prop_desc,
                                                          false);
-        JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+        JERRY_ASSERT (ecma_is_value_true (completion));
 
         ecma_deref_ecma_string (indx_string_p);
         ecma_deref_ecma_string (name_p);
@@ -197,7 +197,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
                                                true, /* Configurable */
                                                false); /* Failure handling */
 
-    JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+    JERRY_ASSERT (ecma_is_value_true (completion));
 
     ecma_deref_ecma_string (callee_magic_string_p);
   }
@@ -227,7 +227,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
                                                      callee_magic_string_p,
                                                      &prop_desc,
                                                      false);
-    JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+    JERRY_ASSERT (ecma_is_value_true (completion));
     ecma_deref_ecma_string (callee_magic_string_p);
 
     ecma_string_t *caller_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CALLER);
@@ -235,7 +235,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
                                                      caller_magic_string_p,
                                                      &prop_desc,
                                                      false);
-    JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+    JERRY_ASSERT (ecma_is_value_true (completion));
     ecma_deref_ecma_string (caller_magic_string_p);
 
     ecma_deref_object (thrower_p);
@@ -252,17 +252,17 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
   }
   else
   {
-    ecma_completion_value_t completion = ecma_op_create_mutable_binding (lex_env_p,
-                                                                         arguments_string_p,
-                                                                         false);
-    JERRY_ASSERT (ecma_is_completion_value_empty (completion));
+    ecma_value_t completion = ecma_op_create_mutable_binding (lex_env_p,
+                                                              arguments_string_p,
+                                                              false);
+    JERRY_ASSERT (ecma_is_value_empty (completion));
 
     completion = ecma_op_set_mutable_binding (lex_env_p,
                                               arguments_string_p,
                                               ecma_make_object_value (obj_p),
                                               false);
 
-    JERRY_ASSERT (ecma_is_completion_value_empty (completion));
+    JERRY_ASSERT (ecma_is_value_empty (completion));
   }
 
   ecma_deref_ecma_string (arguments_string_p);
@@ -275,10 +275,10 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
  * Note:
  *      The procedure emulates execution of function described by MakeArgGetter
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-static ecma_completion_value_t
+static ecma_value_t
 ecma_arguments_get_mapped_arg_value (ecma_object_t *map_p, /**< [[ParametersMap]] object */
                                      ecma_property_t *arg_name_prop_p) /**< property of [[ParametersMap]]
                                                                             corresponding to index and value
@@ -294,10 +294,8 @@ ecma_arguments_get_mapped_arg_value (ecma_object_t *map_p, /**< [[ParametersMap]
 
   ecma_string_t *arg_name_p = ecma_get_string_from_value (arg_name_prop_value);
 
-  ecma_completion_value_t completion = ecma_op_get_binding_value (lex_env_p,
-                                                                  arg_name_p,
-                                                                  true);
-  JERRY_ASSERT (ecma_is_completion_value_normal (completion));
+  ecma_value_t completion = ecma_op_get_binding_value (lex_env_p, arg_name_p, true);
+  JERRY_ASSERT (!ecma_is_value_error (completion));
 
   return completion;
 } /* ecma_arguments_get_mapped_arg_value */
@@ -309,10 +307,10 @@ ecma_arguments_get_mapped_arg_value (ecma_object_t *map_p, /**< [[ParametersMap]
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *          ECMA-262 v5, 10.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_arguments_object_get (ecma_object_t *obj_p, /**< the object */
                               ecma_string_t *property_name_p) /**< property name */
 {
@@ -346,8 +344,8 @@ ecma_op_arguments_object_get (ecma_object_t *obj_p, /**< the object */
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *          ECMA-262 v5, 10.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
 ecma_property_t*
 ecma_op_arguments_object_get_own_property (ecma_object_t *obj_p, /**< the object */
@@ -374,11 +372,11 @@ ecma_op_arguments_object_get_own_property (ecma_object_t *obj_p, /**< the object
   if (mapped_prop_p != NULL)
   {
     // a.
-    ecma_completion_value_t completion = ecma_arguments_get_mapped_arg_value (map_p, mapped_prop_p);
+    ecma_value_t completion = ecma_arguments_get_mapped_arg_value (map_p, mapped_prop_p);
 
-    ecma_named_data_property_assign_value (obj_p, desc_p, ecma_get_completion_value_value (completion));
+    ecma_named_data_property_assign_value (obj_p, desc_p, completion);
 
-    ecma_free_completion_value (completion);
+    ecma_free_value (completion);
   }
 
   // 6.
@@ -392,10 +390,10 @@ ecma_op_arguments_object_get_own_property (ecma_object_t *obj_p, /**< the object
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *          ECMA-262 v5, 10.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the object */
                                               ecma_string_t *property_name_p, /**< property name */
                                               const ecma_property_descriptor_t *property_desc_p, /**< property
@@ -411,7 +409,7 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the obj
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
 
   // 3.
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (defined,
                   ecma_op_general_object_define_own_property (obj_p,
@@ -427,18 +425,18 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the obj
     if (property_desc_p->is_get_defined
         || property_desc_p->is_set_defined)
     {
-      ecma_completion_value_t completion = ecma_op_object_delete (map_p, property_name_p, false);
+      ecma_value_t completion = ecma_op_object_delete (map_p, property_name_p, false);
 
-      JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+      JERRY_ASSERT (ecma_is_value_true (completion));
 
       // 6.
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
     }
     else
     {
       // b.
 
-      ecma_completion_value_t completion = ecma_make_empty_completion_value ();
+      ecma_value_t completion = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
       // i.
       if (property_desc_p->is_value_defined)
@@ -457,7 +455,7 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the obj
                                                   arg_name_p,
                                                   property_desc_p->value,
                                                   true);
-        JERRY_ASSERT (ecma_is_completion_value_empty (completion));
+        JERRY_ASSERT (ecma_is_value_empty (completion));
       }
 
       // ii.
@@ -468,16 +466,16 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the obj
                                             property_name_p,
                                             false);
 
-        JERRY_ASSERT (ecma_is_completion_value_normal_true (completion));
+        JERRY_ASSERT (ecma_is_value_true (completion));
       }
 
       // 6.
-      ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
     }
   }
   else
   {
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
 
   ECMA_FINALIZE (defined);
@@ -492,10 +490,10 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the obj
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *          ECMA-262 v5, 10.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_arguments_object_delete (ecma_object_t *obj_p, /**< the object */
                                  ecma_string_t *property_name_p, /**< property name */
                                  bool is_throw) /**< flag that controls failure handling */
@@ -509,7 +507,7 @@ ecma_op_arguments_object_delete (ecma_object_t *obj_p, /**< the object */
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
 
   // 3.
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (delete_in_args_ret,
                   ecma_op_general_object_delete (obj_p,
@@ -521,19 +519,17 @@ ecma_op_arguments_object_delete (ecma_object_t *obj_p, /**< the object */
   {
     if (mapped_prop_p != NULL)
     {
-      ecma_completion_value_t delete_in_map_completion = ecma_op_object_delete (map_p,
-                                                                                property_name_p,
-                                                                                false);
-      JERRY_ASSERT (ecma_is_completion_value_normal_true (delete_in_map_completion));
+      ecma_value_t delete_in_map_completion = ecma_op_object_delete (map_p, property_name_p, false);
+      JERRY_ASSERT (ecma_is_value_true (delete_in_map_completion));
     }
 
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
   else
   {
     JERRY_ASSERT (ecma_is_value_boolean (delete_in_args_ret));
 
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
 
   ECMA_FINALIZE (delete_in_args_ret);

--- a/jerry-core/ecma/operations/ecma-objects-arguments.h
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.h
@@ -23,13 +23,13 @@ extern void
 ecma_op_create_arguments_object (ecma_object_t *, ecma_object_t *, const ecma_value_t *,
                                  ecma_length_t, const ecma_compiled_code_t *);
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_arguments_object_get (ecma_object_t *, ecma_string_t *);
 extern ecma_property_t *
 ecma_op_arguments_object_get_own_property (ecma_object_t *, ecma_string_t *);
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_arguments_object_delete (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_arguments_object_define_own_property (ecma_object_t *, ecma_string_t *,
                                               const ecma_property_descriptor_t *, bool);
 

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -34,19 +34,19 @@
 /**
  * Reject sequence
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_reject (bool is_throw) /**< Throw flag */
 {
   if (is_throw)
   {
-    return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    return ecma_raise_type_error ("");
   }
   else
   {
-    return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
+    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
 } /* ecma_reject */
 
@@ -77,7 +77,7 @@ ecma_op_create_object_object_noarg (void)
  *
  * @return pointer to newly created 'Object' object
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_create_object_object_arg (ecma_value_t value) /**< argument of constructor */
 {
   ecma_check_value_type_is_spec_defined (value);
@@ -98,7 +98,7 @@ ecma_op_create_object_object_arg (ecma_value_t value) /**< argument of construct
 
     ecma_object_t *obj_p = ecma_op_create_object_object_noarg ();
 
-    return ecma_make_normal_completion_value (ecma_make_object_value (obj_p));
+    return ecma_make_object_value (obj_p);
   }
 } /* ecma_op_create_object_object_arg */
 
@@ -135,10 +135,10 @@ ecma_op_create_object_object_noarg_and_set_prototype (ecma_object_t *object_prot
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *          ECMA-262 v5, 8.12.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_general_object_get (ecma_object_t *obj_p, /**< the object */
                             ecma_string_t *property_name_p) /**< property name */
 {
@@ -152,14 +152,13 @@ ecma_op_general_object_get (ecma_object_t *obj_p, /**< the object */
   // 2.
   if (prop_p == NULL)
   {
-    return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
   }
 
   // 3.
   if (prop_p->type == ECMA_PROPERTY_NAMEDDATA)
   {
-    return ecma_make_normal_completion_value (ecma_copy_value (ecma_get_named_data_property_value (prop_p),
-                                                               true));
+    return ecma_copy_value (ecma_get_named_data_property_value (prop_p), true);
   }
   else
   {
@@ -169,7 +168,7 @@ ecma_op_general_object_get (ecma_object_t *obj_p, /**< the object */
     // 5.
     if (getter_p == NULL)
     {
-      return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
     }
     else
     {
@@ -252,13 +251,13 @@ ecma_op_general_object_get_property (ecma_object_t *obj_p, /**< the object */
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *          ECMA-262 v5, 8.12.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_general_object_put (ecma_object_t *obj_p, /**< the object */
                             ecma_string_t *property_name_p, /**< property name */
-                            ecma_value_t value, /**< ecma-value */
+                            ecma_value_t value, /**< ecma value */
                             bool is_throw) /**< flag that controls failure handling */
 {
   JERRY_ASSERT (obj_p != NULL
@@ -271,12 +270,12 @@ ecma_op_general_object_put (ecma_object_t *obj_p, /**< the object */
     if (is_throw)
     {
       // a.
-      return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+      return ecma_raise_type_error ("");
     }
     else
     {
       // b.
-      return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
+      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
     }
   }
 
@@ -312,7 +311,7 @@ ecma_op_general_object_put (ecma_object_t *obj_p, /**< the object */
     ecma_object_t *setter_p = ecma_get_named_accessor_property_setter (desc_p);
     JERRY_ASSERT (setter_p != NULL);
 
-    ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+    ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (call_ret,
                     ecma_op_function_call (setter_p,
@@ -321,7 +320,7 @@ ecma_op_general_object_put (ecma_object_t *obj_p, /**< the object */
                                            1),
                     ret_value);
 
-    ret_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
 
     ECMA_FINALIZE (call_ret);
 
@@ -449,10 +448,10 @@ ecma_op_general_object_can_put (ecma_object_t *obj_p, /**< the object */
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *          ECMA-262 v5, 8.12.7
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_general_object_delete (ecma_object_t *obj_p, /**< the object */
                                ecma_string_t *property_name_p, /**< property name */
                                bool is_throw) /**< flag that controls failure handling */
@@ -467,7 +466,7 @@ ecma_op_general_object_delete (ecma_object_t *obj_p, /**< the object */
   // 2.
   if (desc_p == NULL)
   {
-    return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
 
   // 3.
@@ -477,17 +476,17 @@ ecma_op_general_object_delete (ecma_object_t *obj_p, /**< the object */
     ecma_delete_property (obj_p, desc_p);
 
     // b.
-    return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
   else if (is_throw)
   {
     // 4.
-    return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    return ecma_raise_type_error ("");
   }
   else
   {
     // 5.
-    return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_FALSE);
+    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
 
   JERRY_UNREACHABLE ();
@@ -500,10 +499,10 @@ ecma_op_general_object_delete (ecma_object_t *obj_p, /**< the object */
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *          ECMA-262 v5, 8.12.8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
                                       ecma_preferred_type_hint_t hint) /**< hint on preferred result type */
 {
@@ -538,20 +537,20 @@ ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
 
     ecma_string_t *function_name_p = ecma_get_magic_string (function_name_magic_string_id);
 
-    ecma_completion_value_t function_value_get_completion = ecma_op_object_get (obj_p, function_name_p);
+    ecma_value_t function_value_get_completion = ecma_op_object_get (obj_p, function_name_p);
 
     ecma_deref_ecma_string (function_name_p);
 
-    if (!ecma_is_completion_value_normal (function_value_get_completion))
+    if (ecma_is_value_error (function_value_get_completion))
     {
       return function_value_get_completion;
     }
 
-    ecma_completion_value_t call_completion = ecma_make_empty_completion_value ();
+    ecma_value_t call_completion = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
-    if (ecma_op_is_callable (ecma_get_completion_value_value (function_value_get_completion)))
+    if (ecma_op_is_callable (function_value_get_completion))
     {
-      ecma_object_t *func_obj_p = ecma_get_object_from_completion_value (function_value_get_completion);
+      ecma_object_t *func_obj_p = ecma_get_object_from_value (function_value_get_completion);
 
       call_completion = ecma_op_function_call (func_obj_p,
                                                ecma_make_object_value (obj_p),
@@ -559,23 +558,19 @@ ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
                                                0);
     }
 
-    ecma_free_completion_value (function_value_get_completion);
+    ecma_free_value (function_value_get_completion);
 
-    if (!ecma_is_completion_value_normal (call_completion))
+    if (ecma_is_value_error (call_completion)
+        || (!ecma_is_value_empty (call_completion)
+           && !ecma_is_value_object (call_completion)))
     {
       return call_completion;
     }
 
-    if (!ecma_is_completion_value_empty (call_completion)
-        && !ecma_is_value_object (ecma_get_completion_value_value (call_completion)))
-    {
-      return call_completion;
-    }
-
-    ecma_free_completion_value (call_completion);
+    ecma_free_value (call_completion);
   }
 
-  return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+  return ecma_raise_type_error ("");
 } /* ecma_op_general_object_default_value */
 
 /**
@@ -585,10 +580,10 @@ ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *          ECMA-262 v5, 8.12.9
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the object */
                                             ecma_string_t *property_name_p, /**< property name */
                                             const ecma_property_descriptor_t *property_desc_p, /**< property
@@ -650,7 +645,7 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
 
     }
 
-    return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
 
   // 5.
@@ -658,7 +653,7 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
       && !property_desc_p->is_enumerable_defined
       && !property_desc_p->is_configurable_defined)
   {
-    return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
 
   // 6.
@@ -723,7 +718,7 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
 
   if (is_every_field_in_desc_also_occurs_in_current_desc_with_same_value)
   {
-    return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
 
   // 7.
@@ -863,7 +858,7 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
     ecma_set_property_configurable_attr (current_p, property_desc_p->is_configurable);
   }
 
-  return ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+  return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
 } /* ecma_op_general_object_define_own_property */
 
 /**

--- a/jerry-core/ecma/operations/ecma-objects-general.h
+++ b/jerry-core/ecma/operations/ecma-objects-general.h
@@ -26,20 +26,20 @@
  * @{
  */
 
-extern ecma_completion_value_t ecma_reject (bool);
+extern ecma_value_t ecma_reject (bool);
 extern ecma_object_t *ecma_op_create_object_object_noarg (void);
-extern ecma_completion_value_t ecma_op_create_object_object_arg (ecma_value_t);
+extern ecma_value_t ecma_op_create_object_object_arg (ecma_value_t);
 extern ecma_object_t *ecma_op_create_object_object_noarg_and_set_prototype (ecma_object_t *);
 
-extern ecma_completion_value_t ecma_op_general_object_get (ecma_object_t *, ecma_string_t *);
+extern ecma_value_t ecma_op_general_object_get (ecma_object_t *, ecma_string_t *);
 extern ecma_property_t *ecma_op_general_object_get_own_property (ecma_object_t *, ecma_string_t *);
 extern ecma_property_t *ecma_op_general_object_get_property (ecma_object_t *, ecma_string_t *);
-extern ecma_completion_value_t ecma_op_general_object_put (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
+extern ecma_value_t ecma_op_general_object_put (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
 extern bool ecma_op_general_object_can_put (ecma_object_t *, ecma_string_t *);
-extern ecma_completion_value_t ecma_op_general_object_delete (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_completion_value_t ecma_op_general_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);
-extern ecma_completion_value_t
-ecma_op_general_object_define_own_property (ecma_object_t *, ecma_string_t *, const ecma_property_descriptor_t *, bool);
+extern ecma_value_t ecma_op_general_object_delete (ecma_object_t *, ecma_string_t *, bool);
+extern ecma_value_t ecma_op_general_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);
+extern ecma_value_t ecma_op_general_object_define_own_property (ecma_object_t *, ecma_string_t *,
+                                                                const ecma_property_descriptor_t *, bool);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -53,10 +53,10 @@ ecma_assert_object_type_is_valid (ecma_object_type_t type) /**< object's impleme
  * See also:
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_object_get (ecma_object_t *obj_p, /**< the object */
                     ecma_string_t *property_name_p) /**< property name */
 {
@@ -88,7 +88,7 @@ ecma_op_object_get (ecma_object_t *obj_p, /**< the object */
 
   JERRY_ASSERT (false);
 
-  return ecma_make_empty_completion_value ();
+  return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 } /* ecma_op_object_get */
 
 /**
@@ -229,13 +229,13 @@ ecma_op_object_get_property (ecma_object_t *obj_p, /**< the object */
  * See also:
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_object_put (ecma_object_t *obj_p, /**< the object */
                     ecma_string_t *property_name_p, /**< property name */
-                    ecma_value_t value, /**< ecma-value */
+                    ecma_value_t value, /**< ecma value */
                     bool is_throw) /**< flag that controls failure handling */
 {
   JERRY_ASSERT (obj_p != NULL
@@ -311,10 +311,10 @@ ecma_op_object_can_put (ecma_object_t *obj_p, /**< the object */
  * See also:
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_object_delete (ecma_object_t *obj_p, /**< the object */
                        ecma_string_t *property_name_p, /**< property name */
                        bool is_throw) /**< flag that controls failure handling */
@@ -351,7 +351,7 @@ ecma_op_object_delete (ecma_object_t *obj_p, /**< the object */
 
   JERRY_ASSERT (false);
 
-  return ecma_make_empty_completion_value ();
+  return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 } /* ecma_op_object_delete */
 
 /**
@@ -360,10 +360,10 @@ ecma_op_object_delete (ecma_object_t *obj_p, /**< the object */
  * See also:
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_object_default_value (ecma_object_t *obj_p, /**< the object */
                               ecma_preferred_type_hint_t hint) /**< hint on preferred result type */
 {
@@ -399,10 +399,10 @@ ecma_op_object_default_value (ecma_object_t *obj_p, /**< the object */
  * See also:
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_object_define_own_property (ecma_object_t *obj_p, /**< the object */
                                     ecma_string_t *property_name_p, /**< property name */
                                     const ecma_property_descriptor_t *property_desc_p, /**< property
@@ -450,7 +450,7 @@ ecma_op_object_define_own_property (ecma_object_t *obj_p, /**< the object */
 
   JERRY_ASSERT (false);
 
-  return ecma_make_empty_completion_value ();
+  return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 } /* ecma_op_object_define_own_property */
 
 /**
@@ -459,7 +459,7 @@ ecma_op_object_define_own_property (ecma_object_t *obj_p, /**< the object */
  * See also:
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 9
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_object_has_instance (ecma_object_t *obj_p, /**< the object */
                              ecma_value_t value) /**< argument 'V' */
 {
@@ -476,7 +476,7 @@ ecma_op_object_has_instance (ecma_object_t *obj_p, /**< the object */
     case ECMA_OBJECT_TYPE_STRING:
     case ECMA_OBJECT_TYPE_ARGUMENTS:
     {
-      return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+      return ecma_raise_type_error ("");
     }
 
     case ECMA_OBJECT_TYPE_FUNCTION:

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -26,16 +26,16 @@
  * @{
  */
 
-extern ecma_completion_value_t ecma_op_object_get (ecma_object_t *, ecma_string_t *);
+extern ecma_value_t ecma_op_object_get (ecma_object_t *, ecma_string_t *);
 extern ecma_property_t *ecma_op_object_get_own_property (ecma_object_t *, ecma_string_t *);
 extern ecma_property_t *ecma_op_object_get_property (ecma_object_t *, ecma_string_t *);
-extern ecma_completion_value_t ecma_op_object_put (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
+extern ecma_value_t ecma_op_object_put (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
 extern bool ecma_op_object_can_put (ecma_object_t *, ecma_string_t *);
-extern ecma_completion_value_t ecma_op_object_delete (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_completion_value_t ecma_op_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);
-extern ecma_completion_value_t
-ecma_op_object_define_own_property (ecma_object_t *, ecma_string_t *, const ecma_property_descriptor_t *, bool);
-extern ecma_completion_value_t ecma_op_object_has_instance (ecma_object_t *, ecma_value_t);
+extern ecma_value_t ecma_op_object_delete (ecma_object_t *, ecma_string_t *, bool);
+extern ecma_value_t ecma_op_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);
+extern ecma_value_t ecma_op_object_define_own_property (ecma_object_t *, ecma_string_t *,
+                                                        const ecma_property_descriptor_t *, bool);
+extern ecma_value_t ecma_op_object_has_instance (ecma_object_t *, ecma_value_t);
 extern bool ecma_op_object_is_prototype_of (ecma_object_t *, ecma_object_t *);
 extern ecma_collection_header_t * ecma_op_object_get_property_names (ecma_object_t *, bool, bool, bool);
 

--- a/jerry-core/ecma/operations/ecma-reference.c
+++ b/jerry-core/ecma/operations/ecma-reference.c
@@ -117,7 +117,7 @@ ecma_make_reference (ecma_value_t base, /**< base value */
 void
 ecma_free_reference (ecma_reference_t ref) /**< reference */
 {
-  ecma_free_value (ref.base, true);
+  ecma_free_value (ref.base);
   ecma_deref_ecma_string (ECMA_GET_NON_NULL_POINTER (ecma_string_t,
                                                      ref.referenced_name_cp));
 } /* ecma_free_reference */

--- a/jerry-core/ecma/operations/ecma-regexp-object.h
+++ b/jerry-core/ecma/operations/ecma-regexp-object.h
@@ -32,9 +32,9 @@
 /**
  * RegExp flags
  */
-#define RE_FLAG_GLOBAL              (1 << 1) /* ECMA-262 v5, 15.10.7.2 */
-#define RE_FLAG_IGNORE_CASE         (1 << 2) /* ECMA-262 v5, 15.10.7.3 */
-#define RE_FLAG_MULTILINE           (1 << 3) /* ECMA-262 v5, 15.10.7.4 */
+#define RE_FLAG_GLOBAL              (1u << 1) /* ECMA-262 v5, 15.10.7.2 */
+#define RE_FLAG_IGNORE_CASE         (1u << 2) /* ECMA-262 v5, 15.10.7.3 */
+#define RE_FLAG_MULTILINE           (1u << 3) /* ECMA-262 v5, 15.10.7.4 */
 
 /**
  * RegExp executor context
@@ -53,10 +53,10 @@ typedef struct
 extern ecma_value_t
 ecma_op_create_regexp_object_from_bytecode (re_compiled_code_t *);
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_create_regexp_object (ecma_string_t *, ecma_string_t *);
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_regexp_exec_helper (ecma_value_t, ecma_value_t, bool);
 
 extern ecma_char_t
@@ -64,7 +64,7 @@ re_canonicalize (ecma_char_t, bool);
 extern void
 re_set_result_array_properties (ecma_object_t *, ecma_string_t *, uint32_t, int32_t);
 
-extern ecma_completion_value_t
+extern ecma_value_t
 re_parse_regexp_flags (ecma_string_t *, uint16_t *);
 
 extern void

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -35,10 +35,10 @@
  *
  * See also: ECMA-262 v5, 15.5.2.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of arguments that
                                                                          are passed to String constructor */
                               ecma_length_t arguments_list_len) /**< length of the arguments' list */
@@ -57,18 +57,18 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
   }
   else
   {
-    ecma_completion_value_t to_str_arg_value = ecma_op_to_string (arguments_list_p[0]);
+    ecma_value_t to_str_arg_value = ecma_op_to_string (arguments_list_p[0]);
 
-    if (ecma_is_completion_value_throw (to_str_arg_value))
+    if (ecma_is_value_error (to_str_arg_value))
     {
       return to_str_arg_value;
     }
     else
     {
-      JERRY_ASSERT (ecma_is_completion_value_normal (to_str_arg_value));
+      JERRY_ASSERT (!ecma_is_value_error (to_str_arg_value));
+      JERRY_ASSERT (ecma_is_value_string (to_str_arg_value));
 
-      JERRY_ASSERT (ecma_is_value_string (ecma_get_completion_value_value (to_str_arg_value)));
-      prim_prop_str_value_p = ecma_get_string_from_completion_value (to_str_arg_value);
+      prim_prop_str_value_p = ecma_get_string_from_value (to_str_arg_value);
 
       ecma_length_t string_len = ecma_string_get_length (prim_prop_str_value_p);
       length_value = ecma_uint32_to_number ((uint32_t) string_len);
@@ -106,7 +106,7 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
   ecma_set_named_data_property_value (length_prop_p, ecma_make_number_value (length_prop_value_p));
   ecma_deref_ecma_string (length_magic_string_p);
 
-  return ecma_make_normal_completion_value (ecma_make_object_value (obj_p));
+  return ecma_make_object_value (obj_p);
 } /* ecma_op_create_string_object */
 
 /**
@@ -116,8 +116,8 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
  *          ECMA-262 v5, 15.5.5.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
 ecma_property_t*
 ecma_op_string_object_get_own_property (ecma_object_t *obj_p, /**< a String object */

--- a/jerry-core/ecma/operations/ecma-string-object.h
+++ b/jerry-core/ecma/operations/ecma-string-object.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-extern ecma_completion_value_t
+extern ecma_value_t
 ecma_op_create_string_object (const ecma_value_t *, ecma_length_t);
 
 extern ecma_property_t *

--- a/jerry-core/ecma/operations/ecma-try-catch-macro.h
+++ b/jerry-core/ecma/operations/ecma-try-catch-macro.h
@@ -30,17 +30,15 @@
  *      statement with same argument as corresponding ECMA_TRY_CATCH's first argument.
  */
 #define ECMA_TRY_CATCH(var, op, return_value) \
-  JERRY_ASSERT (return_value == ecma_make_empty_completion_value ()); \
-  ecma_completion_value_t var ## _completion = op; \
-  if (unlikely (ecma_is_completion_value_throw (var ## _completion))) \
+  JERRY_ASSERT (return_value == ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY)); \
+  ecma_value_t var ## _completion = op; \
+  if (unlikely (ecma_is_value_error (var ## _completion))) \
   { \
     return_value = var ## _completion; \
   } \
   else \
   { \
-    JERRY_ASSERT (ecma_is_completion_value_normal (var ## _completion)); \
-    \
-    ecma_value_t var __attr_unused___ = ecma_get_completion_value_value (var ## _completion)
+    ecma_value_t var __attr_unused___ = var ## _completion;
 
 /**
  * The macro marks end of code block that is defined by corresponding
@@ -50,7 +48,8 @@
  *      Each ECMA_TRY_CATCH should be followed by ECMA_FINALIZE with same argument
  *      as corresponding ECMA_TRY_CATCH's first argument.
  */
-#define ECMA_FINALIZE(var) ecma_free_completion_value (var ## _completion); \
+#define ECMA_FINALIZE(var) \
+    ecma_free_value (var ## _completion); \
   }
 
 /**
@@ -65,7 +64,7 @@
  *      statement with same argument as corresponding ECMA_OP_TO_NUMBER_TRY_CATCH's first argument.
  */
 #define ECMA_OP_TO_NUMBER_TRY_CATCH(num_var, value, return_value) \
-  JERRY_ASSERT (ecma_is_completion_value_empty (return_value)); \
+  JERRY_ASSERT (return_value == ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY)); \
   ecma_number_t num_var = ecma_number_make_nan (); \
   if (ecma_is_value_number (value)) \
   { \
@@ -82,7 +81,7 @@
     ECMA_FINALIZE (to_number_value); \
   } \
   \
-  if (ecma_is_completion_value_empty (return_value)) \
+  if (ecma_is_value_empty (return_value)) \
   {
 
 /**

--- a/jerry-core/jerry-internal.h
+++ b/jerry-core/jerry-internal.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 #include "ecma-globals.h"
 #include "jerry-api.h"
 
-extern ecma_completion_value_t
+extern ecma_value_t
 jerry_dispatch_external_function (ecma_object_t *, ecma_external_pointer_t, ecma_value_t, ecma_collection_header_t *);
 
 extern void

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -363,7 +363,7 @@ jerry_api_create_string_value (jerry_api_string_t *value) /**< jerry_api_string_
 } /* jerry_api_create_string_value */
 
 /**
- * Convert ecma-value to Jerry API value representation
+ * Convert ecma value to Jerry API value representation
  *
  * Note:
  *      if the output value contains string / object, it should be freed
@@ -372,7 +372,7 @@ jerry_api_create_string_value (jerry_api_string_t *value) /**< jerry_api_string_
  */
 static void
 jerry_api_convert_ecma_value_to_api_value (jerry_api_value_t *out_value_p, /**< out: api value */
-                                           ecma_value_t value) /**< ecma-value (undefined,
+                                           ecma_value_t value) /**< ecma value (undefined,
                                                                 *   null, boolean, number,
                                                                 *   string or object */
 {
@@ -428,13 +428,13 @@ jerry_api_convert_ecma_value_to_api_value (jerry_api_value_t *out_value_p, /**< 
 } /* jerry_api_convert_ecma_value_to_api_value */
 
 /**
- * Convert value, represented in Jerry API format, to ecma-value.
+ * Convert value, represented in Jerry API format, to ecma value.
  *
  * Note:
- *      the output ecma-value should be freed with ecma_free_value when it becomes unnecessary.
+ *      the output ecma value should be freed with ecma_free_value when it becomes unnecessary.
  */
 static void
-jerry_api_convert_api_value_to_ecma_value (ecma_value_t *out_value_p, /**< out: ecma-value */
+jerry_api_convert_api_value_to_ecma_value (ecma_value_t *out_value_p, /**< out: ecma value */
                                            const jerry_api_value_t *api_value_p) /**< value in Jerry API format */
 {
   switch (api_value_p->type)
@@ -521,32 +521,22 @@ jerry_api_convert_api_value_to_ecma_value (ecma_value_t *out_value_p, /**< out: 
  */
 static jerry_completion_code_t
 jerry_api_convert_eval_completion_to_retval (jerry_api_value_t *retval_p, /**< out: api value */
-                                             ecma_completion_value_t completion) /**< completion of 'eval'-mode
-                                                                                  *   code execution */
+                                             ecma_value_t completion) /**< completion of 'eval'-mode
+                                                                       *   code execution */
 {
   jerry_completion_code_t ret_code;
 
-  if (ecma_is_completion_value_normal (completion))
+  if (!ecma_is_value_error (completion))
   {
-    ret_code = JERRY_COMPLETION_CODE_OK;
+    jerry_api_convert_ecma_value_to_api_value (retval_p, completion);
 
-    jerry_api_convert_ecma_value_to_api_value (retval_p,
-                                               ecma_get_completion_value_value (completion));
+    ret_code = JERRY_COMPLETION_CODE_OK;
   }
   else
   {
     jerry_api_convert_ecma_value_to_api_value (retval_p, ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED));
 
-    if (ecma_is_completion_value_throw (completion))
-    {
-      ret_code = JERRY_COMPLETION_CODE_UNHANDLED_EXCEPTION;
-    }
-    else
-    {
-      JERRY_ASSERT (ecma_is_completion_value_empty (completion));
-
-      ret_code = JERRY_COMPLETION_CODE_OK;
-    }
+    ret_code = JERRY_COMPLETION_CODE_UNHANDLED_EXCEPTION;
   }
 
   return ret_code;
@@ -730,12 +720,11 @@ jerry_api_create_array_object (jerry_api_size_t size) /* size of array */
   ecma_value_t array_length = ecma_make_number_value (length_num_p);
 
   jerry_api_length_t argument_size = 1;
-  ecma_completion_value_t new_array_completion = ecma_op_create_array_object (&array_length, argument_size, true);
-  JERRY_ASSERT (ecma_is_completion_value_normal (new_array_completion));
-  ecma_value_t val = ecma_get_completion_value_value (new_array_completion);
-  jerry_api_object_t *obj_p = ecma_get_object_from_value (val);
+  ecma_value_t new_array_completion = ecma_op_create_array_object (&array_length, argument_size, true);
+  JERRY_ASSERT (!ecma_is_value_error (new_array_completion));
+  jerry_api_object_t *obj_p = ecma_get_object_from_value (new_array_completion);
 
-  ecma_free_value (array_length, true);
+  ecma_free_value (array_length);
   return obj_p;
 } /* jerry_api_create_array_object */
 
@@ -753,12 +742,12 @@ jerry_api_set_array_index_value (jerry_api_object_t *array_obj_p, /* array objec
   ecma_string_t *str_idx_p = ecma_new_ecma_string_from_uint32 ((uint32_t) index);
   ecma_value_t value;
   jerry_api_convert_api_value_to_ecma_value (&value, value_p);
-  ecma_completion_value_t set_completion = ecma_op_object_put (array_obj_p, str_idx_p, value, false);
-  JERRY_ASSERT (ecma_is_completion_value_normal (set_completion));
+  ecma_value_t set_completion = ecma_op_object_put (array_obj_p, str_idx_p, value, false);
+  JERRY_ASSERT (!ecma_is_value_error (set_completion));
 
-  ecma_free_completion_value (set_completion);
+  ecma_free_value (set_completion);
   ecma_deref_ecma_string (str_idx_p);
-  ecma_free_value (value, true);
+  ecma_free_value (value);
 
   return true;
 } /* jerry_api_set_array_index_value */
@@ -780,12 +769,11 @@ jerry_api_get_array_index_value (jerry_api_object_t *array_obj_p, /* array objec
                                  jerry_api_value_t *value_p) /* output value at index */
 {
   ecma_string_t *str_idx_p = ecma_new_ecma_string_from_uint32 ((uint32_t) index);
-  ecma_completion_value_t get_completion = ecma_op_object_get (array_obj_p, str_idx_p);
-  JERRY_ASSERT (ecma_is_completion_value_normal (get_completion));
-  ecma_value_t val = ecma_get_completion_value_value (get_completion);
-  jerry_api_convert_ecma_value_to_api_value (value_p, val);
+  ecma_value_t get_completion = ecma_op_object_get (array_obj_p, str_idx_p);
+  JERRY_ASSERT (!ecma_is_value_error (get_completion));
+  jerry_api_convert_ecma_value_to_api_value (value_p, get_completion);
 
-  ecma_free_completion_value (get_completion);
+  ecma_free_value (get_completion);
   ecma_deref_ecma_string (str_idx_p);
 
   return true;
@@ -911,10 +899,10 @@ jerry_api_create_external_function (jerry_external_handler_t handler_p) /**< poi
  *       if called native handler returns true, then dispatcher just returns value received
  *       through 'return value' output argument, otherwise - throws the value as an exception.
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 jerry_dispatch_external_function (ecma_object_t *function_object_p, /**< external function object */
                                   ecma_external_pointer_t handler_p, /**< pointer to the function's native handler */
                                   ecma_value_t this_arg_value, /**< 'this' argument */
@@ -924,7 +912,7 @@ jerry_dispatch_external_function (ecma_object_t *function_object_p, /**< externa
 
   const ecma_length_t args_count = (arg_collection_p != NULL ? arg_collection_p->unit_number : 0);
 
-  ecma_completion_value_t completion_value;
+  ecma_value_t completion_value;
 
   MEM_DEFINE_LOCAL_ARRAY (api_arg_values, args_count, jerry_api_value_t);
 
@@ -957,11 +945,11 @@ jerry_dispatch_external_function (ecma_object_t *function_object_p, /**< externa
 
   if (is_successful)
   {
-    completion_value = ecma_make_normal_completion_value (ret_value);
+    completion_value = ret_value;
   }
   else
   {
-    completion_value = ecma_make_throw_completion_value (ret_value);
+    completion_value = ecma_make_error_value (ret_value);
   }
 
   jerry_api_release_value (&api_ret_value);
@@ -1071,7 +1059,7 @@ jerry_api_add_object_field (jerry_api_object_t *object_p, /**< object to add fie
                                                 true);
       ecma_named_data_property_assign_value (object_p, prop_p, value_to_put);
 
-      ecma_free_value (value_to_put, true);
+      ecma_free_value (value_to_put);
     }
 
     ecma_deref_ecma_string (field_name_str_p);
@@ -1099,18 +1087,16 @@ jerry_api_delete_object_field (jerry_api_object_t *object_p, /**< object to dele
   ecma_string_t *field_name_str_p = ecma_new_ecma_string_from_utf8 ((lit_utf8_byte_t *) field_name_p,
                                                                     (lit_utf8_size_t) field_name_size);
 
-  ecma_completion_value_t delete_completion = ecma_op_object_delete (object_p,
-                                                                     field_name_str_p,
-                                                                     true);
+  ecma_value_t delete_completion = ecma_op_object_delete (object_p,
+                                                          field_name_str_p,
+                                                          true);
 
-  if (!ecma_is_completion_value_normal (delete_completion))
+  if (ecma_is_value_error (delete_completion))
   {
-    JERRY_ASSERT (ecma_is_completion_value_throw (delete_completion));
-
     is_successful = false;
   }
 
-  ecma_free_completion_value (delete_completion);
+  ecma_free_value (delete_completion);
 
   ecma_deref_ecma_string (field_name_str_p);
 
@@ -1158,11 +1144,11 @@ jerry_api_foreach_object_field (jerry_api_object_t *object_p, /**< object */
   ecma_collection_header_t *names_p = ecma_op_object_get_property_names (object_p, false, true, true);
   ecma_collection_iterator_init (&names_iter, names_p);
 
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   bool continuous = true;
 
-  while (ecma_is_completion_value_empty (ret_value)
+  while (ecma_is_value_empty (ret_value)
          && continuous
          && ecma_collection_iterator_next (&names_iter))
   {
@@ -1181,15 +1167,15 @@ jerry_api_foreach_object_field (jerry_api_object_t *object_p, /**< object */
   }
 
   ecma_free_values_collection (names_p, true);
-  if (ecma_is_completion_value_empty (ret_value))
+  if (ecma_is_value_empty (ret_value))
   {
     return true;
   }
   else
   {
-    JERRY_ASSERT (ecma_is_completion_value_throw (ret_value));
+    JERRY_ASSERT (ecma_is_value_error (ret_value));
 
-    ecma_free_completion_value (ret_value);
+    ecma_free_value (ret_value);
 
     return false;
   }
@@ -1220,23 +1206,19 @@ jerry_api_get_object_field_value_sz (jerry_api_object_t *object_p, /**< object *
   ecma_string_t *field_name_str_p = ecma_new_ecma_string_from_utf8 ((lit_utf8_byte_t *) field_name_p,
                                                                     (lit_utf8_size_t) field_name_size);
 
-  ecma_completion_value_t get_completion = ecma_op_object_get (object_p,
-                                                               field_name_str_p);
+  ecma_value_t get_completion = ecma_op_object_get (object_p,
+                                                    field_name_str_p);
 
-  if (ecma_is_completion_value_normal (get_completion))
+  if (!ecma_is_value_error (get_completion))
   {
-    ecma_value_t val = ecma_get_completion_value_value (get_completion);
-
-    jerry_api_convert_ecma_value_to_api_value (field_value_p, val);
+    jerry_api_convert_ecma_value_to_api_value (field_value_p, get_completion);
   }
   else
   {
-    JERRY_ASSERT (ecma_is_completion_value_throw (get_completion));
-
     is_successful = false;
   }
 
-  ecma_free_completion_value (get_completion);
+  ecma_free_value (get_completion);
 
   ecma_deref_ecma_string (field_name_str_p);
 
@@ -1284,21 +1266,19 @@ jerry_api_set_object_field_value_sz (jerry_api_object_t *object_p, /**< object *
   ecma_value_t value_to_put;
   jerry_api_convert_api_value_to_ecma_value (&value_to_put, field_value_p);
 
-  ecma_completion_value_t set_completion = ecma_op_object_put (object_p,
-                                                               field_name_str_p,
-                                                               value_to_put,
-                                                               true);
+  ecma_value_t set_completion = ecma_op_object_put (object_p,
+                                                    field_name_str_p,
+                                                    value_to_put,
+                                                    true);
 
-  if (!ecma_is_completion_value_normal (set_completion))
+  if (ecma_is_value_error (set_completion))
   {
-    JERRY_ASSERT (ecma_is_completion_value_throw (set_completion));
-
     is_successful = false;
   }
 
-  ecma_free_completion_value (set_completion);
+  ecma_free_value (set_completion);
 
-  ecma_free_value (value_to_put, true);
+  ecma_free_value (value_to_put);
   ecma_deref_ecma_string (field_name_str_p);
 
   return is_successful;
@@ -1413,7 +1393,7 @@ jerry_api_invoke_function (bool is_invoke_as_constructor, /**< true - invoke fun
     jerry_api_convert_api_value_to_ecma_value (arguments_list_p + i, args_p + i);
   }
 
-  ecma_completion_value_t call_completion;
+  ecma_value_t call_completion;
 
   if (is_invoke_as_constructor)
   {
@@ -1445,25 +1425,22 @@ jerry_api_invoke_function (bool is_invoke_as_constructor, /**< true - invoke fun
                                              args_count);
   }
 
-  if (!ecma_is_completion_value_normal (call_completion))
+  if (ecma_is_value_error (call_completion))
   {
     /* unhandled exception during the function call */
-    JERRY_ASSERT (ecma_is_completion_value_throw (call_completion));
-
     is_successful = false;
   }
 
   if (retval_p != NULL)
   {
-    jerry_api_convert_ecma_value_to_api_value (retval_p,
-                                               ecma_get_completion_value_value (call_completion));
+    jerry_api_convert_ecma_value_to_api_value (retval_p, call_completion);
   }
 
-  ecma_free_completion_value (call_completion);
+  ecma_free_value (call_completion);
 
   for (uint32_t i = 0; i < args_count; ++i)
   {
-    ecma_free_value (arguments_list_p[i], true);
+    ecma_free_value (arguments_list_p[i]);
   }
 
   MEM_FINALIZE_LOCAL_ARRAY (arguments_list_p);
@@ -1605,14 +1582,14 @@ jerry_api_eval (const jerry_api_char_t *source_p, /**< source code */
 
   jerry_completion_code_t status;
 
-  ecma_completion_value_t completion = ecma_op_eval_chars_buffer ((const lit_utf8_byte_t *) source_p,
-                                                                  source_size,
-                                                                  is_direct,
-                                                                  is_strict);
+  ecma_value_t completion = ecma_op_eval_chars_buffer ((const lit_utf8_byte_t *) source_p,
+                                                       source_size,
+                                                       is_direct,
+                                                       is_strict);
 
   status = jerry_api_convert_eval_completion_to_retval (retval_p, completion);
 
-  ecma_free_completion_value (completion);
+  ecma_free_value (completion);
 
   return status;
 } /* jerry_api_eval */
@@ -2010,8 +1987,8 @@ jerry_snapshot_set_offsets (uint8_t *buffer_p, /**< buffer */
     ecma_compiled_code_t *bytecode_p = (ecma_compiled_code_t *) buffer_p;
 
     /* Set reference counter to 1. */
-    bytecode_p->status_flags &= (1 << ECMA_BYTECODE_REF_SHIFT) - 1;
-    bytecode_p->status_flags |= 1 << ECMA_BYTECODE_REF_SHIFT;
+    bytecode_p->status_flags &= (1u << ECMA_BYTECODE_REF_SHIFT) - 1;
+    bytecode_p->status_flags |= 1u << ECMA_BYTECODE_REF_SHIFT;
 
     if (bytecode_p->status_flags & CBC_CODE_FLAGS_FUNCTION)
     {
@@ -2451,11 +2428,11 @@ jerry_exec_snapshot (const void *snapshot_p, /**< snapshot */
   else
   {
     /* vm should be already initialized */
-    ecma_completion_value_t completion = vm_run_eval (bytecode_p, false);
+    ecma_value_t completion = vm_run_eval (bytecode_p, false);
 
     ret_code = jerry_api_convert_eval_completion_to_retval (retval_p, completion);
 
-    ecma_free_completion_value (completion);
+    ecma_free_value (completion);
   }
 
   return ret_code;

--- a/jerry-core/mem/mem-allocator.h
+++ b/jerry-core/mem/mem-allocator.h
@@ -41,7 +41,7 @@ typedef uint16_t mem_cpointer_t;
 /**
  * Required alignment for allocated units/blocks
  */
-#define MEM_ALIGNMENT       (1 << MEM_ALIGNMENT_LOG)
+#define MEM_ALIGNMENT       (1u << MEM_ALIGNMENT_LOG)
 
 /**
  * Width of compressed memory pointer

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -1809,7 +1809,7 @@ lexer_construct_regexp_object (parser_context_t *context_p, /**< context */
 
   /* Compile the RegExp literal and store the RegExp bytecode pointer */
   re_compiled_code_t *re_bytecode_p = NULL;
-  ecma_completion_value_t completion_value;
+  ecma_value_t completion_value;
 
   ecma_string_t *pattern_str_p = ecma_new_ecma_string_from_utf8 (regex_start_p, length);
   // FIXME: check return value of 're_compile_bytecode' and throw an error
@@ -1818,9 +1818,9 @@ lexer_construct_regexp_object (parser_context_t *context_p, /**< context */
                                           current_flags);
   ecma_deref_ecma_string (pattern_str_p);
 
-  bool is_throw = ecma_is_completion_value_throw (completion_value);
+  bool is_throw = ecma_is_value_error (completion_value);
 
-  ecma_free_completion_value (completion_value);
+  ecma_free_value (completion_value);
 
   if (is_throw)
   {

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1462,7 +1462,7 @@ parser_post_processing (parser_context_t *context_p) /**< context */
   compiled_code_p = (ecma_compiled_code_t *) parser_malloc (context_p, total_size);
 
   byte_code_p = (uint8_t *) compiled_code_p;
-  compiled_code_p->status_flags = CBC_CODE_FLAGS_FUNCTION | (1 << ECMA_BYTECODE_REF_SHIFT);
+  compiled_code_p->status_flags = CBC_CODE_FLAGS_FUNCTION | (1u << ECMA_BYTECODE_REF_SHIFT);
 
   if (needs_uint16_arguments)
   {

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -389,20 +389,20 @@ re_insert_into_group_with_jump (re_compiler_ctx_t *re_ctx_p, /**< RegExp compile
  * Parse alternatives
  *
  * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ *         Returned value must be freed with ecma_free_value
  */
-static ecma_completion_value_t
+static ecma_value_t
 re_parse_alternative (re_compiler_ctx_t *re_ctx_p, /**< RegExp compiler context */
                       bool expect_eof) /**< expect end of file */
 {
   uint32_t idx;
   re_bytecode_ctx_t *bc_ctx_p = re_ctx_p->bytecode_ctx_p;
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   uint32_t alterantive_offset = re_get_bytecode_length (re_ctx_p->bytecode_ctx_p);
   bool should_loop = true;
 
-  while (ecma_is_completion_value_empty (ret_value) && should_loop)
+  while (ecma_is_value_empty (ret_value) && should_loop)
   {
     ECMA_TRY_CATCH (empty,
                     re_parse_next_token (re_ctx_p->parser_ctx_p,
@@ -420,7 +420,7 @@ re_parse_alternative (re_compiler_ctx_t *re_ctx_p, /**< RegExp compiler context 
 
         ret_value = re_parse_alternative (re_ctx_p, false);
 
-        if (ecma_is_completion_value_empty (ret_value))
+        if (ecma_is_value_empty (ret_value))
         {
           re_insert_into_group (re_ctx_p, new_atom_start_offset, idx, true);
         }
@@ -434,7 +434,7 @@ re_parse_alternative (re_compiler_ctx_t *re_ctx_p, /**< RegExp compiler context 
 
         ret_value = re_parse_alternative (re_ctx_p, false);
 
-        if (ecma_is_completion_value_empty (ret_value))
+        if (ecma_is_value_empty (ret_value))
         {
           re_insert_into_group (re_ctx_p, new_atom_start_offset, idx, false);
         }
@@ -507,7 +507,7 @@ re_parse_alternative (re_compiler_ctx_t *re_ctx_p, /**< RegExp compiler context 
 
         ret_value = re_parse_alternative (re_ctx_p, false);
 
-        if (ecma_is_completion_value_empty (ret_value))
+        if (ecma_is_value_empty (ret_value))
         {
           re_append_opcode (bc_ctx_p, RE_OP_MATCH);
 
@@ -524,7 +524,7 @@ re_parse_alternative (re_compiler_ctx_t *re_ctx_p, /**< RegExp compiler context 
 
         ret_value = re_parse_alternative (re_ctx_p, false);
 
-        if (ecma_is_completion_value_empty (ret_value))
+        if (ecma_is_value_empty (ret_value))
         {
           re_append_opcode (bc_ctx_p, RE_OP_MATCH);
 
@@ -628,14 +628,14 @@ re_parse_alternative (re_compiler_ctx_t *re_ctx_p, /**< RegExp compiler context 
  * Compilation of RegExp bytecode
  *
  * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 re_compile_bytecode (re_compiled_code_t **out_bytecode_p, /**< out:pointer to bytecode */
                      ecma_string_t *pattern_str_p, /**< pattern */
                      uint16_t flags) /**< flags */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   re_compiler_ctx_t re_ctx;
   re_ctx.flags = flags;
   re_ctx.highest_backref = 0;
@@ -680,7 +680,7 @@ re_compile_bytecode (re_compiled_code_t **out_bytecode_p, /**< out:pointer to by
     /* 3. Insert extra informations for bytecode header */
     re_compiled_code_t re_compiled_code;
 
-    re_compiled_code.flags = re_ctx.flags | (1 << ECMA_BYTECODE_REF_SHIFT);
+    re_compiled_code.flags = re_ctx.flags | (1u << ECMA_BYTECODE_REF_SHIFT);
     ECMA_SET_NON_NULL_POINTER (re_compiled_code.pattern_cp,
                                ecma_copy_or_ref_ecma_string (pattern_str_p));
     re_compiled_code.num_of_captures = re_ctx.num_of_captures * 2;
@@ -695,7 +695,7 @@ re_compile_bytecode (re_compiled_code_t **out_bytecode_p, /**< out:pointer to by
 
   MEM_FINALIZE_LOCAL_ARRAY (pattern_start_p);
 
-  if (!ecma_is_completion_value_empty (ret_value))
+  if (!ecma_is_value_empty (ret_value))
   {
     /* Compilation failed, free bytecode. */
     mem_heap_free_block (bc_ctx.block_start_p);

--- a/jerry-core/parser/regexp/re-compiler.h
+++ b/jerry-core/parser/regexp/re-compiler.h
@@ -111,7 +111,7 @@ typedef struct
   re_parser_ctx_t *parser_ctx_p;     /**< pointer of RegExp parser context */
 } re_compiler_ctx_t;
 
-ecma_completion_value_t
+ecma_value_t
 re_compile_bytecode (re_compiled_code_t **, ecma_string_t *, uint16_t);
 
 re_opcode_t

--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -1,5 +1,5 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,13 +106,13 @@ re_parse_octal (re_parser_ctx_t *parser_ctx_p) /**< RegExp parser context */
  * Parse RegExp iterators
  *
  * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ *         Returned value must be freed with ecma_free_value
  */
-static ecma_completion_value_t
+static ecma_value_t
 re_parse_iterator (re_parser_ctx_t *parser_ctx_p, /**< RegExp parser context */
                    re_token_t *re_token_p) /**< out: output token */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   re_token_p->qmin = 1;
   re_token_p->qmax = 1;
@@ -239,7 +239,7 @@ re_parse_iterator (re_parser_ctx_t *parser_ctx_p, /**< RegExp parser context */
     }
   }
 
-  JERRY_ASSERT (ecma_is_completion_value_empty (ret_value));
+  JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
   if (re_token_p->qmin > re_token_p->qmax)
   {
@@ -299,9 +299,9 @@ re_count_num_of_groups (re_parser_ctx_t *parser_ctx_p) /**< RegExp parser contex
  * Read the input pattern and parse the range of character class
  *
  * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 re_parse_char_class (re_parser_ctx_t *parser_ctx_p, /**< number of classes */
                      re_char_class_callback append_char_class, /**< callback function,
                                                                 *   which adds the char-ranges
@@ -557,13 +557,13 @@ re_parse_char_class (re_parser_ctx_t *parser_ctx_p, /**< number of classes */
  * Read the input pattern and parse the next token for the RegExp compiler
  *
  * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 re_parse_next_token (re_parser_ctx_t *parser_ctx_p, /**< RegExp parser context */
                      re_token_t *out_token_p) /**< out: output token */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (parser_ctx_p->input_curr_p >= parser_ctx_p->input_end_p)
   {

--- a/jerry-core/parser/regexp/re-parser.h
+++ b/jerry-core/parser/regexp/re-parser.h
@@ -106,10 +106,10 @@ typedef struct
 
 typedef void (*re_char_class_callback) (void *re_ctx_p, uint32_t start, uint32_t end);
 
-ecma_completion_value_t
+ecma_value_t
 re_parse_char_class (re_parser_ctx_t *, re_char_class_callback, void *, re_token_t *);
 
-ecma_completion_value_t
+ecma_value_t
 re_parse_next_token (re_parser_ctx_t *, re_token_t *);
 
 /**

--- a/jerry-core/vm/opcodes-ecma-arithmetics.c
+++ b/jerry-core/vm/opcodes-ecma-arithmetics.c
@@ -37,15 +37,15 @@
  *   rightNum = ToNumber (rightValue);
  *   result = leftNum ArithmeticOp rightNum;
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 do_number_arithmetic (number_arithmetic_op op, /**< number arithmetic operation */
                       ecma_value_t left_value, /**< left value */
                       ecma_value_t right_value) /**< right value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (num_left, left_value, ret_value);
   ECMA_OP_TO_NUMBER_TRY_CATCH (num_right, right_value, ret_value);
@@ -81,7 +81,7 @@ do_number_arithmetic (number_arithmetic_op op, /**< number arithmetic operation 
     }
   }
 
-  ret_value = ecma_make_completion_value (ECMA_COMPLETION_TYPE_NORMAL, ecma_make_number_value (res_p));
+  ret_value = ecma_make_number_value (res_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (num_right);
   ECMA_OP_TO_NUMBER_FINALIZE (num_left);
@@ -94,14 +94,14 @@ do_number_arithmetic (number_arithmetic_op op, /**< number arithmetic operation 
  *
  * See also: ECMA-262 v5, 11.6.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_addition (ecma_value_t left_value, /**< left value */
                  ecma_value_t right_value) /**< right value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (prim_left_value,
                   ecma_op_to_primitive (left_value,
@@ -123,7 +123,7 @@ opfunc_addition (ecma_value_t left_value, /**< left value */
 
     ecma_string_t *concat_str_p = ecma_concat_ecma_strings (string1_p, string2_p);
 
-    ret_value = ecma_make_completion_value (ECMA_COMPLETION_TYPE_NORMAL, ecma_make_string_value (concat_str_p));
+    ret_value = ecma_make_string_value (concat_str_p);
 
     ECMA_FINALIZE (str_right_value);
     ECMA_FINALIZE (str_left_value);
@@ -146,13 +146,13 @@ opfunc_addition (ecma_value_t left_value, /**< left value */
  *
  * See also: ECMA-262 v5, 11.4, 11.4.6
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_unary_plus (ecma_value_t left_value) /**< left value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (num_var_value,
                                left_value,
@@ -161,7 +161,7 @@ opfunc_unary_plus (ecma_value_t left_value) /**< left value */
   ecma_number_t *tmp_p = ecma_alloc_number ();
 
   *tmp_p = num_var_value;
-  ret_value = ecma_make_completion_value (ECMA_COMPLETION_TYPE_NORMAL, ecma_make_number_value (tmp_p));
+  ret_value = ecma_make_number_value (tmp_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (num_var_value);
 
@@ -173,13 +173,13 @@ opfunc_unary_plus (ecma_value_t left_value) /**< left value */
  *
  * See also: ECMA-262 v5, 11.4, 11.4.7
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_unary_minus (ecma_value_t left_value) /**< left value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (num_var_value,
                                left_value,
@@ -188,7 +188,7 @@ opfunc_unary_minus (ecma_value_t left_value) /**< left value */
   ecma_number_t *tmp_p = ecma_alloc_number ();
 
   *tmp_p = ecma_number_negate (num_var_value);
-  ret_value = ecma_make_completion_value (ECMA_COMPLETION_TYPE_NORMAL, ecma_make_number_value (tmp_p));
+  ret_value = ecma_make_number_value (tmp_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (num_var_value);
 

--- a/jerry-core/vm/opcodes-ecma-bitwise.c
+++ b/jerry-core/vm/opcodes-ecma-bitwise.c
@@ -35,15 +35,15 @@
  *   rightNum = ToNumber (rightValue);
  *   result = leftNum BitwiseLogicOp rightNum;
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 do_number_bitwise_logic (number_bitwise_logic_op op, /**< number bitwise logic operation */
                          ecma_value_t left_value, /**< left value */
                          ecma_value_t right_value) /**< right value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (num_left, left_value, ret_value);
   ECMA_OP_TO_NUMBER_TRY_CATCH (num_right, right_value, ret_value);
@@ -94,7 +94,7 @@ do_number_bitwise_logic (number_bitwise_logic_op op, /**< number bitwise logic o
     }
   }
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_number_value (res_p));
+  ret_value = ecma_make_number_value (res_p);
 
   ECMA_OP_TO_NUMBER_FINALIZE (num_right);
   ECMA_OP_TO_NUMBER_FINALIZE (num_left);

--- a/jerry-core/vm/opcodes-ecma-equality.c
+++ b/jerry-core/vm/opcodes-ecma-equality.c
@@ -37,14 +37,14 @@
  *
  * See also: ECMA-262 v5, 11.9.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_equal_value (ecma_value_t left_value, /**< left value */
                     ecma_value_t right_value) /**< right value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (compare_result,
                   ecma_op_abstract_equality_compare (left_value,
@@ -53,7 +53,7 @@ opfunc_equal_value (ecma_value_t left_value, /**< left value */
 
   JERRY_ASSERT (ecma_is_value_boolean (compare_result));
 
-  ret_value = ecma_make_normal_completion_value (compare_result);
+  ret_value = compare_result;
 
   ECMA_FINALIZE (compare_result);
 
@@ -65,14 +65,14 @@ opfunc_equal_value (ecma_value_t left_value, /**< left value */
  *
  * See also: ECMA-262 v5, 11.9.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_not_equal_value (ecma_value_t left_value, /**< left value */
                         ecma_value_t right_value) /**< right value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (compare_result,
                   ecma_op_abstract_equality_compare (left_value, right_value),
@@ -82,8 +82,8 @@ opfunc_not_equal_value (ecma_value_t left_value, /**< left value */
 
   bool is_equal = ecma_is_value_true (compare_result);
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_FALSE
-                                                                                  : ECMA_SIMPLE_VALUE_TRUE));
+  ret_value = ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_FALSE
+                                               : ECMA_SIMPLE_VALUE_TRUE);
 
   ECMA_FINALIZE (compare_result);
 
@@ -95,17 +95,17 @@ opfunc_not_equal_value (ecma_value_t left_value, /**< left value */
  *
  * See also: ECMA-262 v5, 11.9.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_equal_value_type (ecma_value_t left_value, /**< left value */
                          ecma_value_t right_value) /**< right value */
 {
   bool is_equal = ecma_op_strict_equality_compare (left_value, right_value);
 
-  return ecma_make_normal_completion_value (ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE
-                                                                             : ECMA_SIMPLE_VALUE_FALSE));
+  return ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE
+                                          : ECMA_SIMPLE_VALUE_FALSE);
 } /* opfunc_equal_value_type */
 
 /**
@@ -113,17 +113,17 @@ opfunc_equal_value_type (ecma_value_t left_value, /**< left value */
  *
  * See also: ECMA-262 v5, 11.9.5
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_not_equal_value_type (ecma_value_t left_value, /**< left value */
                              ecma_value_t right_value) /**< right value */
 {
   bool is_equal = ecma_op_strict_equality_compare (left_value, right_value);
 
-  return ecma_make_normal_completion_value (ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_FALSE
-                                                                             : ECMA_SIMPLE_VALUE_TRUE));
+  return ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_FALSE
+                                          : ECMA_SIMPLE_VALUE_TRUE);
 } /* opfunc_not_equal_value_type */
 
 /**

--- a/jerry-core/vm/opcodes-ecma-relational.c
+++ b/jerry-core/vm/opcodes-ecma-relational.c
@@ -34,33 +34,29 @@
  *
  * See also: ECMA-262 v5, 11.8.1
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_less_than (ecma_value_t left_value, /**< left value */
                   ecma_value_t right_value) /**< right value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (compare_result,
                   ecma_op_abstract_relational_compare (left_value, right_value, true),
                   ret_value);
 
-  ecma_simple_value_t res;
-
   if (ecma_is_value_undefined (compare_result))
   {
-    res = ECMA_SIMPLE_VALUE_FALSE;
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
   else
   {
     JERRY_ASSERT (ecma_is_value_boolean (compare_result));
 
-    res = (ecma_is_value_true (compare_result) ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+    ret_value = compare_result;
   }
-
-  ret_value = ecma_make_simple_completion_value (res);
 
   ECMA_FINALIZE (compare_result);
 
@@ -72,33 +68,29 @@ opfunc_less_than (ecma_value_t left_value, /**< left value */
  *
  * See also: ECMA-262 v5, 11.8.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_greater_than (ecma_value_t left_value, /**< left value */
                      ecma_value_t right_value) /**< right value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (compare_result,
                   ecma_op_abstract_relational_compare (right_value, left_value, false),
                   ret_value);
 
-  ecma_simple_value_t res;
-
   if (ecma_is_value_undefined (compare_result))
   {
-    res = ECMA_SIMPLE_VALUE_FALSE;
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
   else
   {
     JERRY_ASSERT (ecma_is_value_boolean (compare_result));
 
-    res = (ecma_is_value_true (compare_result) ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+    ret_value = compare_result;
   }
-
-  ret_value = ecma_make_simple_completion_value (res);
 
   ECMA_FINALIZE (compare_result);
 
@@ -110,24 +102,22 @@ opfunc_greater_than (ecma_value_t left_value, /**< left value */
  *
  * See also: ECMA-262 v5, 11.8.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_less_or_equal_than (ecma_value_t left_value, /**< left value */
                            ecma_value_t right_value) /**< right value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (compare_result,
                   ecma_op_abstract_relational_compare (right_value, left_value, false),
                   ret_value);
 
-  ecma_simple_value_t res;
-
   if (ecma_is_value_undefined (compare_result))
   {
-    res = ECMA_SIMPLE_VALUE_FALSE;
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
   else
   {
@@ -135,15 +125,13 @@ opfunc_less_or_equal_than (ecma_value_t left_value, /**< left value */
 
     if (ecma_is_value_true (compare_result))
     {
-      res = ECMA_SIMPLE_VALUE_FALSE;
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
     }
     else
     {
-      res = ECMA_SIMPLE_VALUE_TRUE;
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
     }
   }
-
-  ret_value = ecma_make_simple_completion_value (res);
 
   ECMA_FINALIZE (compare_result);
 
@@ -155,24 +143,22 @@ opfunc_less_or_equal_than (ecma_value_t left_value, /**< left value */
  *
  * See also: ECMA-262 v5, 11.8.4
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_greater_or_equal_than (ecma_value_t left_value, /**< left value */
                               ecma_value_t right_value) /**< right value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (compare_result,
                   ecma_op_abstract_relational_compare (left_value, right_value, true),
                   ret_value);
 
-  ecma_simple_value_t res;
-
   if (ecma_is_value_undefined (compare_result))
   {
-    res = ECMA_SIMPLE_VALUE_FALSE;
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
   else
   {
@@ -180,15 +166,13 @@ opfunc_greater_or_equal_than (ecma_value_t left_value, /**< left value */
 
     if (ecma_is_value_true (compare_result))
     {
-      res = ECMA_SIMPLE_VALUE_FALSE;
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
     }
     else
     {
-      res = ECMA_SIMPLE_VALUE_TRUE;
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
     }
   }
-
-  ret_value = ecma_make_simple_completion_value (res);
 
   ECMA_FINALIZE (compare_result);
 
@@ -200,18 +184,18 @@ opfunc_greater_or_equal_than (ecma_value_t left_value, /**< left value */
  *
  * See also: ECMA-262 v5, 11.8.6
  *
- * @return completion value
- *         returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_instanceof (ecma_value_t left_value, /**< left value */
                    ecma_value_t right_value) /**< right value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (right_value))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -221,7 +205,7 @@ opfunc_instanceof (ecma_value_t left_value, /**< left value */
                     ecma_op_object_has_instance (right_value_obj_p, left_value),
                     ret_value);
 
-    ret_value = ecma_make_normal_completion_value (is_instance_of);
+    ret_value = is_instance_of;
 
     ECMA_FINALIZE (is_instance_of);
   }
@@ -234,37 +218,34 @@ opfunc_instanceof (ecma_value_t left_value, /**< left value */
  *
  * See also: ECMA-262 v5, 11.8.7
  *
- * @return completion value
- *         returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_in (ecma_value_t left_value, /**< left value */
            ecma_value_t right_value) /**< right value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_value_object (right_value))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
     ECMA_TRY_CATCH (str_left_value, ecma_op_to_string (left_value), ret_value);
 
-    ecma_simple_value_t is_in = ECMA_SIMPLE_VALUE_UNDEFINED;
     ecma_string_t *left_value_prop_name_p = ecma_get_string_from_value (str_left_value);
     ecma_object_t *right_value_obj_p = ecma_get_object_from_value (right_value);
 
     if (ecma_op_object_get_property (right_value_obj_p, left_value_prop_name_p) != NULL)
     {
-      is_in = ECMA_SIMPLE_VALUE_TRUE;
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
     }
     else
     {
-      is_in = ECMA_SIMPLE_VALUE_FALSE;
+      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
     }
-
-    ret_value = ecma_make_simple_completion_value (is_in);
 
     ECMA_FINALIZE (str_left_value);
   }

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -40,20 +40,20 @@
  *
  * See also: ECMA-262 v5, 11.2.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_call_n (ecma_value_t this_value, /**< this object value */
                ecma_value_t func_value, /**< function object value */
                const ecma_value_t *arguments_list_p, /**< stack pointer */
                ecma_length_t arguments_list_len) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_op_is_callable (func_value))
   {
-    return ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    return ecma_raise_type_error ("");
   }
 
   ecma_object_t *func_obj_p = ecma_get_object_from_value (func_value);
@@ -71,19 +71,19 @@ opfunc_call_n (ecma_value_t this_value, /**< this object value */
  *
  * See also: ECMA-262 v5, 11.2.2
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value.
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value.
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_construct_n (ecma_value_t constructor_value, /**< constructor object value */
                     const ecma_value_t *arguments_list_p, /**< stack pointer */
                     ecma_length_t arguments_list_len) /**< number of arguments */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (!ecma_is_constructor (constructor_value))
   {
-    ret_value = ecma_make_throw_obj_completion_value (ecma_new_standard_error (ECMA_ERROR_TYPE));
+    ret_value = ecma_raise_type_error ("");
   }
   else
   {
@@ -95,7 +95,7 @@ opfunc_construct_n (ecma_value_t constructor_value, /**< constructor object valu
                                                 arguments_list_len),
                     ret_value);
 
-    ret_value = ecma_make_normal_completion_value (ecma_copy_value (construction_ret_value, true));
+    ret_value = ecma_copy_value (construction_ret_value, true);
 
     ECMA_FINALIZE (construction_ret_value);
   }
@@ -108,11 +108,11 @@ opfunc_construct_n (ecma_value_t constructor_value, /**< constructor object valu
  *
  * See also: ECMA-262 v5, 10.5 - Declaration binding instantiation (block 8).
  *
- * @return completion value
+ * @return ecma value
  *         Returned value is simple and so need not be freed.
- *         However, ecma_free_completion_value may be called for it, but it is a no-op.
+ *         However, ecma_free_value may be called for it, but it is a no-op.
  */
-ecma_completion_value_t
+ecma_value_t
 vm_var_decl (vm_frame_ctx_t *frame_ctx_p, /**< interpreter context */
              ecma_string_t *var_name_str_p) /**< variable name */
 {
@@ -120,21 +120,20 @@ vm_var_decl (vm_frame_ctx_t *frame_ctx_p, /**< interpreter context */
   {
     const bool is_configurable_bindings = frame_ctx_p->is_eval_code;
 
-    ecma_completion_value_t completion = ecma_op_create_mutable_binding (frame_ctx_p->lex_env_p,
-                                                                         var_name_str_p,
-                                                                         is_configurable_bindings);
+    ecma_value_t completion_value = ecma_op_create_mutable_binding (frame_ctx_p->lex_env_p,
+                                                                    var_name_str_p,
+                                                                    is_configurable_bindings);
 
-    JERRY_ASSERT (ecma_is_completion_value_empty (completion));
+    JERRY_ASSERT (ecma_is_value_empty (completion_value));
 
     /* Skipping SetMutableBinding as we have already checked that there were not
      * any binding with specified name in current lexical environment
      * and CreateMutableBinding sets the created binding's value to undefined */
-    JERRY_ASSERT (ecma_is_completion_value_normal_simple_value (ecma_op_get_binding_value (frame_ctx_p->lex_env_p,
-                                                                                           var_name_str_p,
-                                                                                           true),
-                                                                ECMA_SIMPLE_VALUE_UNDEFINED));
+    JERRY_ASSERT (ecma_is_value_undefined (ecma_op_get_binding_value (frame_ctx_p->lex_env_p,
+                                                                      var_name_str_p,
+                                                                      true)));
   }
-  return ecma_make_empty_completion_value ();
+  return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 } /* vm_var_decl */
 
 /**
@@ -142,23 +141,19 @@ vm_var_decl (vm_frame_ctx_t *frame_ctx_p, /**< interpreter context */
  *
  * See also: ECMA-262 v5, 11.4.9
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_logical_not (ecma_value_t left_value) /**< left value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
+  ecma_value_t to_bool_value = ecma_op_to_boolean (left_value);
 
-  ecma_simple_value_t old_value = ECMA_SIMPLE_VALUE_TRUE;
-  ecma_completion_value_t to_bool_value = ecma_op_to_boolean (left_value);
-
-  if (ecma_is_value_true (ecma_get_completion_value_value (to_bool_value)))
+  if (ecma_is_value_true (to_bool_value))
   {
-    old_value = ECMA_SIMPLE_VALUE_FALSE;
+    ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
-
-  ret_value = ecma_make_simple_completion_value (old_value);
 
   return ret_value;
 } /* opfunc_logical_not */
@@ -168,13 +163,13 @@ opfunc_logical_not (ecma_value_t left_value) /**< left value */
  *
  * See also: ECMA-262 v5, 11.4.3
  *
- * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 opfunc_typeof (ecma_value_t left_value) /**< left value */
 {
-  ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
+  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ecma_string_t *type_str_p = NULL;
 
@@ -212,7 +207,7 @@ opfunc_typeof (ecma_value_t left_value) /**< left value */
     }
   }
 
-  ret_value = ecma_make_normal_completion_value (ecma_make_string_value (type_str_p));
+  ret_value = ecma_make_string_value (type_str_p);
 
   return ret_value;
 } /* opfunc_typeof */
@@ -278,22 +273,23 @@ opfunc_set_accessor (bool is_getter, /**< is getter accessor */
 /**
  * Deletes an object property.
  *
- * @return completion value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 vm_op_delete_prop (ecma_value_t object, /**< base object */
                    ecma_value_t property, /**< property name */
                    bool is_strict) /**< strict mode */
 {
-  ecma_completion_value_t completion_value = ecma_make_empty_completion_value ();
+  ecma_value_t completion_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   if (ecma_is_value_undefined (object))
   {
-    completion_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    completion_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
   else
   {
-    completion_value = ecma_make_empty_completion_value ();
+    completion_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
     ECMA_TRY_CATCH (check_coercible_ret,
                     ecma_op_check_object_coercible (object),
@@ -315,7 +311,7 @@ vm_op_delete_prop (ecma_value_t object, /**< base object */
                     ecma_op_object_delete (obj_p, name_string_p, is_strict),
                     completion_value);
 
-    completion_value = ecma_make_normal_completion_value (delete_op_ret_val);
+    completion_value = delete_op_ret_val;
 
     ECMA_FINALIZE (delete_op_ret_val);
     ECMA_FINALIZE (obj_value);
@@ -329,14 +325,15 @@ vm_op_delete_prop (ecma_value_t object, /**< base object */
 /**
  * Deletes a variable.
  *
- * @return completion value
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
  */
-ecma_completion_value_t
+ecma_value_t
 vm_op_delete_var (lit_cpointer_t name_literal, /**< name literal */
                   ecma_object_t *lex_env_p, /**< lexical environment */
                   bool is_strict) /**< strict mode */
 {
-  ecma_completion_value_t completion_value = ecma_make_empty_completion_value ();
+  ecma_value_t completion_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ecma_string_t *var_name_str_p;
 
@@ -349,7 +346,7 @@ vm_op_delete_var (lit_cpointer_t name_literal, /**< name literal */
 
   if (ecma_is_value_undefined (ref.base))
   {
-    completion_value = ecma_make_simple_completion_value (ECMA_SIMPLE_VALUE_TRUE);
+    completion_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
   else
   {
@@ -363,7 +360,7 @@ vm_op_delete_var (lit_cpointer_t name_literal, /**< name literal */
                                                                        ref.referenced_name_cp)),
                     completion_value);
 
-    completion_value = ecma_make_normal_completion_value (delete_op_ret_val);
+    completion_value = delete_op_ret_val;
 
     ECMA_FINALIZE (delete_op_ret_val);
 
@@ -382,13 +379,13 @@ vm_op_delete_var (lit_cpointer_t name_literal, /**< name literal */
  *          ECMA-262 v5, 12.6.4
  *
  * @return completion value
- *         Returned value must be freed with ecma_free_completion_value
+ *         Returned value must be freed with ecma_free_value
  */
 ecma_collection_header_t *
 opfunc_for_in (ecma_value_t left_value, /**< left value */
                ecma_value_t *result_obj_p) /**< expression object */
 {
-  ecma_completion_value_t compl_val = ecma_make_empty_completion_value ();
+  ecma_value_t compl_val = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_collection_header_t *prop_names_p = NULL;
 
   /* 3. */
@@ -417,7 +414,7 @@ opfunc_for_in (ecma_value_t left_value, /**< left value */
     ECMA_FINALIZE (obj_expr_value);
   }
 
-  JERRY_ASSERT (ecma_is_completion_value_empty (compl_val));
+  JERRY_ASSERT (ecma_is_value_empty (compl_val));
 
   return prop_names_p;
 } /* opfunc_for_in */

--- a/jerry-core/vm/opcodes.h
+++ b/jerry-core/vm/opcodes.h
@@ -53,75 +53,75 @@ typedef enum
   NUMBER_BITWISE_NOT, /**< bitwise NOT calculation */
 } number_bitwise_logic_op;
 
-ecma_completion_value_t
+ecma_value_t
 vm_var_decl (vm_frame_ctx_t *, ecma_string_t *);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_call_n (ecma_value_t, ecma_value_t,
                const ecma_value_t *, ecma_length_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_construct_n (ecma_value_t,
                     const ecma_value_t *, ecma_length_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_equal_value (ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_not_equal_value (ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_equal_value_type (ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_not_equal_value_type (ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 do_number_arithmetic (number_arithmetic_op, ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_unary_plus (ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_unary_minus (ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 do_number_bitwise_logic (number_bitwise_logic_op, ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_addition (ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_less_than (ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_greater_than (ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_less_or_equal_than (ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_greater_or_equal_than (ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_in (ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_instanceof (ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_logical_not (ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 opfunc_typeof (ecma_value_t);
 
 void
 opfunc_set_accessor (bool, ecma_value_t, ecma_value_t, ecma_value_t);
 
-ecma_completion_value_t
+ecma_value_t
 vm_op_delete_prop (ecma_value_t, ecma_value_t, bool);
 
-ecma_completion_value_t
+ecma_value_t
 vm_op_delete_var (lit_cpointer_t, ecma_object_t *, bool);
 
 ecma_collection_header_t *

--- a/jerry-core/vm/vm-stack.c
+++ b/jerry-core/vm/vm-stack.c
@@ -41,7 +41,7 @@ vm_stack_context_abort (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
     case VM_CONTEXT_FINALLY_THROW:
     case VM_CONTEXT_FINALLY_RETURN:
     {
-      ecma_free_value (vm_stack_top_p[-2], true);
+      ecma_free_value (vm_stack_top_p[-2]);
 
       VM_MINUS_EQUAL_U16 (frame_ctx_p->context_depth, PARSER_TRY_CONTEXT_STACK_ALLOCATION);
       vm_stack_top_p -= PARSER_TRY_CONTEXT_STACK_ALLOCATION;
@@ -76,13 +76,13 @@ vm_stack_context_abort (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
                                                                         current);
 
         lit_utf8_byte_t *data_ptr = chunk_p->data;
-        ecma_free_value (*(ecma_value_t *) data_ptr, true);
+        ecma_free_value (*(ecma_value_t *) data_ptr);
 
         current = chunk_p->next_chunk_cp;
         ecma_dealloc_collection_chunk (chunk_p);
       }
 
-      ecma_free_value (vm_stack_top_p[-3], true);
+      ecma_free_value (vm_stack_top_p[-3]);
 
       VM_MINUS_EQUAL_U16 (frame_ctx_p->context_depth, PARSER_FOR_IN_CONTEXT_STACK_ALLOCATION);
       vm_stack_top_p -= PARSER_FOR_IN_CONTEXT_STACK_ALLOCATION;

--- a/jerry-core/vm/vm-stack.h
+++ b/jerry-core/vm/vm-stack.h
@@ -28,7 +28,7 @@
  */
 
 /**
- * Number of ecma-values inlined into stack frame
+ * Number of ecma values inlined into stack frame
  */
 #define VM_STACK_FRAME_INLINED_VALUES_NUMBER CONFIG_VM_STACK_FRAME_INLINED_VALUES_NUMBER
 

--- a/jerry-core/vm/vm.h
+++ b/jerry-core/vm/vm.h
@@ -187,16 +187,13 @@ typedef enum
 extern void vm_init (ecma_compiled_code_t *, bool);
 extern void vm_finalize (void);
 extern jerry_completion_code_t vm_run_global (void);
-extern ecma_completion_value_t vm_run_eval (ecma_compiled_code_t *, bool);
+extern ecma_value_t vm_run_eval (ecma_compiled_code_t *, bool);
 
-extern ecma_completion_value_t vm_loop (vm_frame_ctx_t *);
+extern ecma_value_t vm_loop (vm_frame_ctx_t *);
 
-extern ecma_completion_value_t vm_run (const ecma_compiled_code_t *,
-                                       ecma_value_t,
-                                       ecma_object_t *,
-                                       bool,
-                                       const ecma_value_t *,
-                                       ecma_length_t);
+extern ecma_value_t vm_run (const ecma_compiled_code_t *, ecma_value_t,
+                            ecma_object_t *, bool, const ecma_value_t *,
+                            ecma_length_t);
 
 extern bool vm_is_strict_mode (void);
 extern bool vm_is_direct_eval_form_call (void);


### PR DESCRIPTION
Remove ecma_completion_value_t, and an extra bit to ecma_value_t to represent errors. From the long list of completion types only normal and error remained.