### PR TITLE
Eliminating doxygen warnings by fixing the documentation

### DIFF
--- a/jerry-core/ecma/base/ecma-init-finalize.h
+++ b/jerry-core/ecma/base/ecma-init-finalize.h
@@ -21,7 +21,7 @@
  */
 
 /**
- * \addtogroup ecmainitfinalize Initialization and finalization of ECMA
+ * \addtogroup ecmainitfinalize Initialization and finalization of ECMA components
  * @{
  */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -295,7 +295,7 @@ ecma_builtin_array_prototype_object_concat (ecma_value_t this_arg, /**< this arg
  *         Returned value must be freed with ecma_free_completion_value.
  */
 static ecma_completion_value_t
-ecma_op_array_get_separator_string (ecma_value_t separator) /** < possible separator */
+ecma_op_array_get_separator_string (ecma_value_t separator) /**< possible separator */
 {
   if (ecma_is_value_undefined (separator))
   {
@@ -318,8 +318,8 @@ ecma_op_array_get_separator_string (ecma_value_t separator) /** < possible separ
  *         Returned value must be freed with ecma_free_completion_value.
  */
 static ecma_completion_value_t
-ecma_op_array_get_to_string_at_index (ecma_object_t *obj_p, /** < this object */
-                                      uint32_t index) /** < array index */
+ecma_op_array_get_to_string_at_index (ecma_object_t *obj_p, /**< this object */
+                                      uint32_t index) /**< array index */
 {
   ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
   ecma_string_t *index_string_p = ecma_new_ecma_string_from_uint32 (index);
@@ -357,7 +357,7 @@ ecma_op_array_get_to_string_at_index (ecma_object_t *obj_p, /** < this object */
  */
 static ecma_completion_value_t
 ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argument */
-                                   const ecma_value_t separator_arg) /** < separator argument */
+                                   const ecma_value_t separator_arg) /**< separator argument */
 {
   ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
@@ -65,8 +65,8 @@ ecma_builtin_function_dispatch_call (const ecma_value_t *arguments_list_p, /**< 
  *         Returned value must be freed with ecma_free_completion_value.
  */
 static ecma_completion_value_t
-ecma_builtin_function_helper_get_function_expression (const ecma_value_t *arguments_list_p, /** < arguments list */
-                                                      ecma_length_t arguments_list_len) /** < number of arguments */
+ecma_builtin_function_helper_get_function_expression (const ecma_value_t *arguments_list_p, /**< arguments list */
+                                                      ecma_length_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -53,8 +53,8 @@
  *
  * The routine converts all of its arguments to strings and outputs them using 'printf'.
  *
- * Code points, with except of <NUL> character, that are representable with one utf8-byte
- * are outputted as is, using '%c' format argument, and other code points are outputted as '\uhhll',
+ * Code points, with except of NUL character, that are representable with one utf8-byte
+ * are outputted as is, using "%c" format argument, and other code points are outputted as "\uhhll",
  * where hh and ll are values of code point's high and low bytes, correspondingly.
  *
  * @return completion value

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -124,8 +124,8 @@ ecma_builtin_helper_object_to_string (const ecma_value_t this_arg) /**< this arg
  *         Returned value must be freed with ecma_free_completion_value.
  */
 ecma_completion_value_t
-ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /** < this object */
-                                                   uint32_t index) /** < array index */
+ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /**< this object */
+                                                   uint32_t index) /**< array index */
 {
   ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
   ecma_string_t *index_string_p = ecma_new_ecma_string_from_uint32 (index);
@@ -196,8 +196,8 @@ ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /** < t
  *         Returned value must be freed with ecma_free_completion_value.
  */
 ecma_completion_value_t
-ecma_builtin_helper_object_get_properties (ecma_object_t *obj_p, /** < object */
-                                           bool only_enumerable_properties) /** < list enumerable properties? */
+ecma_builtin_helper_object_get_properties (ecma_object_t *obj_p, /**< object */
+                                           bool only_enumerable_properties) /**< list enumerable properties? */
 {
   JERRY_ASSERT (obj_p != NULL);
 
@@ -564,7 +564,7 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index
                                        ecma_string_t *search_str_p, /**< string's length */
                                        bool first_index, /**< whether search for first (t) or last (f) index */
                                        ecma_length_t start_pos, /**< start position */
-                                       ecma_length_t *ret_index_p) /**> position found in original string */
+                                       ecma_length_t *ret_index_p) /**< position found in original string */
 {
   bool match_found = false;
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -608,7 +608,7 @@ ecma_builtin_json_parse_value (ecma_json_token_t *token_p) /**< token argument *
 static ecma_completion_value_t
 ecma_builtin_json_walk (ecma_object_t *reviver_p, /**< reviver function */
                         ecma_object_t *holder_p, /**< holder object */
-                        ecma_string_t *name_p) /** < property name */
+                        ecma_string_t *name_p) /**< property name */
 {
   JERRY_ASSERT (reviver_p);
   JERRY_ASSERT (holder_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -41,7 +41,7 @@
  * \addtogroup ecmabuiltins
  * @{
  *
- * \addtogroup regexp ECMA RegExp.prototype object built-in
+ * \addtogroup regexpprototype ECMA RegExp.prototype object built-in
  * @{
  */
 

--- a/jerry-core/ecma/operations/ecma-conversion.h
+++ b/jerry-core/ecma/operations/ecma-conversion.h
@@ -22,7 +22,7 @@
 /** \addtogroup ecma ECMA
  * @{
  *
- * \addtogroup ecmaconversion ECMA conversion
+ * \addtogroup ecmaconversion ECMA conversion routines
  * @{
  */
 

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -501,8 +501,8 @@ ecma_op_object_has_instance (ecma_object_t *obj_p, /**< the object */
  *         false if the target object is not prototype of the base object
  */
 bool
-ecma_op_object_is_prototype_of (ecma_object_t *base_p, /** < base object */
-                                ecma_object_t *target_p) /** < target object */
+ecma_op_object_is_prototype_of (ecma_object_t *base_p, /**< base object */
+                                ecma_object_t *target_p) /**< target object */
 {
   do
   {

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -1176,7 +1176,7 @@ void
 re_set_result_array_properties (ecma_object_t *array_obj_p, /**< result array */
                                 ecma_string_t *input_str_p, /**< input string */
                                 uint32_t num_of_elements, /**< Number of array elements */
-                                int32_t index) /** index of matching */
+                                int32_t index) /**< index of matching */
 {
   /* Set index property of the result array */
   ecma_string_t *result_prop_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);

--- a/jerry-core/jerry-port.h
+++ b/jerry-core/jerry-port.h
@@ -24,7 +24,7 @@
 # define EXTERN_C
 #endif /* !__cplusplus */
 
-/** \addtogroup jerry Jerry engine port
+/** \addtogroup jerry_port Jerry engine port
  * @{
  */
 

--- a/jerry-core/jrt/jrt-fatals.c
+++ b/jerry-core/jrt/jrt-fatals.c
@@ -89,7 +89,7 @@ void __noreturn
 jerry_assert_fail (const char *assertion, /**< assertion condition string */
                    const char *file, /**< file name */
                    const char *function, /**< function name */
-                   const uint32_t line) /** line */
+                   const uint32_t line) /**< line */
 {
 #if !defined (JERRY_NDEBUG) || !defined (JERRY_DISABLE_HEAVY_DEBUG)
   printf ("ICE: Assertion '%s' failed at %s(%s):%lu.\n",

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -199,16 +199,16 @@ extern void __noreturn jerry_fatal (jerry_fatal_code_t);
  */
 
 /**
- * Aligns @value to @alignment.
+ * Aligns @a value to @a alignment.
  *
- * Returns maximum positive value, that divides @alignment and is less than or equal to @value
+ * Returns maximum positive value, that divides @a alignment and is less than or equal to @a value
  */
 #define JERRY_ALIGNDOWN(value, alignment) ((alignment) * ((value) / (alignment)))
 
 /**
- * Aligns @value to @alignment.
+ * Aligns @a value to @a alignment.
  *
- * Returns minimum positive value, that divides @alignment and is more than or equal to @value
+ * Returns minimum positive value, that divides @a alignment and is more than or equal to @a value
  */
 #define JERRY_ALIGNUP(value, alignment) ((alignment) * (((value) + (alignment) - 1) / (alignment)))
 

--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -328,7 +328,7 @@ lit_char_hex_to_int (ecma_char_t c) /**< code unit, corresponding to
 bool
 lit_read_code_point_from_hex (lit_utf8_byte_t *buf_p, /**< buffer with characters */
                               lit_utf8_size_t number_of_characters, /**< number of characters to be read */
-                              lit_code_point_t *out_code_point_p) /**< @out: decoded result */
+                              lit_code_point_t *out_code_point_p) /**< [out] decoded result */
 {
   lit_code_point_t code_point = 0;
 

--- a/jerry-core/lit/lit-literal-storage.c
+++ b/jerry-core/lit/lit-literal-storage.c
@@ -82,7 +82,7 @@ lit_storage_create_magic_literal_ex (rcs_record_set_t *rec_set_p, /**< recordset
  * @return  pointer to the created record
  */
 rcs_record_t *
-lit_storage_create_number_literal (rcs_record_set_t *rec_set_p, /** recordset */
+lit_storage_create_number_literal (rcs_record_set_t *rec_set_p, /**< recordset */
                                    ecma_number_t num) /**< numeric value */
 {
   const size_t record_size = RCS_NUMBER_HEADER_SIZE + sizeof (ecma_number_t);

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -346,7 +346,7 @@ convert_code_point_to_high_surrogate (lit_code_point_t code_point) /**< code poi
  * @return next code unit
  */
 ecma_char_t
-lit_utf8_iterator_peek_next (const lit_utf8_iterator_t *iter_p) /**< @in: utf-8 string iterator */
+lit_utf8_iterator_peek_next (const lit_utf8_iterator_t *iter_p) /**< [in] utf-8 string iterator */
 {
   JERRY_ASSERT (!lit_utf8_iterator_is_eos (iter_p));
 
@@ -377,7 +377,7 @@ lit_utf8_iterator_peek_next (const lit_utf8_iterator_t *iter_p) /**< @in: utf-8 
  * Increment iterator to point to next code unit
  */
 void
-lit_utf8_iterator_incr (lit_utf8_iterator_t *iter_p) /**< @in-out: utf-8 string iterator */
+lit_utf8_iterator_incr (lit_utf8_iterator_t *iter_p) /**< [in,out] utf-8 string iterator */
 {
   lit_utf8_iterator_read_next (iter_p);
 } /* lit_utf8_iterator_incr */
@@ -386,7 +386,7 @@ lit_utf8_iterator_incr (lit_utf8_iterator_t *iter_p) /**< @in-out: utf-8 string 
  * Skip specified number of code units
  */
 void
-lit_utf8_iterator_advance (lit_utf8_iterator_t *iter_p, /**< in-out: iterator */
+lit_utf8_iterator_advance (lit_utf8_iterator_t *iter_p, /**< [in,out] iterator */
                            ecma_length_t chars_count) /**< number of code units to skip */
 {
   while (chars_count--)
@@ -401,7 +401,7 @@ lit_utf8_iterator_advance (lit_utf8_iterator_t *iter_p, /**< in-out: iterator */
  * @return next code unit
  */
 ecma_char_t
-lit_utf8_iterator_read_next (lit_utf8_iterator_t *iter_p) /**< @in-out: utf-8 string iterator */
+lit_utf8_iterator_read_next (lit_utf8_iterator_t *iter_p) /**< [in,out] utf-8 string iterator */
 {
   JERRY_ASSERT (!lit_utf8_iterator_is_eos (iter_p));
 
@@ -491,7 +491,7 @@ lit_utf8_string_length (const lit_utf8_byte_t *utf8_buf_p, /**< utf-8 string */
 lit_utf8_size_t
 lit_read_code_point_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer with characters */
                                lit_utf8_size_t buf_size, /**< size of the buffer in bytes */
-                               lit_code_point_t *code_point) /**< @out: code point */
+                               lit_code_point_t *code_point) /**< [out] code point */
 {
   JERRY_ASSERT (buf_p && buf_size);
 
@@ -543,7 +543,7 @@ lit_read_code_point_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer with ch
  */
 lit_utf8_size_t
 lit_read_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer with characters */
-                               ecma_char_t *code_point) /**< @out: code point */
+                               ecma_char_t *code_point) /**< [out] code point */
 {
   JERRY_ASSERT (buf_p);
 
@@ -586,7 +586,7 @@ lit_read_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer with cha
  */
 lit_utf8_size_t
 lit_read_prev_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer with characters */
-                                   ecma_char_t *code_point) /**< @out: code point */
+                                   ecma_char_t *code_point) /**< [out] code point */
 {
   JERRY_ASSERT (buf_p);
 

--- a/jerry-core/parser/js/common.h
+++ b/jerry-core/parser/js/common.h
@@ -164,4 +164,10 @@ void util_print_literal (lexer_literal_t *);
 #define PARSER_INLINE inline
 #define PARSER_NOINLINE __attribute__ ((noinline))
 
+/**
+ * @}
+ * @}
+ * @}
+ */
+
 #endif /* !COMMON_H */

--- a/jerry-core/parser/js/js-lexer.h
+++ b/jerry-core/parser/js/js-lexer.h
@@ -49,15 +49,15 @@ typedef enum
 #define LEXER_IS_UNARY_LVALUE_OP_TOKEN(token_type) \
   ((token_type) >= LEXER_KEYW_DELETE && (token_type) <= LEXER_DECREASE)
 
-  LEXER_PLUS,                    /**< + */
-  LEXER_NEGATE,                  /**< - */
-  LEXER_LOGICAL_NOT,             /**< ! */
-  LEXER_BIT_NOT,                 /**< ~ */
+  LEXER_PLUS,                    /**< "+" */
+  LEXER_NEGATE,                  /**< "-" */
+  LEXER_LOGICAL_NOT,             /**< "!" */
+  LEXER_BIT_NOT,                 /**< "~" */
   LEXER_KEYW_VOID,               /**< void */
   LEXER_KEYW_TYPEOF,             /**< typeof */
   LEXER_KEYW_DELETE,             /**< delete */
-  LEXER_INCREASE,                /**< ++ */
-  LEXER_DECREASE,                /**< -- */
+  LEXER_INCREASE,                /**< "++" */
+  LEXER_DECREASE,                /**< "--" */
 
   /* Binary operators
    * IMPORTANT: update CBC_BINARY_OP_TOKEN_TO_OPCODE,
@@ -69,53 +69,53 @@ typedef enum
   ((token_type) >= LEXER_ASSIGN && (token_type) <= LEXER_ASSIGN_BIT_XOR)
 #define LEXER_FIRST_BINARY_OP LEXER_ASSIGN
 
-  LEXER_ASSIGN,                  /**< = (prec: 3) */
-  LEXER_ASSIGN_ADD,              /**< += (prec: 3) */
-  LEXER_ASSIGN_SUBTRACT,         /**< -= (prec: 3) */
-  LEXER_ASSIGN_MULTIPLY,         /**< *= (prec: 3) */
-  LEXER_ASSIGN_DIVIDE,           /**< /= (prec: 3) */
-  LEXER_ASSIGN_MODULO,           /**< %= (prec: 3) */
-  LEXER_ASSIGN_LEFT_SHIFT,       /**< <<= (prec: 3) */
-  LEXER_ASSIGN_RIGHT_SHIFT,      /**< >>= (prec: 3) */
-  LEXER_ASSIGN_UNS_RIGHT_SHIFT,  /**< >>>= (prec: 3) */
-  LEXER_ASSIGN_BIT_AND,          /**< &= (prec: 3) */
-  LEXER_ASSIGN_BIT_OR,           /**< |= (prec: 3) */
-  LEXER_ASSIGN_BIT_XOR,          /**< ^= (prec: 3) */
-  LEXER_QUESTION_MARK,           /**< ? (prec: 4) */
-  LEXER_LOGICAL_OR,              /**< || (prec: 5) */
-  LEXER_LOGICAL_AND,             /**< && (prec: 6) */
-  LEXER_BIT_OR,                  /**< | (prec: 7) */
-  LEXER_BIT_XOR,                 /**< ^ (prec: 8) */
-  LEXER_BIT_AND,                 /**< & (prec: 9) */
-  LEXER_EQUAL,                   /**< == (prec: 10) */
-  LEXER_NOT_EQUAL,               /**< != (prec: 10) */
-  LEXER_STRICT_EQUAL,            /**< === (prec: 10) */
-  LEXER_STRICT_NOT_EQUAL,        /**< !== (prec: 10) */
-  LEXER_LESS,                    /**< < (prec: 11) */
-  LEXER_GREATER,                 /**< > (prec: 11) */
-  LEXER_LESS_EQUAL,              /**< <= (prec: 11) */
-  LEXER_GREATER_EQUAL,           /**< >= (prec: 11) */
+  LEXER_ASSIGN,                  /**< "=" (prec: 3) */
+  LEXER_ASSIGN_ADD,              /**< "+=" (prec: 3) */
+  LEXER_ASSIGN_SUBTRACT,         /**< "-=" (prec: 3) */
+  LEXER_ASSIGN_MULTIPLY,         /**< "*=" (prec: 3) */
+  LEXER_ASSIGN_DIVIDE,           /**< "/=" (prec: 3) */
+  LEXER_ASSIGN_MODULO,           /**< "%=" (prec: 3) */
+  LEXER_ASSIGN_LEFT_SHIFT,       /**< "<<=" (prec: 3) */
+  LEXER_ASSIGN_RIGHT_SHIFT,      /**< ">>=" (prec: 3) */
+  LEXER_ASSIGN_UNS_RIGHT_SHIFT,  /**< ">>>=" (prec: 3) */
+  LEXER_ASSIGN_BIT_AND,          /**< "&=" (prec: 3) */
+  LEXER_ASSIGN_BIT_OR,           /**< "|=" (prec: 3) */
+  LEXER_ASSIGN_BIT_XOR,          /**< "^=" (prec: 3) */
+  LEXER_QUESTION_MARK,           /**< "?" (prec: 4) */
+  LEXER_LOGICAL_OR,              /**< "||" (prec: 5) */
+  LEXER_LOGICAL_AND,             /**< "&&" (prec: 6) */
+  LEXER_BIT_OR,                  /**< "|" (prec: 7) */
+  LEXER_BIT_XOR,                 /**< "^" (prec: 8) */
+  LEXER_BIT_AND,                 /**< "&" (prec: 9) */
+  LEXER_EQUAL,                   /**< "==" (prec: 10) */
+  LEXER_NOT_EQUAL,               /**< "!=" (prec: 10) */
+  LEXER_STRICT_EQUAL,            /**< "===" (prec: 10) */
+  LEXER_STRICT_NOT_EQUAL,        /**< "!==" (prec: 10) */
+  LEXER_LESS,                    /**< "<" (prec: 11) */
+  LEXER_GREATER,                 /**< ">" (prec: 11) */
+  LEXER_LESS_EQUAL,              /**< "<=" (prec: 11) */
+  LEXER_GREATER_EQUAL,           /**< ">=" (prec: 11) */
   LEXER_KEYW_IN,                 /**< in (prec: 11) */
   LEXER_KEYW_INSTANCEOF,         /**< instanceof (prec: 11) */
-  LEXER_LEFT_SHIFT,              /**< << (prec: 12) */
-  LEXER_RIGHT_SHIFT,             /**< >> (prec: 12) */
-  LEXER_UNS_RIGHT_SHIFT,         /**< >>> (prec: 12) */
-  LEXER_ADD,                     /**< + (prec: 13) */
-  LEXER_SUBTRACT,                /**< - (prec: 13) */
-  LEXER_MULTIPLY,                /**< * (prec: 14) */
-  LEXER_DIVIDE,                  /**< / (prec: 14) */
-  LEXER_MODULO,                  /**< % (prec: 14) */
+  LEXER_LEFT_SHIFT,              /**< "<<" (prec: 12) */
+  LEXER_RIGHT_SHIFT,             /**< ">>" (prec: 12) */
+  LEXER_UNS_RIGHT_SHIFT,         /**< ">>>" (prec: 12) */
+  LEXER_ADD,                     /**< "+" (prec: 13) */
+  LEXER_SUBTRACT,                /**< "-" (prec: 13) */
+  LEXER_MULTIPLY,                /**< "*" (prec: 14) */
+  LEXER_DIVIDE,                  /**< "/" (prec: 14) */
+  LEXER_MODULO,                  /**< "%" (prec: 14) */
 
-  LEXER_LEFT_BRACE,              /**< { */
-  LEXER_LEFT_PAREN,              /**< ( */
-  LEXER_LEFT_SQUARE,             /**< [ */
-  LEXER_RIGHT_BRACE,             /**< } */
-  LEXER_RIGHT_PAREN,             /**<_) */
-  LEXER_RIGHT_SQUARE,            /**< ] */
-  LEXER_DOT,                     /**< . */
-  LEXER_SEMICOLON,               /**< ; */
-  LEXER_COLON,                   /**< : */
-  LEXER_COMMA,                   /**< , */
+  LEXER_LEFT_BRACE,              /**< "{" */
+  LEXER_LEFT_PAREN,              /**< "(" */
+  LEXER_LEFT_SQUARE,             /**< "[" */
+  LEXER_RIGHT_BRACE,             /**< "}" */
+  LEXER_RIGHT_PAREN,             /**<_")" */
+  LEXER_RIGHT_SQUARE,            /**< "]" */
+  LEXER_DOT,                     /**< "." */
+  LEXER_SEMICOLON,               /**< ";" */
+  LEXER_COLON,                   /**< ":" */
+  LEXER_COMMA,                   /**< "," */
 
   LEXER_KEYW_BREAK,              /**< break */
   LEXER_KEYW_DO,                 /**< do */

--- a/jerry-core/parser/js/js-parser-mem.c
+++ b/jerry-core/parser/js/js-parser-mem.c
@@ -471,8 +471,8 @@ parser_stack_pop_uint16 (parser_context_t *context_p) /**< context */
  */
 void
 parser_stack_push (parser_context_t *context_p, /**< context */
-                   const void *data_p, /* data pushed onto the stack */
-                   uint32_t length) /* length of the data */
+                   const void *data_p, /**< data pushed onto the stack */
+                   uint32_t length) /**< length of the data */
 {
   uint32_t fragment_length = PARSER_STACK_PAGE_SIZE - context_p->stack.last_position;
   const uint8_t *bytes_p = (const uint8_t *) data_p;
@@ -529,8 +529,8 @@ parser_stack_push (parser_context_t *context_p, /**< context */
  */
 void
 parser_stack_pop (parser_context_t *context_p, /**< context */
-                  void *data_p, /* destination buffer, can be NULL */
-                  uint32_t length) /* length of the data */
+                  void *data_p, /**< destination buffer, can be NULL */
+                  uint32_t length) /**< length of the data */
 {
   uint8_t *bytes_p = (uint8_t *) data_p;
   parser_mem_page_t *page_p = context_p->stack.first_p;
@@ -604,8 +604,8 @@ parser_stack_iterator_skip (parser_stack_iterator_t *iterator, /**< iterator */
  */
 void
 parser_stack_iterator_read (parser_stack_iterator_t *iterator, /**< iterator */
-                            void *data_p, /* destination buffer */
-                            size_t length) /* length of the data */
+                            void *data_p, /**< destination buffer */
+                            size_t length) /**< length of the data */
 {
   uint8_t *bytes_p = (uint8_t *) data_p;
 
@@ -636,8 +636,8 @@ parser_stack_iterator_read (parser_stack_iterator_t *iterator, /**< iterator */
  */
 void
 parser_stack_iterator_write (parser_stack_iterator_t *iterator, /**< iterator */
-                             const void *data_p, /* destination buffer */
-                             size_t length) /* length of the data */
+                             const void *data_p, /**< destination buffer */
+                             size_t length) /**< length of the data */
 {
   const uint8_t *bytes_p = (const uint8_t *) data_p;
 

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -922,6 +922,7 @@ re_dump_bytecode (re_bytecode_ctx_t *bc_ctx_p) /**< RegExp bytecode context */
 /**
  * @}
  * @}
+ * @}
  */
 
 #endif /* CONFIG_ECMA_COMPACT_PROFILE_DISABLE_REGEXP_BUILTIN */

--- a/jerry-core/parser/regexp/re-compiler.h
+++ b/jerry-core/parser/regexp/re-compiler.h
@@ -56,14 +56,14 @@ typedef enum
   RE_OP_CHAR,                                     /**< any character */
   RE_OP_SAVE_AT_START,                            /**< save at start */
   RE_OP_SAVE_AND_MATCH,                           /**< save and match */
-  RE_OP_PERIOD,                                   /**< . */
-  RE_OP_ALTERNATIVE,                              /**< | */
+  RE_OP_PERIOD,                                   /**< "." */
+  RE_OP_ALTERNATIVE,                              /**< "|" */
   RE_OP_GREEDY_ITERATOR,                          /**< greedy iterator */
   RE_OP_NON_GREEDY_ITERATOR,                      /**< non-greedy iterator */
-  RE_OP_ASSERT_START,                             /**< ^ */
-  RE_OP_ASSERT_END,                               /**< $ */
-  RE_OP_ASSERT_WORD_BOUNDARY,                     /**< \b */
-  RE_OP_ASSERT_NOT_WORD_BOUNDARY,                 /**< \B */
+  RE_OP_ASSERT_START,                             /**< "^" */
+  RE_OP_ASSERT_END,                               /**< "$" */
+  RE_OP_ASSERT_WORD_BOUNDARY,                     /**< "\b" */
+  RE_OP_ASSERT_NOT_WORD_BOUNDARY,                 /**< "\B" */
   RE_OP_LOOKAHEAD_POS,                            /**< lookahead pos */
   RE_OP_LOOKAHEAD_NEG,                            /**< lookahead neg */
   RE_OP_BACKREFERENCE,                            /**< \[0..9] */

--- a/jerry-core/parser/regexp/re-parser.h
+++ b/jerry-core/parser/regexp/re-parser.h
@@ -115,6 +115,7 @@ re_parse_next_token (re_parser_ctx_t *, re_token_t *);
 /**
  * @}
  * @}
+ * @}
  */
 
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_REGEXP_BUILTIN */

--- a/jerry-core/rcs/rcs-chunked-list.h
+++ b/jerry-core/rcs/rcs-chunked-list.h
@@ -60,5 +60,9 @@ extern rcs_chunked_list_node_t *rcs_chunked_list_get_node_from_pointer (rcs_chun
 extern uint8_t *rcs_chunked_list_get_node_data_space (rcs_chunked_list_t *, rcs_chunked_list_node_t *);
 extern size_t rcs_chunked_list_get_node_data_space_size (void);
 
+/**
+ * @}
+ * @}
+ */
 
 #endif /* RCS_CHUNKED_LIST_H */

--- a/jerry-core/vm/opcodes-ecma-bitwise.c
+++ b/jerry-core/vm/opcodes-ecma-bitwise.c
@@ -41,7 +41,7 @@
 ecma_completion_value_t
 do_number_bitwise_logic (number_bitwise_logic_op op, /**< number bitwise logic operation */
                          ecma_value_t left_value, /**< left value */
-                         ecma_value_t right_value) /** right value */
+                         ecma_value_t right_value) /**< right value */
 {
   ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
 

--- a/jerry-libc/jerry-libc.c
+++ b/jerry-libc/jerry-libc.c
@@ -54,7 +54,7 @@ CALL_PRAGMA (GCC optimize ("-fno-tree-loop-distribute-patterns"))
 /**
  * memset
  *
- * @return @s
+ * @return @a s
  */
 void * __attr_used___ // FIXME
 memset (void *s,  /**< area to set values in */


### PR DESCRIPTION
I've worked my way through the warnings emitted by doxygen, fixing one group of related issues at a time. The documentation is still far from being perfect -- or, from being consistent -- but now the comments are syntactically correct from doxygen's point of view, at least.