### PR TITLE
Turn some global variables `static const`

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -1904,12 +1904,12 @@ lexer_expect_identifier (parser_context_t *context_p, /**< context */
   parser_raise_error (context_p, PARSER_ERR_IDENTIFIER_EXPECTED);
 } /* lexer_expect_identifier */
 
-static lexer_lit_location_t lexer_get_literal =
+static const lexer_lit_location_t lexer_get_literal =
 {
   (const uint8_t *) "get", 3, LEXER_IDENT_LITERAL, PARSER_FALSE
 };
 
-static lexer_lit_location_t lexer_set_literal =
+static const lexer_lit_location_t lexer_set_literal =
 {
   (const uint8_t *) "set", 3, LEXER_IDENT_LITERAL, PARSER_FALSE
 };

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -157,7 +157,7 @@ vm_init (ecma_compiled_code_t *program_p, /**< pointer to byte-code data */
 /**
  * Decode table for opcodes.
  */
-uint32_t vm_decode_table[] =
+static const uint32_t vm_decode_table[] =
 {
   CBC_OPCODE_LIST
 };
@@ -165,7 +165,7 @@ uint32_t vm_decode_table[] =
 /**
  * Decode table for extended opcodes.
  */
-uint32_t vm_ext_decode_table[] =
+static const uint32_t vm_ext_decode_table[] =
 {
   CBC_EXT_OPCODE_LIST
 };


### PR DESCRIPTION
Generally, it helps the optimizing passes of the compiler if global
varibles are `static`, and it is good for RAM usage to have data
marked read-only `const`. Found some globals, which could benefit
from these qualifiers.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu