### PR TITLE
Rearrange fields of ecma_property_t to be naturally aligned.

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -289,130 +289,121 @@ ecma_gc_mark (ecma_object_t *object_p) /**< object to mark from */
       next_property_p = ECMA_GET_POINTER (ecma_property_t,
                                           property_p->next_property_p);
 
-      switch ((ecma_property_type_t) property_p->type)
+      if (property_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA)
       {
-        case ECMA_PROPERTY_NAMEDDATA:
+        ecma_value_t value = ecma_get_named_data_property_value (property_p);
+
+        if (ecma_is_value_object (value))
         {
-          ecma_value_t value = ecma_get_named_data_property_value (property_p);
+          ecma_object_t *value_obj_p = ecma_get_object_from_value (value);
 
-          if (ecma_is_value_object (value))
-          {
-            ecma_object_t *value_obj_p = ecma_get_object_from_value (value);
+          ecma_gc_set_object_visited (value_obj_p, true);
+        }
+      }
+      else if (property_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR)
+      {
+        ecma_object_t *getter_obj_p = ecma_get_named_accessor_property_getter (property_p);
+        ecma_object_t *setter_obj_p = ecma_get_named_accessor_property_setter (property_p);
 
-            ecma_gc_set_object_visited (value_obj_p, true);
-          }
-
-          break;
+        if (getter_obj_p != NULL)
+        {
+          ecma_gc_set_object_visited (getter_obj_p, true);
         }
 
-        case ECMA_PROPERTY_NAMEDACCESSOR:
+        if (setter_obj_p != NULL)
         {
-          ecma_object_t *getter_obj_p = ecma_get_named_accessor_property_getter (property_p);
-          ecma_object_t *setter_obj_p = ecma_get_named_accessor_property_setter (property_p);
-
-          if (getter_obj_p != NULL)
-          {
-            ecma_gc_set_object_visited (getter_obj_p, true);
-          }
-
-          if (setter_obj_p != NULL)
-          {
-            ecma_gc_set_object_visited (setter_obj_p, true);
-          }
-
-          break;
+          ecma_gc_set_object_visited (setter_obj_p, true);
         }
+      }
+      else
+      {
+        JERRY_ASSERT (property_p->flags & ECMA_PROPERTY_FLAG_INTERNAL);
 
-        case ECMA_PROPERTY_INTERNAL:
+        ecma_internal_property_id_t property_id = (ecma_internal_property_id_t) property_p->h.internal_property_type;
+        uint32_t property_value = property_p->v.internal_property.value;
+
+        switch (property_id)
         {
-          ecma_internal_property_id_t property_id = (ecma_internal_property_id_t) property_p->u.internal_property.type;
-          uint32_t property_value = property_p->u.internal_property.value;
-
-          switch (property_id)
+          case ECMA_INTERNAL_PROPERTY_NUMBER_INDEXED_ARRAY_VALUES: /* a collection of ecma values */
+          case ECMA_INTERNAL_PROPERTY_STRING_INDEXED_ARRAY_VALUES: /* a collection of ecma values */
           {
-            case ECMA_INTERNAL_PROPERTY_NUMBER_INDEXED_ARRAY_VALUES: /* a collection of ecma values */
-            case ECMA_INTERNAL_PROPERTY_STRING_INDEXED_ARRAY_VALUES: /* a collection of ecma values */
+            JERRY_UNIMPLEMENTED ("Indexed array storage is not implemented yet.");
+          }
+
+          case ECMA_INTERNAL_PROPERTY_PROTOTYPE: /* the property's value is located in ecma_object_t
+                                                      (see above in the routine) */
+          case ECMA_INTERNAL_PROPERTY_EXTENSIBLE: /* the property's value is located in ecma_object_t
+                                                       (see above in the routine) */
+          case ECMA_INTERNAL_PROPERTY__COUNT: /* not a real internal property type,
+                                               * but number of the real internal property types */
+          {
+            JERRY_UNREACHABLE ();
+          }
+
+          case ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE: /* compressed pointer to a ecma_string_t */
+          case ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE: /* compressed pointer to a ecma_number_t */
+          case ECMA_INTERNAL_PROPERTY_PRIMITIVE_BOOLEAN_VALUE: /* a simple boolean value */
+          case ECMA_INTERNAL_PROPERTY_CLASS: /* an enum */
+          case ECMA_INTERNAL_PROPERTY_CODE_BYTECODE: /* compressed pointer to a bytecode array */
+          case ECMA_INTERNAL_PROPERTY_NATIVE_CODE: /* an external pointer */
+          case ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE: /* an external pointer */
+          case ECMA_INTERNAL_PROPERTY_FREE_CALLBACK: /* an object's native free callback */
+          case ECMA_INTERNAL_PROPERTY_BUILT_IN_ID: /* an integer */
+          case ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC: /* an integer */
+          case ECMA_INTERNAL_PROPERTY_EXTENSION_ID: /* an integer */
+          case ECMA_INTERNAL_PROPERTY_NON_INSTANTIATED_BUILT_IN_MASK_0_31: /* an integer (bit-mask) */
+          case ECMA_INTERNAL_PROPERTY_NON_INSTANTIATED_BUILT_IN_MASK_32_63: /* an integer (bit-mask) */
+          case ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE:
+          {
+            break;
+          }
+
+          case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_THIS: /* an ecma value */
+          {
+            if (ecma_is_value_object (property_value))
             {
-              JERRY_UNIMPLEMENTED ("Indexed array storage is not implemented yet.");
+              ecma_object_t *obj_p = ecma_get_object_from_value (property_value);
+
+              ecma_gc_set_object_visited (obj_p, true);
             }
 
-            case ECMA_INTERNAL_PROPERTY_PROTOTYPE: /* the property's value is located in ecma_object_t
-                                                        (see above in the routine) */
-            case ECMA_INTERNAL_PROPERTY_EXTENSIBLE: /* the property's value is located in ecma_object_t
-                                                         (see above in the routine) */
-            case ECMA_INTERNAL_PROPERTY__COUNT: /* not a real internal property type,
-                                                 * but number of the real internal property types */
-            {
-              JERRY_UNREACHABLE ();
-            }
+            break;
+          }
 
-            case ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE: /* compressed pointer to a ecma_string_t */
-            case ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE: /* compressed pointer to a ecma_number_t */
-            case ECMA_INTERNAL_PROPERTY_PRIMITIVE_BOOLEAN_VALUE: /* a simple boolean value */
-            case ECMA_INTERNAL_PROPERTY_CLASS: /* an enum */
-            case ECMA_INTERNAL_PROPERTY_CODE_BYTECODE: /* compressed pointer to a bytecode array */
-            case ECMA_INTERNAL_PROPERTY_NATIVE_CODE: /* an external pointer */
-            case ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE: /* an external pointer */
-            case ECMA_INTERNAL_PROPERTY_FREE_CALLBACK: /* an object's native free callback */
-            case ECMA_INTERNAL_PROPERTY_BUILT_IN_ID: /* an integer */
-            case ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC: /* an integer */
-            case ECMA_INTERNAL_PROPERTY_EXTENSION_ID: /* an integer */
-            case ECMA_INTERNAL_PROPERTY_NON_INSTANTIATED_BUILT_IN_MASK_0_31: /* an integer (bit-mask) */
-            case ECMA_INTERNAL_PROPERTY_NON_INSTANTIATED_BUILT_IN_MASK_32_63: /* an integer (bit-mask) */
-            case ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE:
-            {
-              break;
-            }
+          case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS: /* a collection of ecma values */
+          {
+            ecma_collection_header_t *bound_arg_list_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_header_t,
+                                                                                    property_value);
 
-            case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_THIS: /* an ecma value */
+            ecma_collection_iterator_t bound_args_iterator;
+            ecma_collection_iterator_init (&bound_args_iterator, bound_arg_list_p);
+
+            for (ecma_length_t i = 0; i < bound_arg_list_p->unit_number; i++)
             {
-              if (ecma_is_value_object (property_value))
+              bool is_moved = ecma_collection_iterator_next (&bound_args_iterator);
+              JERRY_ASSERT (is_moved);
+
+              if (ecma_is_value_object (*bound_args_iterator.current_value_p))
               {
-                ecma_object_t *obj_p = ecma_get_object_from_value (property_value);
+                ecma_object_t *obj_p = ecma_get_object_from_value (*bound_args_iterator.current_value_p);
 
                 ecma_gc_set_object_visited (obj_p, true);
               }
-
-              break;
             }
 
-            case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS: /* a collection of ecma values */
-            {
-              ecma_collection_header_t *bound_arg_list_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_header_t,
-                                                                                      property_value);
-
-              ecma_collection_iterator_t bound_args_iterator;
-              ecma_collection_iterator_init (&bound_args_iterator, bound_arg_list_p);
-
-              for (ecma_length_t i = 0; i < bound_arg_list_p->unit_number; i++)
-              {
-                bool is_moved = ecma_collection_iterator_next (&bound_args_iterator);
-                JERRY_ASSERT (is_moved);
-
-                if (ecma_is_value_object (*bound_args_iterator.current_value_p))
-                {
-                  ecma_object_t *obj_p = ecma_get_object_from_value (*bound_args_iterator.current_value_p);
-
-                  ecma_gc_set_object_visited (obj_p, true);
-                }
-              }
-
-              break;
-            }
-
-            case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION: /* an object */
-            case ECMA_INTERNAL_PROPERTY_SCOPE: /* a lexical environment */
-            case ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP: /* an object */
-            {
-              ecma_object_t *obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, property_value);
-
-              ecma_gc_set_object_visited (obj_p, true);
-
-              break;
-            }
+            break;
           }
 
-          break;
+          case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION: /* an object */
+          case ECMA_INTERNAL_PROPERTY_SCOPE: /* a lexical environment */
+          case ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP: /* an object */
+          {
+            ecma_object_t *obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, property_value);
+
+            ecma_gc_set_object_visited (obj_p, true);
+
+            break;
+          }
         }
       }
     }

--- a/jerry-core/ecma/base/ecma-helpers-external-pointers.c
+++ b/jerry-core/ecma/base/ecma-helpers-external-pointers.c
@@ -61,12 +61,12 @@ ecma_create_external_pointer_property (ecma_object_t *obj_p, /**< object to crea
     is_new = false;
   }
 
-  JERRY_STATIC_ASSERT (sizeof (uint32_t) <= sizeof (prop_p->u.internal_property.value),
+  JERRY_STATIC_ASSERT (sizeof (uint32_t) <= sizeof (prop_p->v.internal_property.value),
                        size_of_internal_property_value_must_be_greater_than_or_equal_to_4_bytes);
 
   if (sizeof (ecma_external_pointer_t) == sizeof (uint32_t))
   {
-    prop_p->u.internal_property.value = (uint32_t) ptr_value;
+    prop_p->v.internal_property.value = (uint32_t) ptr_value;
   }
   else
   {
@@ -76,12 +76,12 @@ ecma_create_external_pointer_property (ecma_object_t *obj_p, /**< object to crea
     {
       handler_p = ecma_alloc_external_pointer ();
 
-      ECMA_SET_NON_NULL_POINTER (prop_p->u.internal_property.value, handler_p);
+      ECMA_SET_NON_NULL_POINTER (prop_p->v.internal_property.value, handler_p);
     }
     else
     {
       handler_p = ECMA_GET_NON_NULL_POINTER (ecma_external_pointer_t,
-                                             prop_p->u.internal_property.value);
+                                             prop_p->v.internal_property.value);
     }
 
     *handler_p = ptr_value;
@@ -123,12 +123,12 @@ ecma_get_external_pointer_value (ecma_object_t *obj_p, /**< object to get proper
 
   if (sizeof (ecma_external_pointer_t) == sizeof (uint32_t))
   {
-    *out_pointer_p = (ecma_external_pointer_t) prop_p->u.internal_property.value;
+    *out_pointer_p = (ecma_external_pointer_t) prop_p->v.internal_property.value;
   }
   else
   {
     ecma_external_pointer_t *handler_p = ECMA_GET_NON_NULL_POINTER (ecma_external_pointer_t,
-                                                                    prop_p->u.internal_property.value);
+                                                                    prop_p->v.internal_property.value);
     *out_pointer_p = *handler_p;
   }
 
@@ -147,9 +147,9 @@ ecma_get_external_pointer_value (ecma_object_t *obj_p, /**< object to get proper
 void
 ecma_free_external_pointer_in_property (ecma_property_t *prop_p) /**< internal property */
 {
-  JERRY_ASSERT (prop_p->u.internal_property.type == ECMA_INTERNAL_PROPERTY_NATIVE_CODE
-                || prop_p->u.internal_property.type == ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE
-                || prop_p->u.internal_property.type == ECMA_INTERNAL_PROPERTY_FREE_CALLBACK);
+  JERRY_ASSERT (prop_p->h.internal_property_type == ECMA_INTERNAL_PROPERTY_NATIVE_CODE
+                || prop_p->h.internal_property_type == ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE
+                || prop_p->h.internal_property_type == ECMA_INTERNAL_PROPERTY_FREE_CALLBACK);
 
   if (sizeof (ecma_external_pointer_t) == sizeof (uint32_t))
   {
@@ -158,7 +158,7 @@ ecma_free_external_pointer_in_property (ecma_property_t *prop_p) /**< internal p
   else
   {
     ecma_external_pointer_t *handler_p = ECMA_GET_NON_NULL_POINTER (ecma_external_pointer_t,
-                                                                    prop_p->u.internal_property.value);
+                                                                    prop_p->v.internal_property.value);
 
     ecma_dealloc_external_pointer (handler_p);
   }

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -302,8 +302,7 @@ ecma_lcache_invalidate (ecma_object_t *object_p, /**< object */
 
   if (prop_p != NULL)
   {
-    JERRY_ASSERT (prop_p->type == ECMA_PROPERTY_NAMEDDATA
-                  || prop_p->type == ECMA_PROPERTY_NAMEDACCESSOR);
+    JERRY_ASSERT (prop_p->flags & (ECMA_PROPERTY_FLAG_NAMEDDATA | ECMA_PROPERTY_FLAG_NAMEDACCESSOR));
 
     bool is_cached = ecma_is_property_lcached (prop_p);
 
@@ -314,15 +313,15 @@ ecma_lcache_invalidate (ecma_object_t *object_p, /**< object */
 
     ecma_set_property_lcached (prop_p, false);
 
-    if (prop_p->type == ECMA_PROPERTY_NAMEDDATA)
+    if (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA)
     {
       prop_name_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                               prop_p->u.named_data_property.name_p);
+                                               prop_p->v.named_data_property.name_p);
     }
     else
     {
       prop_name_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                               prop_p->u.named_accessor_property.name_p);
+                                               prop_p->v.named_accessor_property.name_p);
     }
   }
   else

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
@@ -107,9 +107,9 @@ ecma_builtin_boolean_prototype_object_value_of (ecma_value_t this_arg) /**< this
       ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                        ECMA_INTERNAL_PROPERTY_PRIMITIVE_BOOLEAN_VALUE);
 
-      JERRY_ASSERT (prim_value_prop_p->u.internal_property.value < ECMA_SIMPLE_VALUE__COUNT);
+      JERRY_ASSERT (prim_value_prop_p->v.internal_property.value < ECMA_SIMPLE_VALUE__COUNT);
 
-      ecma_simple_value_t prim_simple_value = (ecma_simple_value_t) prim_value_prop_p->u.internal_property.value;
+      ecma_simple_value_t prim_simple_value = (ecma_simple_value_t) prim_value_prop_p->v.internal_property.value;
 
       ecma_value_t ret_boolean_value = ecma_make_simple_value (prim_simple_value);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -107,7 +107,7 @@ ecma_builtin_date_prototype_to_date_string (ecma_value_t this_arg) /**< this arg
     ecma_property_t *prim_value_prop_p;
     prim_value_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
     ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                 prim_value_prop_p->u.internal_property.value);
+                                                                 prim_value_prop_p->v.internal_property.value);
 
     if (ecma_number_is_nan (*prim_value_num_p))
     {
@@ -154,7 +154,7 @@ ecma_builtin_date_prototype_to_time_string (ecma_value_t this_arg) /**< this arg
     ecma_property_t *prim_value_prop_p;
     prim_value_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
     ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                 prim_value_prop_p->u.internal_property.value);
+                                                                 prim_value_prop_p->v.internal_property.value);
 
     if (ecma_number_is_nan (*prim_value_num_p))
     {
@@ -253,7 +253,7 @@ ecma_builtin_date_prototype_get_time (ecma_value_t this_arg) /**< this argument 
                                                                        ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
       ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                   prim_value_prop_p->u.internal_property.value);
+                                                                   prim_value_prop_p->v.internal_property.value);
 
       ecma_number_t *ret_num_p = ecma_alloc_number ();
       *ret_num_p = *prim_value_num_p;
@@ -366,7 +366,7 @@ ecma_builtin_date_prototype_set_time (ecma_value_t this_arg, /**< this argument 
                                                                      ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
     ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                               prim_value_prop_p->u.internal_property.value);
+                                                               prim_value_prop_p->v.internal_property.value);
     *prim_value_num_p = *value_p;
 
     /* 3. */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -578,11 +578,11 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
 
     ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p,
                                                                    ECMA_INTERNAL_PROPERTY_CLASS);
-    class_prop_p->u.internal_property.value = LIT_MAGIC_STRING_DATE_UL;
+    class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_DATE_UL;
 
     ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                         ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-    ECMA_SET_POINTER (prim_value_prop_p->u.internal_property.value, prim_value_num_p);
+    ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_value_num_p);
 
     ret_value = ecma_make_object_value (obj_p);
   }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -247,7 +247,7 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
                                                             ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
     ecma_object_t *this_arg_obj_p = ecma_get_object_from_value (this_arg);
-    ECMA_SET_NON_NULL_POINTER (target_function_prop_p->u.internal_property.value, this_arg_obj_p);
+    ECMA_SET_NON_NULL_POINTER (target_function_prop_p->v.internal_property.value, this_arg_obj_p);
 
     /* 8. */
     ecma_property_t *bound_this_prop_p;
@@ -256,11 +256,11 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
 
     if (arg_count > 0)
     {
-      bound_this_prop_p->u.internal_property.value = ecma_copy_value (arguments_list_p[0], false);
+      bound_this_prop_p->v.internal_property.value = ecma_copy_value (arguments_list_p[0], false);
     }
     else
     {
-      bound_this_prop_p->u.internal_property.value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+      bound_this_prop_p->v.internal_property.value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
     }
 
     if (arg_count > 1)
@@ -270,7 +270,7 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
 
       ecma_property_t *bound_args_prop_p;
       bound_args_prop_p = ecma_create_internal_property (function_p, ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS);
-      ECMA_SET_NON_NULL_POINTER (bound_args_prop_p->u.internal_property.value, bound_args_collection_p);
+      ECMA_SET_NON_NULL_POINTER (bound_args_prop_p->v.internal_property.value, bound_args_collection_p);
     }
 
     /*

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -915,7 +915,7 @@ ecma_date_set_internal_property (ecma_value_t this_arg, /**< this argument */
                                                                    ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
   ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                               prim_value_prop_p->u.internal_property.value);
+                                                               prim_value_prop_p->v.internal_property.value);
   *prim_value_num_p = *value_p;
 
   return ecma_make_number_value (value_p);
@@ -1342,7 +1342,7 @@ ecma_date_get_primitive_value (ecma_value_t this_arg) /**< this argument */
 
     ecma_number_t *prim_value_num_p = ecma_alloc_number ();
     *prim_value_num_p = *ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                    prim_value_prop_p->u.internal_property.value);
+                                                    prim_value_prop_p->v.internal_property.value);
     ret_value = ecma_make_number_value (prim_value_num_p);
   }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
@@ -194,10 +194,10 @@ TRY_TO_INSTANTIATE_PROPERTY_ROUTINE_NAME (ecma_object_t *obj_p, /**< object */
   if (mask_prop_p == NULL)
   {
     mask_prop_p = ecma_create_internal_property (obj_p, mask_prop_id);
-    mask_prop_p->u.internal_property.value = 0;
+    mask_prop_p->v.internal_property.value = 0;
   }
 
-  uint32_t bit_mask = mask_prop_p->u.internal_property.value;
+  uint32_t bit_mask = mask_prop_p->v.internal_property.value;
 
   if (bit_mask & bit)
   {
@@ -206,7 +206,7 @@ TRY_TO_INSTANTIATE_PROPERTY_ROUTINE_NAME (ecma_object_t *obj_p, /**< object */
 
   bit_mask |= bit;
 
-  mask_prop_p->u.internal_property.value = bit_mask;
+  mask_prop_p->v.internal_property.value = bit_mask;
 
   ecma_value_t value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_property_writable_value_t writable;
@@ -379,7 +379,7 @@ LIST_LAZY_PROPERTY_NAMES_ROUTINE_NAME (ecma_object_t *object_p, /**< a built-in 
     }
     else
     {
-      uint32_t bit_mask = mask_prop_p->u.internal_property.value;
+      uint32_t bit_mask = mask_prop_p->v.internal_property.value;
 
       if (bit_mask & bit)
       {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1455,7 +1455,7 @@ ecma_builtin_json_object (ecma_object_t *obj_p, /**< the object*/
 
       JERRY_ASSERT (ecma_is_property_enumerable (property_p));
 
-      if (property_p->type == ECMA_PROPERTY_NAMEDDATA)
+      if (property_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA)
       {
         ecma_append_to_values_collection (property_keys_p, *iter.current_value_p, true);
       }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -358,7 +358,7 @@ ecma_builtin_number_prototype_object_value_of (ecma_value_t this_arg) /**< this 
                                                                        ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
       ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                   prim_value_prop_p->u.internal_property.value);
+                                                                   prim_value_prop_p->v.internal_property.value);
 
       ecma_number_t *ret_num_p = ecma_alloc_number ();
       *ret_num_p = *prim_value_num_p;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -278,7 +278,7 @@ ecma_builtin_object_object_freeze (ecma_value_t this_arg __attr_unused___, /**< 
       ecma_property_descriptor_t prop_desc = ecma_get_property_descriptor_from_property (property_p);
 
       // 2.b
-      if (property_p->type == ECMA_PROPERTY_NAMEDDATA && ecma_is_property_writable (property_p))
+      if ((property_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA) && ecma_is_property_writable (property_p))
       {
         prop_desc.is_writable = false;
       }
@@ -462,10 +462,10 @@ ecma_builtin_object_object_is_frozen (ecma_value_t this_arg __attr_unused___, /*
         // 2.a
         ecma_property_t *property_p = ecma_op_object_get_own_property (obj_p, property_name_p);
 
-        JERRY_ASSERT (property_p->type == ECMA_PROPERTY_NAMEDDATA || property_p->type == ECMA_PROPERTY_NAMEDACCESSOR);
+        JERRY_ASSERT (property_p->flags & (ECMA_PROPERTY_FLAG_NAMEDDATA | ECMA_PROPERTY_FLAG_NAMEDACCESSOR));
 
         // 2.b
-        if (property_p->type == ECMA_PROPERTY_NAMEDDATA && ecma_is_property_writable (property_p))
+        if ((property_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA) && ecma_is_property_writable (property_p))
         {
           is_frozen = false;
           break;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -138,14 +138,14 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
         JERRY_ASSERT (ecma_is_value_empty (bc_comp));
 
         re_compiled_code_t *old_bc_p = ECMA_GET_POINTER (re_compiled_code_t,
-                                                         bc_prop_p->u.internal_property.value);
+                                                         bc_prop_p->v.internal_property.value);
         if (old_bc_p != NULL)
         {
           /* Free the old bytecode */
           ecma_bytecode_deref ((ecma_compiled_code_t *) old_bc_p);
         }
 
-        ECMA_SET_POINTER (bc_prop_p->u.internal_property.value, new_bc_p);
+        ECMA_SET_POINTER (bc_prop_p->v.internal_property.value, new_bc_p);
 
         re_initialize_props (this_obj_p, pattern_string_p, flags);
 
@@ -207,7 +207,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
                         ret_value);
 
         re_compiled_code_t *old_bc_p = ECMA_GET_POINTER (re_compiled_code_t,
-                                                         bc_prop_p->u.internal_property.value);
+                                                         bc_prop_p->v.internal_property.value);
 
         if (old_bc_p != NULL)
         {
@@ -215,7 +215,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
           ecma_bytecode_deref ((ecma_compiled_code_t *) old_bc_p);
         }
 
-        ECMA_SET_POINTER (bc_prop_p->u.internal_property.value, new_bc_p);
+        ECMA_SET_POINTER (bc_prop_p->v.internal_property.value, new_bc_p);
         re_initialize_props (this_obj_p, pattern_string_p, flags);
         ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 
@@ -270,7 +270,7 @@ ecma_builtin_regexp_prototype_exec (ecma_value_t this_arg, /**< this argument */
     ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
     bytecode_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
 
-    void *bytecode_p = ECMA_GET_POINTER (void, bytecode_prop_p->u.internal_property.value);
+    void *bytecode_p = ECMA_GET_POINTER (void, bytecode_prop_p->v.internal_property.value);
 
     if (bytecode_p == NULL)
     {
@@ -380,7 +380,7 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     ecma_deref_ecma_string (magic_string_p);
 
     ecma_string_t *src_sep_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_SLASH_CHAR);
-    ecma_string_t *source_str_p = ecma_get_string_from_value (source_prop_p->u.named_data_property.value);
+    ecma_string_t *source_str_p = ecma_get_string_from_value (ecma_get_named_data_property_value (source_prop_p));
     ecma_string_t *output_str_p = ecma_concat_ecma_strings (src_sep_str_p, ecma_copy_or_ref_ecma_string (source_str_p));
     ecma_deref_ecma_string (source_str_p);
 
@@ -394,7 +394,7 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     ecma_property_t *global_prop_p = ecma_op_object_get_property (obj_p, magic_string_p);
     ecma_deref_ecma_string (magic_string_p);
 
-    if (ecma_is_value_true (global_prop_p->u.named_data_property.value))
+    if (ecma_is_value_true (ecma_get_named_data_property_value (global_prop_p)))
     {
       ecma_string_t *g_flag_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_G_CHAR);
       concat_p = ecma_concat_ecma_strings (output_str_p, g_flag_str_p);
@@ -408,7 +408,7 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     ecma_property_t *ignorecase_prop_p = ecma_op_object_get_property (obj_p, magic_string_p);
     ecma_deref_ecma_string (magic_string_p);
 
-    if (ecma_is_value_true (ignorecase_prop_p->u.named_data_property.value))
+    if (ecma_is_value_true (ecma_get_named_data_property_value (ignorecase_prop_p)))
     {
       ecma_string_t *ic_flag_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_I_CHAR);
       concat_p = ecma_concat_ecma_strings (output_str_p, ic_flag_str_p);
@@ -422,7 +422,7 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     ecma_property_t *multiline_prop_p = ecma_op_object_get_property (obj_p, magic_string_p);
     ecma_deref_ecma_string (magic_string_p);
 
-    if (ecma_is_value_true (multiline_prop_p->u.named_data_property.value))
+    if (ecma_is_value_true (ecma_get_named_data_property_value (multiline_prop_p)))
     {
       ecma_string_t *m_flag_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_M_CHAR);
       concat_p = ecma_concat_ecma_strings (output_str_p, m_flag_str_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -80,7 +80,7 @@ ecma_builtin_string_prototype_object_to_string (ecma_value_t this_arg) /**< this
                                                                        ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
 
       ecma_string_t *prim_value_str_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                                                   prim_value_prop_p->u.internal_property.value);
+                                                                   prim_value_prop_p->v.internal_property.value);
 
       prim_value_str_p = ecma_copy_or_ref_ecma_string (prim_value_str_p);
 
@@ -1553,7 +1553,7 @@ ecma_builtin_helper_split_match (ecma_value_t input_string, /**< first argument 
       ecma_string_t *magic_index_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
       ecma_property_t *index_prop_p = ecma_get_named_property (obj_p, magic_index_str_p);
 
-      ecma_number_t *index_num_p = ecma_get_number_from_value (index_prop_p->u.named_data_property.value);
+      ecma_number_t *index_num_p = ecma_get_number_from_value (ecma_get_named_data_property_value (index_prop_p));
       *index_num_p += start_idx;
 
       ecma_deref_ecma_string (magic_index_str_p);
@@ -1815,7 +1815,8 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
               ecma_string_t *magic_index_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
               ecma_property_t *index_prop_p = ecma_get_named_property (match_array_obj_p, magic_index_str_p);
 
-              ecma_number_t *index_num_p = ecma_get_number_from_value (index_prop_p->u.named_data_property.value);
+              ecma_value_t index_value = ecma_get_named_data_property_value (index_prop_p);
+              ecma_number_t *index_num_p = ecma_get_number_from_value (index_value);
               JERRY_ASSERT (*index_num_p >= 0);
 
               uint32_t end_pos = ecma_number_to_uint32 (*index_num_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -111,7 +111,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
 
   ecma_property_t *built_in_id_prop_p = ecma_create_internal_property (object_obj_p,
                                                                        ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
-  built_in_id_prop_p->u.internal_property.value = obj_builtin_id;
+  built_in_id_prop_p->v.internal_property.value = obj_builtin_id;
 
   ecma_set_object_is_builtin (object_obj_p, true);
 
@@ -126,7 +126,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *prim_value_prop_p;
       prim_value_prop_p = ecma_create_internal_property (object_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
-      ECMA_SET_POINTER (prim_value_prop_p->u.internal_property.value, prim_prop_str_value_p);
+      ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_prop_str_value_p);
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_STRING_BUILTIN */
@@ -140,7 +140,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *prim_value_prop_p;
       prim_value_prop_p = ecma_create_internal_property (object_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-      ECMA_SET_POINTER (prim_value_prop_p->u.internal_property.value, prim_prop_num_value_p);
+      ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_prop_num_value_p);
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_NUMBER_BUILTIN */
@@ -151,7 +151,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *prim_value_prop_p;
       prim_value_prop_p = ecma_create_internal_property (object_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_PRIMITIVE_BOOLEAN_VALUE);
-      prim_value_prop_p->u.internal_property.value = ECMA_SIMPLE_VALUE_FALSE;
+      prim_value_prop_p->v.internal_property.value = ECMA_SIMPLE_VALUE_FALSE;
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_BOOLEAN_BUILTIN */
@@ -165,7 +165,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *prim_value_prop_p;
       prim_value_prop_p = ecma_create_internal_property (object_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-      ECMA_SET_POINTER (prim_value_prop_p->u.internal_property.value, prim_prop_num_value_p);
+      ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_prop_num_value_p);
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_DATE_BUILTIN */
@@ -176,7 +176,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *bytecode_prop_p;
       bytecode_prop_p = ecma_create_internal_property (object_obj_p,
                                                        ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
-      bytecode_prop_p->u.internal_property.value = ECMA_NULL_POINTER;
+      bytecode_prop_p->v.internal_property.value = ECMA_NULL_POINTER;
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_REGEXP_BUILTIN */
@@ -309,7 +309,7 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
 
       ecma_property_t *desc_prop_p = ecma_get_internal_property (object_p,
                                                                ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC);
-      uint64_t builtin_routine_desc = desc_prop_p->u.internal_property.value;
+      uint64_t builtin_routine_desc = desc_prop_p->v.internal_property.value;
 
       JERRY_STATIC_ASSERT (sizeof (uint8_t) * JERRY_BITSINBYTE == ECMA_BUILTIN_ROUTINE_ID_LENGTH_VALUE_WIDTH,
                            bits_in_uint8_t_must_be_equal_to_ECMA_BUILTIN_ROUTINE_ID_LENGTH_VALUE_WIDTH);
@@ -337,7 +337,7 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
   {
     ecma_property_t *built_in_id_prop_p = ecma_get_internal_property (object_p,
                                                                       ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
-    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->u.internal_property.value;
+    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->v.internal_property.value;
 
     JERRY_ASSERT (ecma_builtin_is (object_p, builtin_id));
 
@@ -411,7 +411,7 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
   {
     ecma_property_t *built_in_id_prop_p = ecma_get_internal_property (object_p,
                                                                       ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
-    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->u.internal_property.value;
+    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->v.internal_property.value;
 
     JERRY_ASSERT (ecma_builtin_is (object_p, builtin_id));
 
@@ -493,7 +493,7 @@ ecma_builtin_make_function_object_for_routine (ecma_builtin_id_t builtin_id, /**
                                                                         ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC);
 
   JERRY_ASSERT ((uint32_t) packed_value == packed_value);
-  routine_desc_prop_p->u.internal_property.value = (uint32_t) packed_value;
+  routine_desc_prop_p->v.internal_property.value = (uint32_t) packed_value;
 
   return func_obj_p;
 } /* ecma_builtin_make_function_object_for_routine */
@@ -517,7 +517,7 @@ ecma_builtin_dispatch_call (ecma_object_t *obj_p, /**< built-in object */
   {
     ecma_property_t *desc_prop_p = ecma_get_internal_property (obj_p,
                                                                ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC);
-    uint64_t builtin_routine_desc = desc_prop_p->u.internal_property.value;
+    uint64_t builtin_routine_desc = desc_prop_p->v.internal_property.value;
 
     uint64_t built_in_id_field = JRT_EXTRACT_BIT_FIELD (uint64_t, builtin_routine_desc,
                                                         ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_OBJECT_ID_POS,
@@ -544,7 +544,7 @@ ecma_builtin_dispatch_call (ecma_object_t *obj_p, /**< built-in object */
 
     ecma_property_t *built_in_id_prop_p = ecma_get_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
-    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->u.internal_property.value;
+    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->v.internal_property.value;
 
     JERRY_ASSERT (ecma_builtin_is (obj_p, builtin_id));
 
@@ -605,7 +605,7 @@ ecma_builtin_dispatch_construct (ecma_object_t *obj_p, /**< built-in object */
 
   ecma_property_t *built_in_id_prop_p = ecma_get_internal_property (obj_p,
                                                                     ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
-  ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->u.internal_property.value;
+  ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->v.internal_property.value;
 
   JERRY_ASSERT (ecma_builtin_is (obj_p, builtin_id));
 

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -156,7 +156,7 @@ ecma_op_array_object_define_own_property (ecma_object_t *obj_p, /**< the array o
   // 1.
   ecma_string_t *magic_string_length_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
   ecma_property_t *len_prop_p = ecma_op_object_get_own_property (obj_p, magic_string_length_p);
-  JERRY_ASSERT (len_prop_p != NULL && len_prop_p->type == ECMA_PROPERTY_NAMEDDATA);
+  JERRY_ASSERT (len_prop_p != NULL && (len_prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA));
 
   // 2.
   ecma_value_t old_len_value = ecma_get_named_data_property_value (len_prop_p);

--- a/jerry-core/ecma/operations/ecma-boolean-object.c
+++ b/jerry-core/ecma/operations/ecma-boolean-object.c
@@ -63,11 +63,11 @@ ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boo
   ecma_deref_object (prototype_obj_p);
 
   ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  class_prop_p->u.internal_property.value = LIT_MAGIC_STRING_BOOLEAN_UL;
+  class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_BOOLEAN_UL;
 
   ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_BOOLEAN_VALUE);
-  prim_value_prop_p->u.internal_property.value = bool_value;
+  prim_value_prop_p->v.internal_property.value = bool_value;
 
   return ecma_make_object_value (obj_p);
 } /* ecma_op_create_boolean_object */

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -96,7 +96,7 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
 
   ecma_property_t *class_prop_p = ecma_create_internal_property (new_error_obj_p,
                                                                  ECMA_INTERNAL_PROPERTY_CLASS);
-  class_prop_p->u.internal_property.value = LIT_MAGIC_STRING_ERROR_UL;
+  class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_ERROR_UL;
 
   return new_error_obj_p;
 #else /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_ERROR_BUILTINS */

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -168,11 +168,11 @@ ecma_op_create_function_object (ecma_object_t *scope_p, /**< function's scope */
 
   // 9.
   ecma_property_t *scope_prop_p = ecma_create_internal_property (f, ECMA_INTERNAL_PROPERTY_SCOPE);
-  ECMA_SET_POINTER (scope_prop_p->u.internal_property.value, scope_p);
+  ECMA_SET_POINTER (scope_prop_p->v.internal_property.value, scope_p);
 
   // 10., 11., 12.
   ecma_property_t *bytecode_prop_p = ecma_create_internal_property (f, ECMA_INTERNAL_PROPERTY_CODE_BYTECODE);
-  MEM_CP_SET_NON_NULL_POINTER (bytecode_prop_p->u.internal_property.value, bytecode_data_p);
+  MEM_CP_SET_NON_NULL_POINTER (bytecode_prop_p->v.internal_property.value, bytecode_data_p);
   ecma_bytecode_ref ((ecma_compiled_code_t *) bytecode_data_p);
 
   // 14., 15., 16., 17., 18.
@@ -294,7 +294,7 @@ ecma_op_function_try_lazy_instantiate_property (ecma_object_t *obj_p, /**< the f
     ecma_property_t *bytecode_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CODE_BYTECODE);
 
     const ecma_compiled_code_t *bytecode_data_p;
-    bytecode_data_p = MEM_CP_GET_POINTER (const ecma_compiled_code_t, bytecode_prop_p->u.internal_property.value);
+    bytecode_data_p = MEM_CP_GET_POINTER (const ecma_compiled_code_t, bytecode_prop_p->v.internal_property.value);
 
     if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_UINT16_ARGUMENTS)
     {
@@ -528,7 +528,7 @@ ecma_op_function_has_instance (ecma_object_t *func_obj_p, /**< Function object *
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
     ecma_object_t *target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                                  target_function_prop_p->u.internal_property.value);
+                                                                  target_function_prop_p->v.internal_property.value);
 
     /* 3. */
     ret_value = ecma_op_object_has_instance (target_func_obj_p, value);
@@ -575,7 +575,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       ecma_property_t *bytecode_prop_p = ecma_get_internal_property (func_obj_p, ECMA_INTERNAL_PROPERTY_CODE_BYTECODE);
 
       ecma_object_t *scope_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                          scope_prop_p->u.internal_property.value);
+                                                          scope_prop_p->v.internal_property.value);
 
       // 8.
       ecma_value_t this_binding;
@@ -583,7 +583,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       bool is_no_lex_env;
 
       const ecma_compiled_code_t *bytecode_data_p;
-      bytecode_data_p = MEM_CP_GET_POINTER (const ecma_compiled_code_t, bytecode_prop_p->u.internal_property.value);
+      bytecode_data_p = MEM_CP_GET_POINTER (const ecma_compiled_code_t, bytecode_prop_p->v.internal_property.value);
 
       is_strict = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE) ? true : false;
       is_no_lex_env = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_LEXICAL_ENV_NOT_NEEDED) ? true : false;
@@ -682,18 +682,18 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
     ecma_object_t *target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                                  target_function_prop_p->u.internal_property.value);
+                                                                  target_function_prop_p->v.internal_property.value);
 
     /* 4. */
     ecma_property_t *bound_args_prop_p;
-    ecma_value_t bound_this_value = bound_this_prop_p->u.internal_property.value;
+    ecma_value_t bound_this_value = bound_this_prop_p->v.internal_property.value;
     bound_args_prop_p = ecma_find_internal_property (func_obj_p, ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS);
 
     if (bound_args_prop_p != NULL)
     {
       ecma_collection_header_t *bound_arg_list_p;
       bound_arg_list_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_header_t,
-                                                    bound_args_prop_p->u.internal_property.value);
+                                                    bound_args_prop_p->v.internal_property.value);
 
       JERRY_ASSERT (bound_arg_list_p->unit_number > 0);
 
@@ -866,7 +866,7 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
     ecma_object_t *target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                                  target_function_prop_p->u.internal_property.value);
+                                                                  target_function_prop_p->v.internal_property.value);
 
     /* 2. */
     if (!ecma_is_constructor (ecma_make_object_value (target_func_obj_p)))
@@ -883,7 +883,7 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
       {
         ecma_collection_header_t *bound_arg_list_p;
         bound_arg_list_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_header_t,
-                                                      bound_args_prop_p->u.internal_property.value);
+                                                      bound_args_prop_p->v.internal_property.value);
 
 
         JERRY_ASSERT (bound_arg_list_p->unit_number > 0);
@@ -973,13 +973,13 @@ ecma_op_function_declaration (ecma_object_t *lex_env_p, /**< lexical environment
 
       JERRY_ASSERT (ecma_is_value_true (completion));
     }
-    else if (existing_prop_p->type == ECMA_PROPERTY_NAMEDACCESSOR)
+    else if (existing_prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR)
     {
       ret_value = ecma_raise_type_error ("");
     }
     else
     {
-      JERRY_ASSERT (existing_prop_p->type == ECMA_PROPERTY_NAMEDDATA);
+      JERRY_ASSERT (existing_prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
 
       if (!ecma_is_property_writable (existing_prop_p)
           || !ecma_is_property_enumerable (existing_prop_p))

--- a/jerry-core/ecma/operations/ecma-get-put-value.c
+++ b/jerry-core/ecma/operations/ecma-get-put-value.c
@@ -123,7 +123,7 @@ ecma_op_get_value_object_base (ecma_reference_t ref) /**< ECMA-reference */
       // 3.
       ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
     }
-    else if (prop_p->type == ECMA_PROPERTY_NAMEDDATA)
+    else if (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA)
     {
       // 4.
       ret_value = ecma_copy_value (ecma_get_named_data_property_value (prop_p), true);
@@ -131,7 +131,7 @@ ecma_op_get_value_object_base (ecma_reference_t ref) /**< ECMA-reference */
     else
     {
       // 5.
-      JERRY_ASSERT (prop_p->type == ECMA_PROPERTY_NAMEDACCESSOR);
+      JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR);
 
       ecma_object_t *obj_p = ecma_get_named_accessor_property_getter (prop_p);
 
@@ -303,17 +303,16 @@ ecma_op_put_value_object_base (ecma_reference_t ref, /**< ECMA-reference */
       ecma_property_t *prop_p = ecma_op_object_get_property (obj_p, referenced_name_p);
 
       // sub_4., sub_7
-      if ((own_prop_p != NULL
-           && own_prop_p->type == ECMA_PROPERTY_NAMEDDATA)
+      if ((own_prop_p != NULL && (own_prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA))
           || (prop_p == NULL)
-          || (prop_p->type != ECMA_PROPERTY_NAMEDACCESSOR))
+          || !(prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR))
       {
         ret_value = ecma_reject_put (ref.is_strict);
       }
       else
       {
         // sub_6.
-        JERRY_ASSERT (prop_p != NULL && prop_p->type == ECMA_PROPERTY_NAMEDACCESSOR);
+        JERRY_ASSERT (prop_p != NULL && (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR));
 
         ecma_object_t *setter_p = ecma_get_named_accessor_property_setter (prop_p);
         JERRY_ASSERT (setter_p != NULL);

--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -330,7 +330,7 @@ ecma_op_delete_binding (ecma_object_t *lex_env_p, /**< lexical environment */
     }
     else
     {
-      JERRY_ASSERT (prop_p->type == ECMA_PROPERTY_NAMEDDATA);
+      JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
 
       if (!ecma_is_property_configurable (prop_p))
       {

--- a/jerry-core/ecma/operations/ecma-number-object.c
+++ b/jerry-core/ecma/operations/ecma-number-object.c
@@ -62,11 +62,11 @@ ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Numb
   ecma_deref_object (prototype_obj_p);
 
   ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  class_prop_p->u.internal_property.value = LIT_MAGIC_STRING_NUMBER_UL;
+  class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_NUMBER_UL;
 
   ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-  ECMA_SET_POINTER (prim_value_prop_p->u.internal_property.value, prim_value_p);
+  ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_value_p);
 
   return ecma_make_object_value (obj_p);
 } /* ecma_op_create_number_object */

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -84,7 +84,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
 
   // 4.
   ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  class_prop_p->u.internal_property.value = LIT_MAGIC_STRING_ARGUMENTS_UL;
+  class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_ARGUMENTS_UL;
 
   // 7.
   ecma_string_t *length_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
@@ -174,11 +174,11 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
 
       ecma_property_t *parameters_map_prop_p = ecma_create_internal_property (obj_p,
                                                                               ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
-      ECMA_SET_POINTER (parameters_map_prop_p->u.internal_property.value, map_p);
+      ECMA_SET_POINTER (parameters_map_prop_p->v.internal_property.value, map_p);
 
       ecma_property_t *scope_prop_p = ecma_create_internal_property (map_p,
                                                                      ECMA_INTERNAL_PROPERTY_SCOPE);
-      ECMA_SET_POINTER (scope_prop_p->u.internal_property.value, lex_env_p);
+      ECMA_SET_POINTER (scope_prop_p->v.internal_property.value, lex_env_p);
 
       ecma_deref_object (map_p);
     }
@@ -286,7 +286,7 @@ ecma_arguments_get_mapped_arg_value (ecma_object_t *map_p, /**< [[ParametersMap]
 {
   ecma_property_t *scope_prop_p = ecma_get_internal_property (map_p, ECMA_INTERNAL_PROPERTY_SCOPE);
   ecma_object_t *lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                        scope_prop_p->u.internal_property.value);
+                                                        scope_prop_p->v.internal_property.value);
   JERRY_ASSERT (lex_env_p != NULL
                 && ecma_is_lexical_environment (lex_env_p));
 
@@ -317,7 +317,7 @@ ecma_op_arguments_object_get (ecma_object_t *obj_p, /**< the object */
   // 1.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
   ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    map_prop_p->u.internal_property.value);
+                                                    map_prop_p->v.internal_property.value);
 
   // 2.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
@@ -363,7 +363,7 @@ ecma_op_arguments_object_get_own_property (ecma_object_t *obj_p, /**< the object
   // 3.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
   ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    map_prop_p->u.internal_property.value);
+                                                    map_prop_p->v.internal_property.value);
 
   // 4.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
@@ -403,7 +403,7 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the obj
   // 1.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
   ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    map_prop_p->u.internal_property.value);
+                                                    map_prop_p->v.internal_property.value);
 
   // 2.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
@@ -444,7 +444,7 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the obj
         /* emulating execution of function described by MakeArgSetter */
         ecma_property_t *scope_prop_p = ecma_get_internal_property (map_p, ECMA_INTERNAL_PROPERTY_SCOPE);
         ecma_object_t *lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                              scope_prop_p->u.internal_property.value);
+                                                              scope_prop_p->v.internal_property.value);
 
         ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
         ecma_value_t arg_name_prop_value = ecma_get_named_data_property_value (mapped_prop_p);
@@ -501,7 +501,7 @@ ecma_op_arguments_object_delete (ecma_object_t *obj_p, /**< the object */
   // 1.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
   ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    map_prop_p->u.internal_property.value);
+                                                    map_prop_p->v.internal_property.value);
 
   // 2.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -156,7 +156,7 @@ ecma_op_general_object_get (ecma_object_t *obj_p, /**< the object */
   }
 
   // 3.
-  if (prop_p->type == ECMA_PROPERTY_NAMEDDATA)
+  if (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA)
   {
     return ecma_copy_value (ecma_get_named_data_property_value (prop_p), true);
   }
@@ -283,8 +283,7 @@ ecma_op_general_object_put (ecma_object_t *obj_p, /**< the object */
   ecma_property_t *own_desc_p = ecma_op_object_get_own_property (obj_p, property_name_p);
 
   // 3.
-  if (own_desc_p != NULL
-      && own_desc_p->type == ECMA_PROPERTY_NAMEDDATA)
+  if (own_desc_p != NULL && (own_desc_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA))
   {
     // a.
     ecma_property_descriptor_t value_desc = ecma_make_empty_property_descriptor ();
@@ -304,8 +303,7 @@ ecma_op_general_object_put (ecma_object_t *obj_p, /**< the object */
   ecma_property_t *desc_p = ecma_op_object_get_property (obj_p, property_name_p);
 
   // 5.
-  if (desc_p != NULL
-      && desc_p->type == ECMA_PROPERTY_NAMEDACCESSOR)
+  if (desc_p != NULL && (desc_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR))
   {
     // a.
     ecma_object_t *setter_p = ecma_get_named_accessor_property_setter (desc_p);
@@ -366,7 +364,7 @@ ecma_op_general_object_can_put (ecma_object_t *obj_p, /**< the object */
   if (prop_p != NULL)
   {
     // a.
-    if (prop_p->type == ECMA_PROPERTY_NAMEDACCESSOR)
+    if (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR)
     {
       ecma_object_t *setter_p = ecma_get_named_accessor_property_setter (prop_p);
 
@@ -382,8 +380,7 @@ ecma_op_general_object_can_put (ecma_object_t *obj_p, /**< the object */
     else
     {
       // b.
-
-      JERRY_ASSERT (prop_p->type == ECMA_PROPERTY_NAMEDDATA);
+      JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
 
       return ecma_is_property_writable (prop_p);
     }
@@ -408,7 +405,7 @@ ecma_op_general_object_can_put (ecma_object_t *obj_p, /**< the object */
   }
 
   // 7.
-  if (inherited_p->type == ECMA_PROPERTY_NAMEDACCESSOR)
+  if (inherited_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR)
   {
     ecma_object_t *setter_p = ecma_get_named_accessor_property_setter (inherited_p);
 
@@ -424,7 +421,7 @@ ecma_op_general_object_can_put (ecma_object_t *obj_p, /**< the object */
   else
   {
     // 8.
-    JERRY_ASSERT (inherited_p->type == ECMA_PROPERTY_NAMEDDATA);
+    JERRY_ASSERT (inherited_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
 
     // a.
     if (!ecma_get_object_extensible (obj_p))
@@ -657,8 +654,8 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
   }
 
   // 6.
-  const bool is_current_data_descriptor = (current_p->type == ECMA_PROPERTY_NAMEDDATA);
-  const bool is_current_accessor_descriptor = (current_p->type == ECMA_PROPERTY_NAMEDACCESSOR);
+  const bool is_current_data_descriptor = (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+  const bool is_current_accessor_descriptor = (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR);
 
   JERRY_ASSERT (is_current_data_descriptor || is_current_accessor_descriptor);
 
@@ -822,28 +819,28 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
   // 12.
   if (property_desc_p->is_value_defined)
   {
-    JERRY_ASSERT (current_p->type == ECMA_PROPERTY_NAMEDDATA);
+    JERRY_ASSERT (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
 
     ecma_named_data_property_assign_value (obj_p, current_p, property_desc_p->value);
   }
 
   if (property_desc_p->is_writable_defined)
   {
-    JERRY_ASSERT (current_p->type == ECMA_PROPERTY_NAMEDDATA);
+    JERRY_ASSERT (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
 
     ecma_set_property_writable_attr (current_p, property_desc_p->is_writable);
   }
 
   if (property_desc_p->is_get_defined)
   {
-    JERRY_ASSERT (current_p->type == ECMA_PROPERTY_NAMEDACCESSOR);
+    JERRY_ASSERT (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR);
 
     ecma_set_named_accessor_property_getter (obj_p, current_p, property_desc_p->get_p);
   }
 
   if (property_desc_p->is_set_defined)
   {
-    JERRY_ASSERT (current_p->type == ECMA_PROPERTY_NAMEDACCESSOR);
+    JERRY_ASSERT (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR);
 
     ecma_set_named_accessor_property_setter (obj_p, current_p, property_desc_p->set_p);
   }

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -628,20 +628,19 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
          prop_iter_p != NULL;
          prop_iter_p = ECMA_GET_POINTER (ecma_property_t, prop_iter_p->next_property_p))
     {
-      if (prop_iter_p->type == ECMA_PROPERTY_NAMEDDATA
-          || prop_iter_p->type == ECMA_PROPERTY_NAMEDACCESSOR)
+      if (prop_iter_p->flags & (ECMA_PROPERTY_FLAG_NAMEDDATA | ECMA_PROPERTY_FLAG_NAMEDACCESSOR))
       {
         ecma_string_t *name_p;
 
-        if (prop_iter_p->type == ECMA_PROPERTY_NAMEDDATA)
+        if (prop_iter_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA)
         {
-          name_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t, prop_iter_p->u.named_data_property.name_p);
+          name_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t, prop_iter_p->v.named_data_property.name_p);
         }
         else
         {
-          JERRY_ASSERT (prop_iter_p->type == ECMA_PROPERTY_NAMEDACCESSOR);
+          JERRY_ASSERT (prop_iter_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR);
 
-          name_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t, prop_iter_p->u.named_accessor_property.name_p);
+          name_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t, prop_iter_p->v.named_accessor_property.name_p);
         }
 
         if (!(is_enumerable_only && !ecma_is_property_enumerable (prop_iter_p)))
@@ -697,7 +696,7 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
       }
       else
       {
-        JERRY_ASSERT (prop_iter_p->type == ECMA_PROPERTY_INTERNAL);
+        JERRY_ASSERT (prop_iter_p->flags & ECMA_PROPERTY_FLAG_INTERNAL);
       }
     }
 
@@ -903,7 +902,7 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
       {
         ecma_property_t *built_in_id_prop_p = ecma_get_internal_property (obj_p,
                                                                           ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
-        ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->u.internal_property.value;
+        ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->v.internal_property.value;
 
         switch (builtin_id)
         {
@@ -984,7 +983,7 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
         }
         else
         {
-          return (lit_magic_string_id_t) class_name_prop_p->u.internal_property.value;
+          return (lit_magic_string_id_t) class_name_prop_p->v.internal_property.value;
         }
       }
     }

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -94,7 +94,7 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
 
   ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
-  ECMA_SET_POINTER (prim_value_prop_p->u.internal_property.value, prim_prop_str_value_p);
+  ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_prop_str_value_p);
 
   // 15.5.5.1
   ecma_string_t *length_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
@@ -169,7 +169,7 @@ ecma_op_string_object_get_own_property (ecma_object_t *obj_p, /**< a String obje
   ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                    ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
   ecma_string_t *prim_value_str_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                                               prim_value_prop_p->u.internal_property.value);
+                                                               prim_value_prop_p->v.internal_property.value);
 
   // 6.
   ecma_length_t length = ecma_string_get_length (prim_value_str_p);
@@ -236,7 +236,7 @@ ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p, /**< a String obj
   ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                    ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
   ecma_string_t *prim_value_str_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                                               prim_value_prop_p->u.internal_property.value);
+                                                               prim_value_prop_p->v.internal_property.value);
 
   ecma_length_t length = ecma_string_get_length (prim_value_str_p);
 

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -157,7 +157,7 @@ opfunc_set_accessor (bool is_getter, /**< is getter accessor */
   ecma_string_t *accessor_name_p = ecma_get_string_from_value (accessor_name);
   ecma_property_t *property_p = ecma_find_named_property (object_p, accessor_name_p);
 
-  if (property_p != NULL && property_p->type != ECMA_PROPERTY_NAMEDACCESSOR)
+  if (property_p != NULL && !(property_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR))
   {
     ecma_delete_property (object_p, property_p);
     property_p = NULL;

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1011,7 +1011,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
             property_p = ecma_find_named_property (object_p, prop_name_p);
           }
 
-          if (property_p != NULL && property_p->type != ECMA_PROPERTY_NAMEDDATA)
+          if (property_p != NULL && !(property_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA))
           {
             ecma_delete_property (object_p, property_p);
             property_p = NULL;
@@ -1087,7 +1087,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
           JERRY_ASSERT (length_prop_p != NULL);
 
-          left_value = length_prop_p->u.named_data_property.value;
+          left_value = ecma_get_named_data_property_value (length_prop_p);
           length_num_p = ecma_get_number_from_value (left_value);
 
           ecma_deref_ecma_string (length_str_p);


### PR DESCRIPTION
Rearrange fields of ecma_property_t to be naturally aligned. Packed attribute and __extension__ keywords are removed. The standard approach reduced the binary size by 2K.