### PR TITLE
Refactor ECMA builtin template

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,9 +60,6 @@
 /* ecma-builtins.c */
 extern ecma_object_t *
 ecma_builtin_make_function_object_for_routine (ecma_builtin_id_t, uint16_t, uint8_t);
-extern int32_t
-ecma_builtin_bin_search_for_magic_string_id_in_array (const lit_magic_string_id_t[],
-                                                      ecma_length_t, lit_magic_string_id_t);
 
 #define BUILTIN(builtin_id, \
                 object_type, \
@@ -88,9 +85,7 @@ extern void \
 ecma_builtin_ ## lowercase_name ## _list_lazy_property_names (ecma_object_t *, \
                                                               bool, \
                                                               ecma_collection_header_t *, \
-                                                              ecma_collection_header_t *); \
-extern void \
-ecma_builtin_ ## lowercase_name ## _sort_property_names (void);
+                                                              ecma_collection_header_t *);
 #include "ecma-builtins.inc.h"
 
 #endif /* !ECMA_BUILTINS_INTERNAL_H */

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -219,10 +219,6 @@ ecma_instantiate_builtin (ecma_builtin_id_t id) /**< built-in id */
     case builtin_id: \
     { \
       JERRY_ASSERT (ecma_builtin_objects[builtin_id] == NULL); \
-      if (is_static) \
-      { \
-        ecma_builtin_ ## lowercase_name ## _sort_property_names (); \
-      } \
       \
       ecma_object_t *prototype_obj_p; \
       if (object_prototype_builtin_id == ECMA_BUILTIN_ID__COUNT) \
@@ -700,57 +696,6 @@ ecma_builtin_dispatch_routine (ecma_builtin_id_t builtin_object_id, /**< built-i
 
   JERRY_UNREACHABLE ();
 } /* ecma_builtin_dispatch_routine */
-
-/**
- * Binary search for magic string identifier in array.
- *
- * Warning:
- *         array should be sorted in ascending order
- *
- * @return index of identifier, if it is contained in array,
- *         -1 - otherwise.
- */
-int32_t
-ecma_builtin_bin_search_for_magic_string_id_in_array (const lit_magic_string_id_t ids[], /**< array to search in */
-                                                      ecma_length_t array_length, /**< number of elements
-                                                                                       in the array */
-                                                      lit_magic_string_id_t key) /**< value to search for */
-{
-#ifndef JERRY_NDEBUG
-  /* For binary search the values should be sorted */
-  for (ecma_length_t id_index = 1;
-       id_index < array_length;
-       id_index++)
-  {
-    JERRY_ASSERT (ids[id_index - 1] < ids[id_index]);
-  }
-#endif /* !JERRY_NDEBUG */
-
-  int32_t min = 0;
-  int32_t max = (int32_t) array_length - 1;
-
-  while (min <= max)
-  {
-    int32_t mid = (min + max) / 2;
-
-    if (ids[mid] == key)
-    {
-      return (int32_t) mid;
-    }
-    else if (ids[mid] > key)
-    {
-      max = mid - 1;
-    }
-    else
-    {
-      JERRY_ASSERT (ids[mid] < key);
-
-      min = mid + 1;
-    }
-  }
-
-  return -1;
-} /* ecma_builtin_bin_search_for_magic_string_id_in_array */
 
 /**
  * @}

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  */
 
 /* Description of built-in objects
-   in format (ECMA_BUILTIN_ID_id, object_type, class_magic_string_id, prototype_id, is_extensible, underscored_id) */
+   in format (ECMA_BUILTIN_ID_id, object_type, prototype_id, is_extensible, is_static, underscored_id) */
 
 /* The Object.prototype object (15.2.4) */
 BUILTIN (ECMA_BUILTIN_ID_OBJECT_PROTOTYPE,


### PR DESCRIPTION
Avoid sorting the array of property magic string IDs and make it
const, thus ensuring that it gets placed in .rodata. Replace the
binary search in the array (which would not work anymore because
of unsortendness) with function that returns the index of the
looked-after magic string ID using a switch-based logic (we rely
on compiler optimization to generate optimal code from that
switch).

Extras:
* Getting rid of the superfluous macro argument from routine names.
* Fixing the list of undef'd macros
* Fixing builtin-related comments

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu