### PR TITLE
Add some more `const`s to get data moved from .data to .rodata

### DIFF
--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -40,17 +40,17 @@
 /**
  * Jerry engine build date
  */
-const char *jerry_build_date = JERRY_BUILD_DATE;
+const char * const jerry_build_date = JERRY_BUILD_DATE;
 
 /**
  * Jerry engine build commit hash
  */
-const char *jerry_commit_hash = JERRY_COMMIT_HASH;
+const char * const jerry_commit_hash = JERRY_COMMIT_HASH;
 
 /**
  * Jerry engine build branch name
  */
-const char *jerry_branch_name = JERRY_BRANCH_NAME;
+const char * const jerry_branch_name = JERRY_BRANCH_NAME;
 
 /**
  * Jerry run-time configuration flags

--- a/jerry-core/jerry.h
+++ b/jerry-core/jerry.h
@@ -64,17 +64,17 @@ typedef enum
 /**
  * Jerry engine build date
  */
-extern const char *jerry_build_date;
+extern const char * const jerry_build_date;
 
 /**
  * Jerry engine build commit hash
  */
-extern const char *jerry_commit_hash;
+extern const char * const jerry_commit_hash;
 
 /**
  * Jerry engine build branch name
  */
-extern const char *jerry_branch_name;
+extern const char * const jerry_branch_name;
 
 #ifdef JERRY_ENABLE_LOG
 extern int jerry_debug_level;

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,10 +55,10 @@ lit_get_magic_string_ex_count (void)
 const lit_utf8_byte_t *
 lit_get_magic_string_utf8 (lit_magic_string_id_t id) /**< magic string id */
 {
-  static const lit_utf8_byte_t *magic_strings[] =
+  static const lit_utf8_byte_t * const magic_strings[] =
   {
 #define LIT_MAGIC_STRING_DEF(id, utf8_string) \
-    (lit_utf8_byte_t *) utf8_string,
+    (const lit_utf8_byte_t *) utf8_string,
 #include "lit-magic-strings.inc.h"
 #undef LIT_MAGIC_STRING_DEF
   };

--- a/jerry-core/parser/js/byte-code.c
+++ b/jerry-core/parser/js/byte-code.c
@@ -54,7 +54,7 @@ const uint8_t cbc_ext_flags[] =
 /**
  * Names of the opcodes.
  */
-const char *cbc_names[] =
+const char * const cbc_names[] =
 {
   CBC_OPCODE_LIST
 };
@@ -62,7 +62,7 @@ const char *cbc_names[] =
 /**
  * Names of the extended opcodes.
  */
-const char *cbc_ext_names[] =
+const char * const cbc_ext_names[] =
 {
   CBC_EXT_OPCODE_LIST
 };

--- a/jerry-core/parser/js/byte-code.h
+++ b/jerry-core/parser/js/byte-code.h
@@ -680,8 +680,8 @@ extern const uint8_t cbc_ext_flags[];
 /**
  * Opcode names for debugging.
  */
-extern const char *cbc_names[];
-extern const char *cbc_ext_names[];
+extern const char * const cbc_names[];
+extern const char * const cbc_ext_names[];
 
 #endif /* PARSER_DUMP_BYTE_CODE */
 


### PR DESCRIPTION
We already had some `const`s but it was still not enough.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu