### PR TITLE
Improve the usability of test runner scripts

### DIFF
--- a/tools/runners/run-test-suite.sh
+++ b/tools/runners/run-test-suite.sh
@@ -20,9 +20,6 @@ TIMEOUT=${TIMEOUT:=5}
 ENGINE="$1"
 shift
 
-OUT_DIR="$1"
-shift
-
 TESTS="$1"
 shift
 
@@ -34,30 +31,20 @@ then
     exit 1
 fi
 
-mkdir -p $OUT_DIR
-
-TEST_FILES=$OUT_DIR/test.files
-TEST_FAILED=$OUT_DIR/test.failed
-TEST_PASSED=$OUT_DIR/test.passed
+TEST_FILES=test.files
+TEST_FAILED=test.failed
+TEST_PASSED=test.passed
 
 if [ -d $TESTS ]
 then
     TESTS_DIR=$TESTS
 
-    ( cd $TESTS; find . -path fail -prune -o -name "[^N]*.js" -print ) | sort > $TEST_FILES
-
-    if [ -d $TESTS/fail ]
-    then
-        for error_code in `cd $TESTS/fail && ls -d [0-9]*`
-        do
-            ( cd $TESTS; find ./fail/$error_code -name "[^N]*.js" -print ) | sort >> $TEST_FILES
-        done
-    fi
+    ( cd $TESTS; find . -name "[^N]*.js" ) | sort > $TEST_FILES
 elif [ -f $TESTS ]
 then
     TESTS_DIR=`dirname $TESTS`
 
-    cp $TESTS $TEST_FILES
+    grep -e '.js\s*$' $TESTS | sort > $TEST_FILES
 else
     echo "$0: $TESTS: not a test suite"
     exit 1
@@ -93,7 +80,7 @@ do
 
     echo -n "[$tested/$total] $ENGINE $ENGINE_ARGS $full_test: "
 
-    ( ulimit -t $TIMEOUT; $ENGINE $ENGINE_ARGS $full_test &>$ENGINE_TEMP; exit $? )
+    ( ulimit -t $TIMEOUT; $ENGINE $ENGINE_ARGS $full_test &>$ENGINE_TEMP )
     status_code=$?
 
     if [ $status_code -ne $error_code ]

--- a/tools/runners/run-unittests.sh
+++ b/tools/runners/run-unittests.sh
@@ -18,10 +18,8 @@
 DIR="$1"
 shift
 
-mkdir -p $DIR/check
-
-UNITTEST_ERROR=$DIR/check/unittests.failed
-UNITTEST_OK=$DIR/check/unittests.passed
+UNITTEST_ERROR=unittests.failed
+UNITTEST_OK=unittests.passed
 
 rm -f $UNITTEST_ERROR $UNITTEST_OK
 


### PR DESCRIPTION
* First of all, remove the counter-intuitive "OUT_DIR" second
  argument of run-test-suite.sh. This, way, the invocation of the
  script becomes easier to remember:
  `tools/runners/run-test-suite.sh <engine> <testsuite>`
  However, this also means that all output files (lists of
  executed, passed, and failed tests) are generated in the current
  working directory.

* Align the behaviour of run-unittests.sh with the above, i.e.,
  don't try to guess where to put output files but write them in
  the CWD.

* Adapt Makefile to the change in the use of the test runner
  scripts: create and change to "check" directories before invoking
  test runner scripts.

Extras:
* tools/runners/run-test-suite.sh collected fail tests from
  directories twice. This does no harm but is inefficient, thus
  removing.
* tools/runners/run-test-suite.sh was too permissive on the
  contents of test suite list files. Better to accept those lines
  only which really contain paths to JS test files.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu