### PR TITLE
Add another argument for the JERRY_STATIC_ASSERT with the description of the assert statement.

### DIFF
--- a/jerry-core/ecma/base/ecma-alloc.c
+++ b/jerry-core/ecma/base/ecma-alloc.c
@@ -1,4 +1,5 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,16 +21,24 @@
 #include "jrt.h"
 #include "mem-poolman.h"
 
-JERRY_STATIC_ASSERT (sizeof (ecma_property_t) <= sizeof (uint64_t));
+JERRY_STATIC_ASSERT (sizeof (ecma_property_t) <= sizeof (uint64_t),
+                     size_of_ecma_property_t_must_be_less_than_or_equal_to_8_bytes);
 
-JERRY_STATIC_ASSERT (sizeof (ecma_object_t) <= sizeof (uint64_t));
-JERRY_STATIC_ASSERT (ECMA_OBJECT_OBJ_TYPE_SIZE <= sizeof (uint64_t) * JERRY_BITSINBYTE);
-JERRY_STATIC_ASSERT (ECMA_OBJECT_LEX_ENV_TYPE_SIZE <= sizeof (uint64_t) * JERRY_BITSINBYTE);
+JERRY_STATIC_ASSERT (sizeof (ecma_object_t) <= sizeof (uint64_t),
+                     size_of_ecma_object_t_must_be_less_than_or_equal_to_8_bytes);
+JERRY_STATIC_ASSERT (ECMA_OBJECT_OBJ_TYPE_SIZE <= sizeof (uint64_t) * JERRY_BITSINBYTE,
+                     ECMA_OBJECT_OBJ_TYPE_SIZE_must_be_less_than_or_equal_to_64_bits);
+JERRY_STATIC_ASSERT (ECMA_OBJECT_LEX_ENV_TYPE_SIZE <= sizeof (uint64_t) * JERRY_BITSINBYTE,
+                     ECMA_OBJECT_LEX_ENV_TYPE_SIZE_must_be_less_than_or_equal_to_64_bits);
 
-JERRY_STATIC_ASSERT (sizeof (ecma_collection_header_t) == sizeof (uint64_t));
-JERRY_STATIC_ASSERT (sizeof (ecma_collection_chunk_t) == sizeof (uint64_t));
-JERRY_STATIC_ASSERT (sizeof (ecma_string_t) == sizeof (uint64_t));
-JERRY_STATIC_ASSERT (sizeof (ecma_getter_setter_pointers_t) <= sizeof (uint64_t));
+JERRY_STATIC_ASSERT (sizeof (ecma_collection_header_t) == sizeof (uint64_t),
+                     size_of_ecma_collection_header_t_must_be_less_than_or_equal_to_8_bytes);
+JERRY_STATIC_ASSERT (sizeof (ecma_collection_chunk_t) == sizeof (uint64_t),
+                     size_of_ecma_collection_chunk_t_must_be_less_than_or_equal_to_8_bytes);
+JERRY_STATIC_ASSERT (sizeof (ecma_string_t) == sizeof (uint64_t),
+                     size_of_ecma_string_t_must_be_less_than_or_equal_to_8_bytes);
+JERRY_STATIC_ASSERT (sizeof (ecma_getter_setter_pointers_t) <= sizeof (uint64_t),
+                     size_of_ecma_getter_setter_pointers_t_must_be_less_than_or_equal_to_8_bytes);
 
 /** \addtogroup ecma ECMA
  * @{

--- a/jerry-core/ecma/base/ecma-helpers-external-pointers.c
+++ b/jerry-core/ecma/base/ecma-helpers-external-pointers.c
@@ -1,4 +1,5 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +61,8 @@ ecma_create_external_pointer_property (ecma_object_t *obj_p, /**< object to crea
     is_new = false;
   }
 
-  JERRY_STATIC_ASSERT (sizeof (uint32_t) <= sizeof (prop_p->u.internal_property.value));
+  JERRY_STATIC_ASSERT (sizeof (uint32_t) <= sizeof (prop_p->u.internal_property.value),
+                       size_of_internal_property_value_must_be_greater_than_or_equal_to_4_bytes);
 
   if (sizeof (ecma_external_pointer_t) == sizeof (uint32_t))
   {
@@ -118,8 +120,6 @@ ecma_get_external_pointer_value (ecma_object_t *obj_p, /**< object to get proper
 
     return false;
   }
-
-  JERRY_STATIC_ASSERT (sizeof (uint32_t) <= sizeof (prop_p->u.internal_property.value));
 
   if (sizeof (ecma_external_pointer_t) == sizeof (uint32_t))
   {

--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -25,7 +25,8 @@
 #include "ecma-helpers.h"
 
 #if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32
-JERRY_STATIC_ASSERT (sizeof (ecma_number_t) == sizeof (uint32_t));
+JERRY_STATIC_ASSERT (sizeof (ecma_number_t) == sizeof (uint32_t),
+                     size_of_ecma_number_t_must_be_equal_to_4_bytes);
 
 /**
  * Packing sign, fraction and biased exponent to ecma-number
@@ -111,7 +112,8 @@ const int32_t ecma_number_exponent_bias = 127;
  */
 const ecma_number_t ecma_number_relative_eps = 1.0e-10f;
 #elif CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64
-JERRY_STATIC_ASSERT (sizeof (ecma_number_t) == sizeof (uint64_t));
+JERRY_STATIC_ASSERT (sizeof (ecma_number_t) == sizeof (uint64_t),
+                     size_of_ecma_number_t_must_be_equal_to_8_bytes);
 
 /**
  * Packing sign, fraction and biased exponent to ecma-number

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -1,4 +1,5 @@
 /* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +42,9 @@
 /**
  * The length should be representable with int32_t.
  */
-JERRY_STATIC_ASSERT ((uint32_t) ((int32_t) ECMA_STRING_MAX_CONCATENATION_LENGTH) ==
-                     ECMA_STRING_MAX_CONCATENATION_LENGTH);
+JERRY_STATIC_ASSERT ((int32_t) ECMA_STRING_MAX_CONCATENATION_LENGTH ==
+                     ECMA_STRING_MAX_CONCATENATION_LENGTH,
+                     ECMA_STRING_MAX_CONCATENATION_LENGTH_should_be_representable_with_int32_t);
 
 static void
 ecma_init_ecma_string_from_lit_cp (ecma_string_t *string_p,

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -28,7 +28,8 @@
 #include "jrt-bit-fields.h"
 #include "vm-defines.h"
 
-JERRY_STATIC_ASSERT (sizeof (ecma_value_t) * JERRY_BITSINBYTE >= ECMA_VALUE_SIZE);
+JERRY_STATIC_ASSERT (sizeof (ecma_value_t) * JERRY_BITSINBYTE >= ECMA_VALUE_SIZE,
+                     bits_in_ecma_value_t_must_be_greater_than_or_equal_to_ECMA_VALUE_SIZE);
 
 /**
  * Get type field of ecma value

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -444,7 +444,11 @@ ecma_create_internal_property (ecma_object_t *object_p, /**< the object */
   ECMA_SET_POINTER (new_property_p->next_property_p, list_head_p);
   ecma_set_property_list (object_p, new_property_p);
 
-  JERRY_STATIC_ASSERT (ECMA_INTERNAL_PROPERTY__COUNT <= (1ull << ECMA_PROPERTY_INTERNAL_PROPERTY_TYPE_WIDTH));
+  JERRY_STATIC_ASSERT (
+    ECMA_INTERNAL_PROPERTY__COUNT <= (1ull << ECMA_PROPERTY_INTERNAL_PROPERTY_TYPE_WIDTH),
+    ECMA_PROPERTY_INTERNAL_PROPERTY_TYPE_WIDTH_bits_must_be_able_to_represent_ECMA_INTERNAL_PROPERTY__COUNT_values
+  );
+
   JERRY_ASSERT (property_id < ECMA_INTERNAL_PROPERTY__COUNT);
 
   new_property_p->u.internal_property.type = property_id & ((1ull << ECMA_PROPERTY_INTERNAL_PROPERTY_TYPE_WIDTH) - 1);

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -45,7 +45,8 @@ typedef struct
   uint16_t padding;
 } ecma_lcache_hash_entry_t;
 
-JERRY_STATIC_ASSERT (sizeof (ecma_lcache_hash_entry_t) == sizeof (uint64_t));
+JERRY_STATIC_ASSERT (sizeof (ecma_lcache_hash_entry_t) == sizeof (uint64_t),
+                     size_of_ecma_lcache_hash_entry_t_must_be_equal_to_8_bytes);
 
 /**
  * LCache hash value length, in bits

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -1,5 +1,5 @@
 /* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged
+ * Copyright 2015-2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,7 +108,8 @@ ecma_builtin_global_object_print (ecma_value_t this_arg __attr_unused___, /**< t
       }
       else
       {
-        JERRY_STATIC_ASSERT (sizeof (code_point) == 2);
+        JERRY_STATIC_ASSERT (sizeof (code_point) == 2,
+                             size_of_code_point_must_be_equal_to_2_bytes);
 
         uint32_t byte_high = (uint32_t) jrt_extract_bit_field (code_point,
                                                                JERRY_BITSINBYTE,

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -1,4 +1,5 @@
 /* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2015-2016 University of Szeged
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -310,7 +311,8 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
                                                                ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC);
       uint64_t builtin_routine_desc = desc_prop_p->u.internal_property.value;
 
-      JERRY_STATIC_ASSERT (sizeof (uint8_t) * JERRY_BITSINBYTE == ECMA_BUILTIN_ROUTINE_ID_LENGTH_VALUE_WIDTH);
+      JERRY_STATIC_ASSERT (sizeof (uint8_t) * JERRY_BITSINBYTE == ECMA_BUILTIN_ROUTINE_ID_LENGTH_VALUE_WIDTH,
+                           bits_in_uint8_t_must_be_equal_to_ECMA_BUILTIN_ROUTINE_ID_LENGTH_VALUE_WIDTH);
       uint8_t length_prop_value = (uint8_t) jrt_extract_bit_field (builtin_routine_desc,
                                                                    ECMA_BUILTIN_ROUTINE_ID_LENGTH_VALUE_POS,
                                                                    ECMA_BUILTIN_ROUTINE_ID_LENGTH_VALUE_WIDTH);

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -1382,7 +1382,8 @@ jerry_api_invoke_function (bool is_invoke_as_constructor, /**< true - invoke fun
                            jerry_api_length_t args_count) /**< number of the arguments */
 {
   JERRY_ASSERT (args_count == 0 || args_p != NULL);
-  JERRY_STATIC_ASSERT (sizeof (args_count) == sizeof (ecma_length_t));
+  JERRY_STATIC_ASSERT (sizeof (args_count) == sizeof (ecma_length_t),
+                       size_of_args_count_must_be_equal_to_size_of_ecma_length_t);
 
   bool is_successful = true;
 

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -1,5 +1,6 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- *
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
+
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -59,10 +60,10 @@
  *         __LINE__ may be the same for asserts in a header
  *         and in an implementation file.
  */
-#define JERRY_STATIC_ASSERT_GLUE_(a, b) a ## b
-#define JERRY_STATIC_ASSERT_GLUE(a, b) JERRY_STATIC_ASSERT_GLUE_ (a, b)
-#define JERRY_STATIC_ASSERT(x) \
-  typedef char JERRY_STATIC_ASSERT_GLUE (static_assertion_failed_, __LINE__) \
+#define JERRY_STATIC_ASSERT_GLUE_(a, b, c) a ## b ## c
+#define JERRY_STATIC_ASSERT_GLUE(a, b, c) JERRY_STATIC_ASSERT_GLUE_ (a, b, c)
+#define JERRY_STATIC_ASSERT(x, msg) \
+  typedef char JERRY_STATIC_ASSERT_GLUE (static_assertion_failed_, __LINE__, msg) \
   [ (x) ? 1 : -1 ] __attr_unused___
 
 #define CALL_PRAGMA(x) _Pragma (#x)

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -17,7 +17,8 @@
 
 #include "jrt-libc-includes.h"
 
-JERRY_STATIC_ASSERT (sizeof (lit_utf8_iterator_pos_t) == sizeof (lit_utf8_size_t));
+JERRY_STATIC_ASSERT (sizeof (lit_utf8_iterator_pos_t) == sizeof (lit_utf8_size_t),
+                     size_of_lit_utf8_iterator_pos_t_must_be_equal_to_size_of_lit_utf8_size_t);
 
 /**
  * Compare two iterator positions

--- a/jerry-core/mem/mem-heap.c
+++ b/jerry-core/mem/mem-heap.c
@@ -1,4 +1,5 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +107,8 @@ typedef enum __attr_packed___
 /**
  * Chunk size should satisfy the required alignment value
  */
-JERRY_STATIC_ASSERT (MEM_HEAP_CHUNK_SIZE % MEM_ALIGNMENT == 0);
+JERRY_STATIC_ASSERT (MEM_HEAP_CHUNK_SIZE % MEM_ALIGNMENT == 0,
+                     MEM_HEAP_CHUNK_SIZE_must_be_multiple_of_MEM_ALIGNMENT);
 
 typedef enum
 {
@@ -160,7 +162,8 @@ typedef size_t mem_heap_bitmap_storage_item_t;
 /**
  * Overall number of bitmap bits is multiple of number of bits in a bitmap storage item
  */
-JERRY_STATIC_ASSERT (MEM_HEAP_BITMAP_BITS % MEM_HEAP_BITMAP_BITS_IN_STORAGE_ITEM == 0);
+JERRY_STATIC_ASSERT (MEM_HEAP_BITMAP_BITS % MEM_HEAP_BITMAP_BITS_IN_STORAGE_ITEM == 0,
+                     MEM_HEAP_BITMAP_BITS_must_be_multiple_of_MEM_HEAP_BITMAP_BITS_IN_STORAGE_ITEM);
 
 /**
  * Number of bitmap storage items
@@ -197,7 +200,8 @@ mem_heap_t mem_heap __attribute__ ((section (JERRY_HEAP_SECTION_ATTR)));
 /**
  * Check size of heap is corresponding to configuration
  */
-JERRY_STATIC_ASSERT (sizeof (mem_heap) <= MEM_HEAP_SIZE);
+JERRY_STATIC_ASSERT (sizeof (mem_heap) <= MEM_HEAP_SIZE,
+                     size_of_mem_heap_must_be_less_than_or_equal_to_MEM_HEAP_SIZE);
 
 /**
  * Bitmap of 'is allocated' flags
@@ -329,10 +333,14 @@ mem_heap_mark_chunk_allocated (size_t chunk_index, /**< index of the heap chunk 
 void
 mem_heap_init (void)
 {
-  JERRY_STATIC_ASSERT ((MEM_HEAP_CHUNK_SIZE & (MEM_HEAP_CHUNK_SIZE - 1u)) == 0);
-  JERRY_STATIC_ASSERT ((uintptr_t) mem_heap.area % MEM_ALIGNMENT == 0);
-  JERRY_STATIC_ASSERT ((uintptr_t) mem_heap.area % MEM_HEAP_CHUNK_SIZE == 0);
-  JERRY_STATIC_ASSERT (MEM_HEAP_AREA_SIZE % MEM_HEAP_CHUNK_SIZE == 0);
+  JERRY_STATIC_ASSERT ((MEM_HEAP_CHUNK_SIZE & (MEM_HEAP_CHUNK_SIZE - 1u)) == 0,
+                       MEM_HEAP_CHUNK_SIZE_must_be_power_of_2);
+  JERRY_STATIC_ASSERT ((uintptr_t) mem_heap.area % MEM_ALIGNMENT == 0,
+                       mem_heap_area_must_be_multiple_of_MEM_ALIGNMENT);
+  JERRY_STATIC_ASSERT ((uintptr_t) mem_heap.area % MEM_HEAP_CHUNK_SIZE == 0,
+                        mem_heap_area_must_be_multiple_of_MEM_HEAP_CHUNK_SIZE);
+  JERRY_STATIC_ASSERT (MEM_HEAP_AREA_SIZE % MEM_HEAP_CHUNK_SIZE == 0,
+                       MEM_HEAP_AREA_SIZE_must_be_multiple_of_MEM_HEAP_CHUNK_SIZE);
 
   JERRY_ASSERT (MEM_HEAP_AREA_SIZE <= (1u << MEM_HEAP_OFFSET_LOG));
 
@@ -757,9 +765,6 @@ mem_heap_free_block (void *ptr) /**< pointer to beginning of data space of the b
 void *
 mem_heap_get_chunked_block_start (void *ptr) /**< pointer into a block */
 {
-  JERRY_STATIC_ASSERT ((MEM_HEAP_CHUNK_SIZE & (MEM_HEAP_CHUNK_SIZE - 1u)) == 0);
-  JERRY_STATIC_ASSERT (((uintptr_t) mem_heap.area % MEM_HEAP_CHUNK_SIZE) == 0);
-
   JERRY_ASSERT (mem_heap.area <= (uint8_t *) ptr && (uint8_t *) ptr < (uint8_t *) mem_heap.area + MEM_HEAP_AREA_SIZE);
 
   uintptr_t uintptr = (uintptr_t) ptr;

--- a/jerry-core/mem/mem-poolman.c
+++ b/jerry-core/mem/mem-poolman.c
@@ -1,4 +1,5 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +113,8 @@ struct mem_pool_chunk
 /**
  * The condition is assumed when using pointer arithmetics on (mem_pool_chunk_t *) pointer type
  */
-JERRY_STATIC_ASSERT (sizeof (mem_pool_chunk_t) == MEM_POOL_CHUNK_SIZE);
+JERRY_STATIC_ASSERT (sizeof (mem_pool_chunk_t) == MEM_POOL_CHUNK_SIZE,
+                     size_of_mem_pool_chunk_t_must_be_equal_to_MEM_POOL_CHUNK_SIZE);
 
 /**
  * List of free pool chunks
@@ -567,9 +569,10 @@ mem_pools_alloc_longpath (void)
   mem_free_chunks_number += MEM_POOL_CHUNKS_NUMBER;
 #endif /* !JERRY_NDEBUG */
 
-  JERRY_STATIC_ASSERT (MEM_POOL_CHUNK_SIZE % MEM_ALIGNMENT == 0);
-  JERRY_STATIC_ASSERT (sizeof (mem_pool_chunk_t) == MEM_POOL_CHUNK_SIZE);
-  JERRY_STATIC_ASSERT (sizeof (mem_pool_chunk_index_t) <= MEM_POOL_CHUNK_SIZE);
+  JERRY_STATIC_ASSERT (MEM_POOL_CHUNK_SIZE % MEM_ALIGNMENT == 0,
+                       MEM_POOL_CHUNK_SIZE_must_be_multiple_of_MEM_ALIGNMENT);
+  JERRY_STATIC_ASSERT (sizeof (mem_pool_chunk_index_t) <= MEM_POOL_CHUNK_SIZE,
+                       size_of_mem_pool_chunk_index_t_must_be_less_than_or_equal_to_MEM_POOL_CHUNK_SIZE);
   JERRY_ASSERT ((mem_pool_chunk_index_t) MEM_POOL_CHUNKS_NUMBER == MEM_POOL_CHUNKS_NUMBER);
   JERRY_ASSERT (MEM_POOL_SIZE == MEM_POOL_CHUNKS_NUMBER * MEM_POOL_CHUNK_SIZE);
 

--- a/jerry-core/rcs/rcs-records.c
+++ b/jerry-core/rcs/rcs-records.c
@@ -1,5 +1,5 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2015-2016 University of Szeged
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -255,7 +255,8 @@ rcs_record_get_pointer (rcs_record_t *rec_p, /**< record */
 rcs_record_type_t
 rcs_record_get_type (rcs_record_t *rec_p) /**< record */
 {
-  JERRY_STATIC_ASSERT (sizeof (rcs_record_type_t) * JERRY_BITSINBYTE >= RCS_HEADER_TYPE_WIDTH);
+  JERRY_STATIC_ASSERT (sizeof (rcs_record_type_t) * JERRY_BITSINBYTE >= RCS_HEADER_TYPE_WIDTH,
+                       bits_in_rcs_record_type_t_must_be_greater_than_or_equal_to_RCS_HEADER_TYPE_WIDTH);
 
   return (rcs_record_type_t) rcs_record_get_field (rec_p, RCS_HEADER_TYPE_POS, RCS_HEADER_TYPE_WIDTH);
 } /* rcs_record_get_type */


### PR DESCRIPTION
The release.linux build fails with enabled ALL_IN_ONE option.