### PR TITLE
Warning fix for ALL_IN_ONE.

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -2088,7 +2088,7 @@ lexer_decode_unicode_sequence (const uint8_t *source_p) /**< source pointer */
  */
 int
 lexer_same_identifiers (lexer_lit_location_t *left, /**< left identifier */
-                        lexer_lit_location_t *right) /**< right identifier */
+                        const lexer_lit_location_t *right) /**< right identifier */
 {
   const uint8_t *left_p;
   const uint8_t *right_p;

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -355,7 +355,7 @@ void lexer_construct_literal_object (parser_context_t *, lexer_lit_location_t *,
 int lexer_construct_number_object (parser_context_t *, int, int);
 void lexer_construct_function_object (parser_context_t *, uint32_t);
 void lexer_construct_regexp_object (parser_context_t *, int);
-int lexer_same_identifiers (lexer_lit_location_t *, lexer_lit_location_t *);
+int lexer_same_identifiers (lexer_lit_location_t *, const lexer_lit_location_t *);
 
 /* Parser functions. */
 


### PR DESCRIPTION
Passing argument 2 of ‘lexer_same_identifiers’ discards ‘const’ qualifier from pointer target type.

JerryScript-DCO-1.0-Signed-off-by: Robert Sipka rsipka.uszeged@partner.samsung.com