### PR TITLE
Remove the prerequisites installation and MCU build steps from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,13 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tools/apt-get-install-deps.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tools/brew-install-deps.sh; fi
 
-install: make prerequisites
+install:
 
 script: "make -j VERBOSE=1 NINJA=1 $TARGET"
 
 env:
   - TARGET="check-signed-off check-vera check-cppcheck"
   - TARGET="build.linux test-js-precommit"
-  - TARGET=build.mcu_stm32f3
-  - TARGET=build.mcu_stm32f4
   - TARGET=test-unit
 
 matrix:

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ $(foreach __SYSTEM,$(NATIVE_SYSTEM) $(MCU_SYSTEMS), \
 # $(3) - target(s) to build with the cmake-generated Makefile
 define BUILD_RULE
 .PHONY: $(1)
-$(1): $$(BUILD_DIR)/$(2)/Makefile prerequisites
+$(1): $$(BUILD_DIR)/$(2)/Makefile
 	$$(Q) $$(call SHLOG,$$(BUILD_COMMAND) -C $$(BUILD_DIR)/$(2) $(3),$$(BUILD_DIR)/$(2)/$(1).log,Build)
 	$$(Q) $$(foreach __TARGET,$(3), \
             mkdir -p $$(OUT_DIR)/$$(__TARGET); \


### PR DESCRIPTION
The repeated downloads of the STM packages cause a huge slow-down
of Travis, especially when the source site becomes irresponsive
(which even causes Travis to report errors when the build would
work fine otherwise). Unfortunately, the license of the STM
packages does not allow their inclusion in the repository. (Note:
locally executed `make precommit` still builds MCU targets.)

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu