### PR TITLE
Add `STRIP_RELEASE_BINARY` option to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,11 @@ BUILD_NAME:=
    CMAKE_DEFINES:=$(CMAKE_DEFINES) -DUSE_COMPILER_DEFAULT_LIBC=$(USE_COMPILER_DEFAULT_LIBC)
   endif
 
+ # Apply strip to release binaries
+  ifneq ($(STRIP_RELEASE_BINARY),)
+   CMAKE_DEFINES:=$(CMAKE_DEFINES) -DSTRIP_RELEASE_BINARY=$(STRIP_RELEASE_BINARY)
+  endif
+
 # Directories
 export ROOT_DIR := $(shell pwd)
 export BUILD_DIR_PREFIX := $(ROOT_DIR)/build/obj


### PR DESCRIPTION
It is already supported by CMakeLists, might be useful to allow it
to be passed through Makefile.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu