### PR TITLE
Remove dead macros from memory management code

### DIFF
--- a/jerry-core/mem/mem-allocator.h
+++ b/jerry-core/mem/mem-allocator.h
@@ -44,11 +44,6 @@ typedef uint16_t mem_cpointer_t;
 #define MEM_ALIGNMENT       (1u << MEM_ALIGNMENT_LOG)
 
 /**
- * Required alignment for allocated units/blocks
- */
-#define MEM_POOL_ALIGNMENT       (1 << MEM_POOL_ALIGNMENT_LOG)
-
-/**
  * Width of compressed memory pointer
  */
 #define MEM_CP_WIDTH (MEM_HEAP_OFFSET_LOG - MEM_ALIGNMENT_LOG)

--- a/jerry-core/mem/mem-config.h
+++ b/jerry-core/mem/mem-config.h
@@ -38,9 +38,4 @@
  */
 #define MEM_ALIGNMENT_LOG   3
 
-/**
- * Logarithm of required alignment for allocated pools
- */
-#define MEM_POOL_ALIGNMENT_LOG   3
-
 #endif /* MEM_CONFIG_H */


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu

(Found some more dead code -- only macros -- after #934 . Sorry about the late hit.)