### PR TITLE
Use basename in a more generic form

### DIFF
--- a/tools/run-mem-stats-test.sh
+++ b/tools/run-mem-stats-test.sh
@@ -76,7 +76,7 @@ fi
 
 for bench in $BENCHMARKS
 do
-  test=`basename -s '.js' $bench`
+  test=`basename $bench .js`
 
   echo "$test" | awk "$PRINT_TEST_NAME_AWK_SCRIPT"
   MEM_STATS=$("$JERRY_MEM_STATS" --mem-stats --mem-stats-separate $bench | grep -e "Peak allocated =" | grep -o "[0-9]*")


### PR DESCRIPTION
Not all versions of basename supports the suffix option.

JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com