### PR TITLE
Few improvements for RegExp

### DIFF
--- a/jerry-core/parser/regexp/re-compiler.h
+++ b/jerry-core/parser/regexp/re-compiler.h
@@ -50,9 +50,6 @@ typedef struct
 ecma_value_t
 re_compile_bytecode (const re_compiled_code_t **, ecma_string_t *, uint16_t);
 
-const re_compiled_code_t *
-re_find_bytecode_in_cache (ecma_string_t *pattern_str_p, uint16_t flags, uint32_t *idx);
-
 void re_cache_gc_run ();
 
 /**


### PR DESCRIPTION
Added eviction mechanism to RegExp cache and small
refactoring. Fixed a bug when logging is enabled.

Related issue: #927

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com