### PR TITLE
Storing byte code size in the byte code header.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -741,16 +741,14 @@ typedef uintptr_t ecma_external_pointer_t;
   */
 typedef struct
 {
-  uint16_t status_flags;            /**< various status flags */
+  uint16_t size;                    /**< real size >> MEM_ALIGNMENT_LOG */
+  uint16_t refs;                    /**< reference counter for the byte code */
+  uint16_t status_flags;            /**< various status flags:
+                                      *    CBC_CODE_FLAGS_FUNCTION flag tells whether
+                                      *    the byte code is function or regular expression.
+                                      *    If function, the other flags must be CBC_CODE_FLAGS...
+                                      *    If regexp, the other flags must be RE_FLAG... */
 } ecma_compiled_code_t;
-
-/**
- * Shift value for byte code reference counting.
- * The last 10 bit of the first uint16_t value
- * of compact byte code or regexp byte code
- * is reserved for reference counting.
- */
-#define ECMA_BYTECODE_REF_SHIFT 6
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -256,7 +256,7 @@ ecma_op_create_regexp_object_from_bytecode (re_compiled_code_t *bytecode_p) /**<
   /* Initialize RegExp object properties */
   re_initialize_props (obj_p,
                        ECMA_GET_NON_NULL_POINTER (ecma_string_t, bytecode_p->pattern_cp),
-                       bytecode_p->flags);
+                       bytecode_p->header.status_flags);
 
   return ecma_make_object_value (obj_p);
 } /* ecma_op_create_regexp_object_from_bytecode */
@@ -1298,7 +1298,7 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
   re_ctx.input_end_p = input_end_p;
 
   /* 1. Read bytecode header and init regexp matcher context. */
-  re_ctx.flags = bc_p->flags;
+  re_ctx.flags = bc_p->header.status_flags;
 
   if (ignore_global)
   {

--- a/jerry-core/jerry-snapshot.h
+++ b/jerry-core/jerry-snapshot.h
@@ -24,27 +24,19 @@
  */
 typedef struct
 {
-  uint32_t last_compiled_code_offset; /**< offset of the last compiled code */
+  /* The size of this structure is recommended to be divisible by
+   * MEM_ALIGNMENT. Otherwise some bytes after the header are wasted. */
+  uint32_t version; /**< version number */
+  uint32_t lit_table_offset; /**< offset of the literal table */
   uint32_t lit_table_size; /**< size of literal table */
-  __extension__ uint32_t is_run_global : 1; /**< flag, indicating whether the snapshot
-                                             *   was dumped as 'Global scope'-mode code (true)
-                                             *   or as eval-mode code (false) */
+  uint32_t is_run_global; /**< flag, indicating whether the snapshot
+                            *   was dumped as 'Global scope'-mode code (true)
+                            *   or as eval-mode code (false) */
 } jerry_snapshot_header_t;
 
 /**
  * Jerry snapshot format version
  */
-#define JERRY_SNAPSHOT_VERSION (3u)
-
-#ifdef JERRY_ENABLE_SNAPSHOT_SAVE
-
-/* Snapshot support functions */
-
-extern bool snapshot_report_byte_code_compilation;
-
-extern void
-snapshot_add_compiled_code (ecma_compiled_code_t *, const uint8_t *, uint32_t);
-
-#endif /* JERRY_ENABLE_SNAPSHOT_SAVE */
+#define JERRY_SNAPSHOT_VERSION (4u)
 
 #endif /* !JERRY_SNAPSHOT_H */

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -200,11 +200,11 @@ extern void __noreturn jerry_fatal (jerry_fatal_code_t);
  */
 
 /**
- * Aligns @a value to @a alignment.
+ * Aligns @a value to @a alignment. @a must be the power of 2.
  *
  * Returns minimum positive value, that divides @a alignment and is more than or equal to @a value
  */
-#define JERRY_ALIGNUP(value, alignment) ((alignment) * (((value) + (alignment) - 1) / (alignment)))
+#define JERRY_ALIGNUP(value, alignment) (((value) + ((alignment) - 1)) & ~((alignment) - 1))
 
 /**
  * min, max

--- a/jerry-core/parser/js/byte-code.h
+++ b/jerry-core/parser/js/byte-code.h
@@ -617,7 +617,7 @@
  */
 typedef struct
 {
-  uint16_t status_flags;            /**< various status flags */
+  ecma_compiled_code_t header;      /**< compiled code header */
   uint8_t stack_limit;              /**< maximum number of values stored on the stack */
   uint8_t argument_end;             /**< number of arguments expected by the function */
   uint8_t register_end;             /**< end position of the register group */
@@ -631,7 +631,7 @@ typedef struct
  */
 typedef struct
 {
-  uint16_t status_flags;            /**< various status flags */
+  ecma_compiled_code_t header;      /**< compiled code header */
   uint16_t stack_limit;             /**< maximum number of values stored on the stack */
   uint16_t argument_end;            /**< number of arguments expected by the function */
   uint16_t register_end;            /**< end position of the register group */

--- a/jerry-core/parser/js/common.c
+++ b/jerry-core/parser/js/common.c
@@ -165,7 +165,7 @@ util_free_literal (lexer_literal_t *literal_p) /**< literal */
   {
     if (!(literal_p->status_flags & LEXER_FLAG_SOURCE_PTR))
     {
-      PARSER_FREE ((uint8_t *) literal_p->u.char_p);
+      mem_heap_free_block_size_stored ((void *) literal_p->u.char_p);
     }
   }
   else if ((literal_p->type == LEXER_FUNCTION_LITERAL)

--- a/jerry-core/parser/js/common.h
+++ b/jerry-core/parser/js/common.h
@@ -47,17 +47,6 @@
 #include "lit-literal.h"
 #include "mem-heap.h"
 
-/* The utilites here are just for compiling purposes, JS
- * engines should have an optimized version for them. */
-
-/* Malloc functions. */
-
-#define PARSER_MALLOC(size) mem_heap_alloc_block_store_size (size)
-#define PARSER_FREE(ptr) mem_heap_free_block_size_stored ((void *) ptr)
-
-#define PARSER_MALLOC_LOCAL(size) mem_heap_alloc_block_store_size (size)
-#define PARSER_FREE_LOCAL(ptr) mem_heap_free_block_size_stored (ptr)
-
 /* UTF character management. Only ASCII characters are
  * supported for simplicity. */
 

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -1203,7 +1203,7 @@ lexer_process_char_literal (parser_context_t *context_p, /**< context */
 
   if (has_escape)
   {
-    literal_p->u.char_p = (uint8_t *) PARSER_MALLOC (length);
+    literal_p->u.char_p = (uint8_t *) mem_heap_alloc_block_store_size (length);
     memcpy ((uint8_t *) literal_p->u.char_p, char_p, length);
   }
   else
@@ -1245,6 +1245,7 @@ lexer_construct_literal_object (parser_context_t *context_p, /**< context */
     {
       destination_start_p = (uint8_t *) parser_malloc_local (context_p, literal_p->length);
       context_p->allocated_buffer_p = destination_start_p;
+      context_p->allocated_buffer_size = literal_p->length;
     }
 
     destination_p = destination_start_p;
@@ -1502,7 +1503,8 @@ lexer_construct_literal_object (parser_context_t *context_p, /**< context */
     JERRY_ASSERT (context_p->allocated_buffer_p == destination_start_p);
 
     context_p->allocated_buffer_p = NULL;
-    parser_free_local (destination_start_p);
+    parser_free_local (destination_start_p,
+                       context_p->allocated_buffer_size);
   }
 
   JERRY_ASSERT (context_p->allocated_buffer_p == NULL);
@@ -1825,15 +1827,6 @@ lexer_construct_regexp_object (parser_context_t *context_p, /**< context */
   {
     parser_raise_error (context_p, PARSER_ERR_INVALID_REGEXP);
   }
-
-#ifdef JERRY_ENABLE_SNAPSHOT_SAVE
-  if (snapshot_report_byte_code_compilation)
-  {
-    snapshot_add_compiled_code ((ecma_compiled_code_t *) re_bytecode_p,
-                                regex_start_p,
-                                length);
-  }
-#endif /* JERRY_ENABLE_SNAPSHOT_SAVE */
 
   literal_p->type = LEXER_REGEXP_LITERAL;
   literal_p->u.bytecode_p = (ecma_compiled_code_t *) re_bytecode_p;

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -236,6 +236,7 @@ typedef struct
   parser_error_t error;                       /**< error code */
   void *allocated_buffer_p;                   /**< dinamically allocated buffer
                                                *   which needs to be freed on error */
+  uint32_t allocated_buffer_size;             /**< size of the dinamically allocated buffer */
 
   /* Parser members. */
   uint32_t status_flags;                      /**< status flags */
@@ -283,9 +284,9 @@ typedef struct
 /* Memory management.
  * Note: throws an error if unsuccessful. */
 void *parser_malloc (parser_context_t *, size_t);
-void parser_free (void *);
+void parser_free (void *, size_t);
 void *parser_malloc_local (parser_context_t *, size_t);
-void parser_free_local (void *);
+void parser_free_local (void *, size_t);
 
 /* Parser byte stream. */
 

--- a/jerry-core/parser/js/js-parser-limits.h
+++ b/jerry-core/parser/js/js-parser-limits.h
@@ -54,7 +54,7 @@
 /* Maximum code size.
  * Limit: 16777215. Recommended: 65535, 16777215. */
 #ifndef PARSER_MAXIMUM_CODE_SIZE
-#define PARSER_MAXIMUM_CODE_SIZE 16777215
+#define PARSER_MAXIMUM_CODE_SIZE (65535 << (MEM_ALIGNMENT_LOG))
 #endif
 
 /* Maximum number of values pushed onto the stack by a function.

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -1285,7 +1285,7 @@ parser_parse_case_statement (parser_context_t *context_p) /**< context */
   parser_stack_iterator_write (&iterator, &switch_statement, sizeof (parser_switch_statement_t));
 
   parser_set_branch_to_current_position (context_p, &branch_p->branch);
-  parser_free (branch_p);
+  parser_free (branch_p, sizeof (parser_branch_node_t));
 } /* parser_parse_case_statement */
 
 /**
@@ -2102,7 +2102,7 @@ parser_free_jumps (parser_stack_iterator_t iterator) /**< iterator position */
         while (branch_list_p != NULL)
         {
           parser_branch_node_t *next_p = branch_list_p->next_p;
-          parser_free (branch_list_p);
+          parser_free (branch_list_p, sizeof (parser_branch_node_t));
           branch_list_p = next_p;
         }
         branch_list_p = loop.branch_list_p;
@@ -2133,7 +2133,7 @@ parser_free_jumps (parser_stack_iterator_t iterator) /**< iterator position */
     while (branch_list_p != NULL)
     {
       parser_branch_node_t *next_p = branch_list_p->next_p;
-      parser_free (branch_list_p);
+      parser_free (branch_list_p, sizeof (parser_branch_node_t));
       branch_list_p = next_p;
     }
   }

--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -619,7 +619,7 @@ parser_set_breaks_to_current_position (parser_context_t *context_p, /**< context
     {
       parser_set_branch_to_current_position (context_p, &current_p->branch);
     }
-    parser_free (current_p);
+    parser_free (current_p, sizeof (parser_branch_node_t));
     current_p = next_p;
   }
 } /* parser_set_breaks_to_current_position */

--- a/jerry-core/parser/regexp/re-bytecode.c
+++ b/jerry-core/parser/regexp/re-bytecode.c
@@ -54,11 +54,11 @@ re_realloc_regexp_bytecode_block (re_bytecode_ctx_t *bc_ctx_p) /**< RegExp bytec
   JERRY_ASSERT (bc_ctx_p->current_p >= bc_ctx_p->block_start_p);
   size_t current_ptr_offset = (size_t) (bc_ctx_p->current_p - bc_ctx_p->block_start_p);
 
-  uint8_t *new_block_start_p = (uint8_t *) mem_heap_alloc_block_store_size (new_block_size);
+  uint8_t *new_block_start_p = (uint8_t *) mem_heap_alloc_block (new_block_size);
   if (bc_ctx_p->current_p)
   {
     memcpy (new_block_start_p, bc_ctx_p->block_start_p, (size_t) (current_ptr_offset));
-    mem_heap_free_block_size_stored (bc_ctx_p->block_start_p);
+    mem_heap_free_block (bc_ctx_p->block_start_p, old_size);
   }
   bc_ctx_p->block_start_p = new_block_start_p;
   bc_ctx_p->block_end_p = new_block_start_p + new_block_size;
@@ -109,10 +109,10 @@ re_bytecode_list_insert (re_bytecode_ctx_t *bc_ctx_p, /**< RegExp bytecode conte
   {
     uint8_t *dest_p = src_p + length;
     uint8_t *tmp_block_start_p;
-    tmp_block_start_p = (uint8_t *) mem_heap_alloc_block_store_size (re_get_bytecode_length (bc_ctx_p) - offset);
+    tmp_block_start_p = (uint8_t *) mem_heap_alloc_block (re_get_bytecode_length (bc_ctx_p) - offset);
     memcpy (tmp_block_start_p, src_p, (size_t) (re_get_bytecode_length (bc_ctx_p) - offset));
     memcpy (dest_p, tmp_block_start_p, (size_t) (re_get_bytecode_length (bc_ctx_p) - offset));
-    mem_heap_free_block_size_stored (tmp_block_start_p);
+    mem_heap_free_block (tmp_block_start_p, re_get_bytecode_length (bc_ctx_p) - offset);
   }
   memcpy (src_p, bytecode_p, length);
 

--- a/jerry-core/parser/regexp/re-bytecode.h
+++ b/jerry-core/parser/regexp/re-bytecode.h
@@ -85,7 +85,7 @@ typedef enum
  */
 typedef struct
 {
-  uint16_t flags;                    /**< RegExp flags */
+  ecma_compiled_code_t header;       /**< compiled code header */
   mem_cpointer_t pattern_cp;         /**< original RegExp pattern */
   uint32_t num_of_captures;          /**< number of capturing brackets */
   uint32_t num_of_non_captures;      /**< number of non capturing brackets */


### PR DESCRIPTION
This reduces the memory consumption, because the new allocator uses less memory if
the size as available when a block is freed. Snapshot generation is also simplified.