### PR TITLE
Initialize ecma gc state on jerry init

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -242,6 +242,9 @@ ecma_gc_init (void)
 {
   ecma_gc_objects_lists[ECMA_GC_COLOR_WHITE_GRAY] = NULL;
   ecma_gc_objects_lists[ECMA_GC_COLOR_BLACK] = NULL;
+  ecma_gc_visited_flip_flag = false;
+  ecma_gc_objects_number = 0;
+  ecma_gc_new_objects_since_last_gc = 0;
 } /* ecma_gc_init */
 
 /**

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -34,6 +34,7 @@
 void
 ecma_init (void)
 {
+  ecma_gc_init ();
   ecma_init_builtins ();
   ecma_lcache_init ();
   ecma_init_environment ();


### PR DESCRIPTION
While trying to run `jerry_init` and `jerry_cleanup` a few times in succession within the same application, I noticed that the memory management code would get very confused.

I narrowed it down to the fact that `ecma_gc_init` is not called anywhere (!!!) and thus that state is stale on the second invocation of the engine.

JerryScript-DCO-1.0-Signed-off-by: François Baldassari francois@pebble.com