### PR TITLE
Check unit tests with vera++ & fix reported issues

### DIFF
--- a/tests/unit/test-api.c
+++ b/tests/unit/test-api.c
@@ -239,10 +239,10 @@ static bool foreach (const jerry_api_string_t *name,
                      const jerry_api_value_t *value, void *user_data)
 {
   char str_buf_p[128];
-  jerry_api_size_t sz = jerry_api_string_to_char_buffer (name, (jerry_api_char_t *)str_buf_p, 128);
+  jerry_api_size_t sz = jerry_api_string_to_char_buffer (name, (jerry_api_char_t *) str_buf_p, 128);
   str_buf_p[sz] = '\0';
 
-  if (!strncmp (str_buf_p, "alpha", (size_t)sz))
+  if (!strncmp (str_buf_p, "alpha", (size_t) sz))
   {
 #if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32
     JERRY_ASSERT (value->type == JERRY_API_DATA_TYPE_FLOAT32);
@@ -252,16 +252,16 @@ static bool foreach (const jerry_api_string_t *name,
     JERRY_ASSERT (value->u.v_float64 == 32.0);
 #endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64 */
   }
-  else if (!strncmp (str_buf_p, "bravo", (size_t)sz))
+  else if (!strncmp (str_buf_p, "bravo", (size_t) sz))
   {
     JERRY_ASSERT (value->type == JERRY_API_DATA_TYPE_BOOLEAN);
     JERRY_ASSERT (value->u.v_bool == false);
   }
-  else if (!strncmp (str_buf_p, "charlie", (size_t)sz))
+  else if (!strncmp (str_buf_p, "charlie", (size_t) sz))
   {
     JERRY_ASSERT (value->type == JERRY_API_DATA_TYPE_OBJECT);
   }
-  else if (!strncmp (str_buf_p, "delta", (size_t)sz))
+  else if (!strncmp (str_buf_p, "delta", (size_t) sz))
   {
 #if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32
     JERRY_ASSERT (value->type == JERRY_API_DATA_TYPE_FLOAT32);
@@ -271,19 +271,19 @@ static bool foreach (const jerry_api_string_t *name,
     JERRY_ASSERT (value->u.v_float64 == 123.45);
 #endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64 */
   }
-  else if (!strncmp (str_buf_p, "echo", (size_t)sz))
+  else if (!strncmp (str_buf_p, "echo", (size_t) sz))
   {
     JERRY_ASSERT (value->type == JERRY_API_DATA_TYPE_STRING);
-    jerry_api_size_t echo_sz = jerry_api_string_to_char_buffer (value->u.v_string, (jerry_api_char_t *)str_buf_p, 128);
+    jerry_api_size_t echo_sz = jerry_api_string_to_char_buffer (value->u.v_string, (jerry_api_char_t *) str_buf_p, 128);
     str_buf_p[echo_sz] = '\0';
-    JERRY_ASSERT (!strncmp (str_buf_p, "foobar", (size_t)echo_sz));
+    JERRY_ASSERT (!strncmp (str_buf_p, "foobar", (size_t) echo_sz));
   }
   else
   {
     JERRY_ASSERT (false);
   }
 
-  JERRY_ASSERT (!strncmp ((const char*)user_data, "user_data", 9));
+  JERRY_ASSERT (!strncmp ((const char *) user_data, "user_data", 9));
   return true;
 } /* foreach */
 
@@ -440,7 +440,7 @@ main (void)
 
   // foreach properties
   jerry_api_get_object_field_value (global_obj_p, (jerry_api_char_t *) "p", &val_p);
-  is_ok = jerry_api_foreach_object_field (val_p.u.v_object, foreach, (void*)"user_data");
+  is_ok = jerry_api_foreach_object_field (val_p.u.v_object, foreach, (void *) "user_data");
   JERRY_ASSERT (is_ok);
 
   // break foreach at third element

--- a/tests/unit/test-heap.c
+++ b/tests/unit/test-heap.c
@@ -85,7 +85,7 @@ main (int __attr_unused___ argc,
     for (uint32_t j = 0; j < test_sub_iters; j++)
     {
       size_t size = (size_t) rand () % test_threshold_block_size;
-      ptrs[j] = (uint8_t*) mem_heap_alloc_block_store_size (size);
+      ptrs[j] = (uint8_t *) mem_heap_alloc_block_store_size (size);
       sizes[j] = size;
 
       JERRY_ASSERT (sizes[j] == 0 || ptrs[j] != NULL);

--- a/tools/check-vera.sh
+++ b/tools/check-vera.sh
@@ -15,10 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-JERRY_CORE_FILES=`find ./jerry-core -name "*.c" -or -name "*.cpp" -or -name "*.h"`
-JERRY_LIBC_FILES=`find ./jerry-libc -name "*.c" -or -name "*.cpp" -or -name "*.h"`
-JERRY_MAIN_FILES=`find . -maxdepth 1 -name "*.c" -or -name "*.cpp" -or -name "*.h"`
+JERRY_CORE_FILES=`find ./jerry-core -name "*.c" -or -name "*.h"`
+JERRY_LIBC_FILES=`find ./jerry-libc -name "*.c" -or -name "*.h"`
+JERRY_MAIN_FILES=`find . -maxdepth 1 -name "*.c" -or -name "*.h"`
+UNIT_TEST_FILES=`find ./tests/unit -name "*.c" -or -name "*.h"`
 
 vera++ -r tools/vera++ -p jerry \
  -e --no-duplicate \
- $JERRY_CORE_FILES $JERRY_LIBC_FILES $JERRY_MAIN_FILES 
+ $JERRY_CORE_FILES $JERRY_LIBC_FILES $JERRY_MAIN_FILES $UNIT_TEST_FILES


### PR DESCRIPTION
Cppcheck has already been used for checking unit test sources
statically but vera++ style-checking of unit tests was left out,
most probably only by mistake. This patch adds unit tests to the
set of style-checked sources and also fixes the stlye issues that
were present in the test code.

(Extra: since the project is pure C now, not trying to collect
*.cpp files anymore.)

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu