### PR TITLE
Unify the naming scheme of all header defines

### DIFF
--- a/jerry-core/ecma/base/ecma-alloc.h
+++ b/jerry-core/ecma/base/ecma-alloc.h
@@ -20,8 +20,8 @@
  * @{
  */
 
-#ifndef JERRY_ECMA_ALLOC_H
-#define  JERRY_ECMA_ALLOC_H
+#ifndef ECMA_ALLOC_H
+#define ECMA_ALLOC_H
 
 #include "ecma-globals.h"
 
@@ -122,7 +122,7 @@ extern ecma_external_pointer_t *ecma_alloc_external_pointer (void);
 extern void ecma_dealloc_external_pointer (ecma_external_pointer_t *);
 
 
-#endif /* JERRY_ECMA_ALLOC_H */
+#endif /* !ECMA_ALLOC_H */
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -20,8 +20,8 @@
  * @{
  */
 
-#ifndef JERRY_ECMA_GLOBALS_H
-#define JERRY_ECMA_GLOBALS_H
+#ifndef ECMA_GLOBALS_H
+#define ECMA_GLOBALS_H
 
 #include "config.h"
 #include "jrt.h"
@@ -756,7 +756,7 @@ typedef struct
  * @}
  */
 
-#endif  /* JERRY_ECMA_GLOBALS_H */
+#endif  /* !ECMA_GLOBALS_H */
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -21,8 +21,8 @@
  * @{
  */
 
-#ifndef JERRY_ECMA_HELPERS_H
-#define JERRY_ECMA_HELPERS_H
+#ifndef ECMA_HELPERS_H
+#define ECMA_HELPERS_H
 
 #include "ecma-globals.h"
 #include "lit-cpointer.h"
@@ -246,7 +246,7 @@ extern ecma_number_t ecma_int32_to_number (int32_t);
 extern ecma_number_t ecma_uint32_to_number (uint32_t);
 extern lit_utf8_size_t ecma_number_to_utf8_string (ecma_number_t, lit_utf8_byte_t *, lit_utf8_size_t);
 
-#endif /* !JERRY_ECMA_HELPERS_H */
+#endif /* !ECMA_HELPERS_H */
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-init-finalize.h
+++ b/jerry-core/ecma/base/ecma-init-finalize.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,4 +33,4 @@ extern void ecma_finalize (void);
  * @}
  */
 
-#endif /* ECMA_INIT_FINALIZE_H */
+#endif /* !ECMA_INIT_FINALIZE_H */

--- a/jerry-core/ecma/base/ecma-lcache.h
+++ b/jerry-core/ecma/base/ecma-lcache.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,4 +34,4 @@ extern void ecma_lcache_invalidate (ecma_object_t *, ecma_string_t *, ecma_prope
  * @}
  */
 
-#endif /* ECMA_LCACHE_H */
+#endif /* !ECMA_LCACHE_H */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef ECMA_OBJECT_PROTOTYPE_H
-#define ECMA_OBJECT_PROTOTYPE_H
+#ifndef ECMA_BUILTIN_HELPERS_H
+#define ECMA_BUILTIN_HELPERS_H
 
 #include "ecma-globals.h"
 
@@ -171,4 +171,4 @@ ecma_builtin_helper_json_create_non_formatted_json (ecma_string_t *, ecma_string
  * @}
  */
 
-#endif /* !ECMA_OBJECT_PROPERTY_H */
+#endif /* !ECMA_BUILTIN_HELPERS_H */

--- a/jerry-core/ecma/operations/ecma-comparison.h
+++ b/jerry-core/ecma/operations/ecma-comparison.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#ifndef JERRY_ECMA_COMPARISON_H
-#define JERRY_ECMA_COMPARISON_H
+#ifndef ECMA_COMPARISON_H
+#define ECMA_COMPARISON_H
 
 #include "ecma-globals.h"
 #include "ecma-helpers.h"
@@ -35,4 +35,4 @@ extern ecma_value_t ecma_op_abstract_relational_compare (ecma_value_t, ecma_valu
  * @}
  */
 
-#endif /* !JERRY_ECMA_COMPARISON_H */
+#endif /* !ECMA_COMPARISON_H */

--- a/jerry-core/ecma/operations/ecma-conversion.h
+++ b/jerry-core/ecma/operations/ecma-conversion.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#ifndef JERRY_ECMA_CONVERSION_H
-#define JERRY_ECMA_CONVERSION_H
+#ifndef ECMA_CONVERSION_H
+#define ECMA_CONVERSION_H
 
 #include "ecma-globals.h"
 #include "ecma-helpers.h"
@@ -53,4 +53,4 @@ extern ecma_value_t ecma_op_to_property_descriptor (ecma_value_t, ecma_property_
  * @}
  */
 
-#endif /* !JERRY_ECMA_CONVERSION_H */
+#endif /* !ECMA_CONVERSION_H */

--- a/jerry-core/ecma/operations/ecma-number-arithmetic.h
+++ b/jerry-core/ecma/operations/ecma-number-arithmetic.h
@@ -1,4 +1,4 @@
-/* Copyright 2014 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#ifndef ECMA_NUMBER_H
-#define ECMA_NUMBER_H
+#ifndef ECMA_NUMBER_ARITHMETIC_H
+#define ECMA_NUMBER_ARITHMETIC_H
 
 #include "ecma-globals.h"
 
@@ -34,4 +34,4 @@ extern ecma_number_t ecma_op_number_remainder (ecma_number_t, ecma_number_t);
  * @}
  */
 
-#endif /* ECMA_NUMBER_H */
+#endif /* !ECMA_NUMBER_ARITHMETIC_H */

--- a/jerry-core/jrt/jrt-bit-fields.h
+++ b/jerry-core/jrt/jrt-bit-fields.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef JERRY_BIT_FIELDS_H
-#define JERRY_BIT_FIELDS_H
+#ifndef JRT_BIT_FIELDS_H
+#define JRT_BIT_FIELDS_H
 
 /**
  * Extract a bit-field.
@@ -42,4 +42,4 @@
 #define JRT_SET_BIT_FIELD_VALUE(type, container, new_bit_field_value, lsb, width) \
   (((container) & ~(((((type) 1) << (width)) - 1) << (lsb))) | (((type) new_bit_field_value) << (lsb)))
 
-#endif /* !JERRY_BIT_FIELDS_H */
+#endif /* !JRT_BIT_FIELDS_H */

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef JERRY_GLOBALS_H
-#define JERRY_GLOBALS_H
+#ifndef JRT_H
+#define JRT_H
 
 #include <stdio.h>
 #include <string.h>
@@ -217,4 +217,4 @@ extern bool jrt_read_from_buffer_by_offset (const uint8_t *, size_t, size_t *, v
 
 extern bool jrt_write_to_buffer_by_offset (uint8_t *, size_t, size_t *, const void *, size_t);
 
-#endif /* !JERRY_GLOBALS_H */
+#endif /* !JRT_H */

--- a/jerry-core/lit/lit-char-helpers.h
+++ b/jerry-core/lit/lit-char-helpers.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,4 +237,4 @@ extern bool lit_char_is_word_char (ecma_char_t);
 ecma_length_t lit_char_to_lower_case (ecma_char_t, ecma_char_t *, ecma_length_t);
 ecma_length_t lit_char_to_upper_case (ecma_char_t, ecma_char_t *, ecma_length_t);
 
-#endif /* LIT_CHAR_HELPERS_H */
+#endif /* !LIT_CHAR_HELPERS_H */

--- a/jerry-core/lit/lit-globals.h
+++ b/jerry-core/lit/lit-globals.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,4 +138,4 @@ typedef uint8_t lit_string_hash_t;
  */
 #define LIT_STRING_HASH_LAST_BYTES_COUNT (2)
 
-#endif /* LIT_GLOBALS_H */
+#endif /* !LIT_GLOBALS_H */

--- a/jerry-core/lit/lit-literal.h
+++ b/jerry-core/lit/lit-literal.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,4 +61,4 @@ extern lit_literal_t lit_literal_get_next (lit_literal_t);
 extern lit_magic_string_id_t lit_magic_literal_get_magic_str_id (lit_literal_t);
 extern lit_magic_string_ex_id_t lit_magic_literal_get_magic_str_ex_id (lit_literal_t);
 
-#endif /* LIT_LITERAL_H */
+#endif /* !LIT_LITERAL_H */

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,4 +64,4 @@ extern bool lit_compare_utf8_string_and_magic_string_ex (const lit_utf8_byte_t *
 
 extern lit_utf8_byte_t *lit_copy_magic_string_to_buffer (lit_magic_string_id_t, lit_utf8_byte_t *, lit_utf8_size_t);
 
-#endif /* LIT_MAGIC_STRINGS_H */
+#endif /* !LIT_MAGIC_STRINGS_H */

--- a/jerry-core/lit/lit-snapshot.h
+++ b/jerry-core/lit/lit-snapshot.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  * Copyright 2015-2016 University of Szeged
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef RCS_SNAPSHOT_H
-#define RCS_SNAPSHOT_H
+#ifndef LIT_SNAPSHOT_H
+#define LIT_SNAPSHOT_H
 
 #include "lit-cpointer.h"
 #include "ecma-globals.h"
@@ -44,4 +44,4 @@ lit_load_literals_from_snapshot (const uint8_t *,
                                  uint32_t *);
 #endif /* JERRY_ENABLE_SNAPSHOT_EXEC */
 
-#endif /* !RCS_SNAPSHOT_H */
+#endif /* !LIT_SNAPSHOT_H */

--- a/jerry-core/lit/lit-strings.h
+++ b/jerry-core/lit/lit-strings.h
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#ifndef LIT_UNICODE_HELPERS_H
-#define LIT_UNICODE_HELPERS_H
+#ifndef LIT_STRINGS_H
+#define LIT_STRINGS_H
 
 #include "jrt.h"
 #include "lit-globals.h"
@@ -191,4 +191,4 @@ void lit_utf8_decr (lit_utf8_byte_t **);
 /* print */
 void lit_put_ecma_char (ecma_char_t);
 
-#endif /* LIT_UNICODE_HELPERS_H */
+#endif /* !LIT_STRINGS_H */

--- a/jerry-core/mem/mem-allocator-internal.h
+++ b/jerry-core/mem/mem-allocator-internal.h
@@ -1,4 +1,4 @@
-/* Copyright 2014 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,4 +30,4 @@ extern void mem_run_try_to_give_memory_back_callbacks (mem_try_give_memory_back_
  * @}
  */
 
-#endif /* MEM_ALLOCATOR_INTERNAL_H */
+#endif /* !MEM_ALLOCATOR_INTERNAL_H */

--- a/jerry-core/mem/mem-allocator.h
+++ b/jerry-core/mem/mem-allocator.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@
 /**
  * Allocator interface
  */
-#ifndef JERRY_MEM_ALLOCATOR_H
-#define JERRY_MEM_ALLOCATOR_H
+#ifndef MEM_ALLOCATOR_H
+#define MEM_ALLOCATOR_H
 
 #include "jrt.h"
 #include "mem-config.h"
@@ -125,7 +125,7 @@ extern void mem_stats_reset_peak (void);
 extern void mem_stats_print (void);
 #endif /* MEM_STATS */
 
-#endif /* !JERRY_MEM_ALLOCATOR_H */
+#endif /* !MEM_ALLOCATOR_H */
 
 /**
  * @}

--- a/jerry-core/mem/mem-config.h
+++ b/jerry-core/mem/mem-config.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,4 +38,4 @@
  */
 #define MEM_ALIGNMENT_LOG   3
 
-#endif /* MEM_CONFIG_H */
+#endif /* !MEM_CONFIG_H */

--- a/jerry-core/mem/mem-heap.h
+++ b/jerry-core/mem/mem-heap.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,8 +24,8 @@
 /**
  * Heap allocator interface
  */
-#ifndef JERRY_MEM_HEAP_H
-#define JERRY_MEM_HEAP_H
+#ifndef MEM_HEAP_H
+#define MEM_HEAP_H
 
 #include "jrt.h"
 
@@ -124,4 +124,4 @@ extern void mem_heap_valgrind_freya_mempool_request (void);
  * @}
  */
 
-#endif /* !JERRY_MEM_HEAP_H */
+#endif /* !MEM_HEAP_H */

--- a/jerry-core/mem/mem-poolman.h
+++ b/jerry-core/mem/mem-poolman.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,8 +25,8 @@
 /**
  * Pool manager interface
  */
-#ifndef JERRY_MEM_POOLMAN_H
-#define JERRY_MEM_POOLMAN_H
+#ifndef MEM_POOLMAN_H
+#define MEM_POOLMAN_H
 
 #include "jrt.h"
 
@@ -65,7 +65,7 @@ extern void mem_pools_get_stats (mem_pools_stats_t *);
 extern void mem_pools_stats_reset_peak (void);
 #endif /* MEM_STATS */
 
-#endif /* JERRY_MEM_POOLMAN_H */
+#endif /* !MEM_POOLMAN_H */
 
 /**
  * @}


### PR DESCRIPTION
There have been several renamings of header files but the
ifndef/define/endif preprocessor directives did not always follow
the file name changes (or perhaps never followed a unified naming
scheme). This patch gets all headers aligned with the style of the
majority.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu