### PR TITLE
Fix terminology of snapshot saving in literals

### DIFF
--- a/jerry-core/jerry-snapshot.h
+++ b/jerry-core/jerry-snapshot.h
@@ -30,7 +30,7 @@ typedef struct
   uint32_t lit_table_offset; /**< offset of the literal table */
   uint32_t lit_table_size; /**< size of literal table */
   uint32_t is_run_global; /**< flag, indicating whether the snapshot
-                            *   was dumped as 'Global scope'-mode code (true)
+                            *   was saved as 'Global scope'-mode code (true)
                             *   or as eval-mode code (false) */
 } jerry_snapshot_header_t;
 

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -2045,7 +2045,7 @@ jerry_parse_and_save_snapshot (const jerry_api_char_t *source_p, /**< script sou
                                size_t source_size, /**< script source size */
                                bool is_for_global, /**< snapshot would be executed as global (true)
                                                     *   or eval (false) */
-                               uint8_t *buffer_p, /**< buffer to dump snapshot to */
+                               uint8_t *buffer_p, /**< buffer to save snapshot to */
                                size_t buffer_size) /**< the buffer's size */
 {
 #ifdef JERRY_ENABLE_SNAPSHOT_SAVE
@@ -2101,7 +2101,7 @@ jerry_parse_and_save_snapshot (const jerry_api_char_t *source_p, /**< script sou
   lit_mem_to_snapshot_id_map_entry_t *lit_map_p = NULL;
   uint32_t literals_num;
 
-  if (!lit_dump_literals_for_snapshot (buffer_p,
+  if (!lit_save_literals_for_snapshot (buffer_p,
                                        buffer_size,
                                        &snapshot_buffer_write_offset,
                                        &lit_map_p,

--- a/jerry-core/lit/lit-snapshot.c
+++ b/jerry-core/lit/lit-snapshot.c
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  * Copyright 2015-2016 University of Szeged
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,14 +22,14 @@
 #ifdef JERRY_ENABLE_SNAPSHOT_SAVE
 
 /**
- * Dump a record to specified snapshot buffer.
+ * Save a record to specified snapshot buffer.
  *
- * @return number of bytes dumped,
- *         or 0 - upon dump failure
+ * @return number of bytes saved,
+ *         or 0 - upon save failure
  */
 static uint32_t
-lit_snapshot_dump (lit_literal_t lit, /**< literal to dump */
-                   uint8_t *buffer_p, /**< buffer to dump to */
+lit_snapshot_save (lit_literal_t lit, /**< literal to save */
+                   uint8_t *buffer_p, /**< buffer to save to */
                    size_t buffer_size, /**< buffer size */
                    size_t *in_out_buffer_offset_p) /**< [in,out] buffer write offset */
 {
@@ -118,23 +118,23 @@ lit_snapshot_dump (lit_literal_t lit, /**< literal to dump */
 
   JERRY_UNREACHABLE ();
   return 0;
-} /* lit_snapshot_dump */
+} /* lit_snapshot_save */
 
 /**
- * Dump literals to specified snapshot buffer.
+ * Save literals to specified snapshot buffer.
  *
- * @return true, if dump was performed successfully (i.e. buffer size is sufficient),
+ * @return true, if save was performed successfully (i.e. buffer size is sufficient),
  *         false - otherwise.
  */
 bool
-lit_dump_literals_for_snapshot (uint8_t *buffer_p, /**< [out] output snapshot buffer */
+lit_save_literals_for_snapshot (uint8_t *buffer_p, /**< [out] output snapshot buffer */
                                 size_t buffer_size, /**< size of the buffer */
                                 size_t *in_out_buffer_offset_p, /**< [in,out] write position in the buffer */
                                 lit_mem_to_snapshot_id_map_entry_t **out_map_p, /**< [out] map from literal identifiers
                                                                                  *        to the literal offsets
                                                                                  *        in snapshot */
                                 uint32_t *out_map_num_p, /**< [out] number of literals */
-                                uint32_t *out_lit_table_size_p) /**< [out] number of bytes, dumped to snapshot buffer */
+                                uint32_t *out_lit_table_size_p) /**< [out] number of bytes, saved to snapshot buffer */
 {
   uint32_t literals_num = lit_count_literals ();
   uint32_t lit_table_size = 0;
@@ -186,7 +186,7 @@ lit_dump_literals_for_snapshot (uint8_t *buffer_p, /**< [out] output snapshot bu
         break;
       }
 
-      uint32_t bytes = lit_snapshot_dump (lit, buffer_p, buffer_size, in_out_buffer_offset_p);
+      uint32_t bytes = lit_snapshot_save (lit, buffer_p, buffer_size, in_out_buffer_offset_p);
 
       if (bytes == 0)
       {
@@ -241,7 +241,7 @@ lit_dump_literals_for_snapshot (uint8_t *buffer_p, /**< [out] output snapshot bu
   *out_map_num_p = literals_num;
   *out_lit_table_size_p = aligned_size;
   return true;
-} /* lit_dump_literals_for_snapshot */
+} /* lit_save_literals_for_snapshot */
 
 #endif /* JERRY_ENABLE_SNAPSHOT_SAVE */
 
@@ -250,7 +250,7 @@ lit_dump_literals_for_snapshot (uint8_t *buffer_p, /**< [out] output snapshot bu
 /**
  * Load literals from snapshot.
  *
- * @return true, if load was performed successfully (i.e. literals dump in the snapshot is consistent),
+ * @return true, if load was performed successfully (i.e. literals saved in the snapshot are consistent),
  *         false - otherwise (i.e. snapshot is incorrect).
  */
 bool

--- a/jerry-core/lit/lit-snapshot.h
+++ b/jerry-core/lit/lit-snapshot.h
@@ -28,7 +28,7 @@ typedef struct
 
 #ifdef JERRY_ENABLE_SNAPSHOT_SAVE
 extern bool
-lit_dump_literals_for_snapshot (uint8_t *,
+lit_save_literals_for_snapshot (uint8_t *,
                                 size_t,
                                 size_t *,
                                 lit_mem_to_snapshot_id_map_entry_t **,

--- a/main-unix.c
+++ b/main-unix.c
@@ -215,9 +215,9 @@ main (int argc,
   const char *exec_snapshot_file_names[JERRY_MAX_COMMAND_LINE_ARGS];
   int exec_snapshots_count = 0;
 
-  bool is_dump_snapshot_mode = false;
-  bool is_dump_snapshot_mode_for_global_or_eval = false;
-  const char *dump_snapshot_file_name_p = NULL;
+  bool is_save_snapshot_mode = false;
+  bool is_save_snapshot_mode_for_global_or_eval = false;
+  const char *save_snapshot_file_name_p = NULL;
 
   bool is_repl_mode = false;
 
@@ -249,18 +249,18 @@ main (int argc,
     {
       flags |= JERRY_FLAG_SHOW_OPCODES;
     }
-    else if (!strcmp ("--dump-snapshot-for-global", argv[i])
-             || !strcmp ("--dump-snapshot-for-eval", argv[i]))
+    else if (!strcmp ("--save-snapshot-for-global", argv[i])
+             || !strcmp ("--save-snapshot-for-eval", argv[i]))
     {
-      is_dump_snapshot_mode = true;
-      is_dump_snapshot_mode_for_global_or_eval = !strcmp ("--dump-snapshot-for-global", argv[i]);
+      is_save_snapshot_mode = true;
+      is_save_snapshot_mode_for_global_or_eval = !strcmp ("--save-snapshot-for-global", argv[i]);
 
       flags |= JERRY_FLAG_PARSE_ONLY;
 
-      if (dump_snapshot_file_name_p == NULL
+      if (save_snapshot_file_name_p == NULL
           && ++i < argc)
       {
-        dump_snapshot_file_name_p = argv[i];
+        save_snapshot_file_name_p = argv[i];
       }
       else
       {
@@ -321,17 +321,17 @@ main (int argc,
     }
   }
 
-  if (is_dump_snapshot_mode)
+  if (is_save_snapshot_mode)
   {
     if (files_counter == 0)
     {
-      JERRY_ERROR_MSG ("--dump-snapshot argument is passed, but no script was specified on command line\n");
+      JERRY_ERROR_MSG ("--save-snapshot argument is passed, but no script was specified on command line\n");
       return JERRY_STANDALONE_EXIT_CODE_FAIL;
     }
 
     if (exec_snapshots_count != 0)
     {
-      JERRY_ERROR_MSG ("--dump-snapshot and --exec-snapshot options can't be passed simultaneously\n");
+      JERRY_ERROR_MSG ("--save-snapshot and --exec-snapshot options can't be passed simultaneously\n");
       return JERRY_STANDALONE_EXIT_CODE_FAIL;
     }
   }
@@ -426,14 +426,14 @@ main (int argc,
 
     if (source_p != NULL)
     {
-      if (is_dump_snapshot_mode)
+      if (is_save_snapshot_mode)
       {
-        static uint8_t snapshot_dump_buffer[ JERRY_BUFFER_SIZE ];
+        static uint8_t snapshot_save_buffer[ JERRY_BUFFER_SIZE ];
 
         size_t snapshot_size = jerry_parse_and_save_snapshot (source_p,
                                                               source_size,
-                                                              is_dump_snapshot_mode_for_global_or_eval,
-                                                              snapshot_dump_buffer,
+                                                              is_save_snapshot_mode_for_global_or_eval,
+                                                              snapshot_save_buffer,
                                                               JERRY_BUFFER_SIZE);
         if (snapshot_size == 0)
         {
@@ -441,8 +441,8 @@ main (int argc,
         }
         else
         {
-          FILE *snapshot_file_p = fopen (dump_snapshot_file_name_p, "w");
-          fwrite (snapshot_dump_buffer, sizeof (uint8_t), snapshot_size, snapshot_file_p);
+          FILE *snapshot_file_p = fopen (save_snapshot_file_name_p, "w");
+          fwrite (snapshot_save_buffer, sizeof (uint8_t), snapshot_size, snapshot_file_p);
           fclose (snapshot_file_p);
         }
       }


### PR DESCRIPTION
In case of literals, snapshot saving is incorrectly named dumping.
Elsewhere in the code, 'dump' functions output debug data (even
literals have a `lit_dump_literals` debug function). To help
distinction and to align terminologies, snapshot saving functions
of literals are also re-named 'save'.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu