### PR TITLE
Remove support for per-instruction memory statistics

### DIFF
--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -1619,16 +1619,14 @@ jerry_init (jerry_flag_t flags) /**< combination of Jerry flags */
 #endif /* !JERRY_ENABLE_LOG */
   }
 
-  if (flags & (JERRY_FLAG_MEM_STATS | JERRY_FLAG_MEM_STATS_PER_OPCODE | JERRY_FLAG_MEM_STATS_SEPARATE))
+  if (flags & (JERRY_FLAG_MEM_STATS | JERRY_FLAG_MEM_STATS_SEPARATE))
   {
 #ifndef MEM_STATS
-    flags &= ~(JERRY_FLAG_MEM_STATS
-               | JERRY_FLAG_MEM_STATS_PER_OPCODE
-               | JERRY_FLAG_MEM_STATS_SEPARATE);
+    flags &= (jerry_flag_t) ~(JERRY_FLAG_MEM_STATS | JERRY_FLAG_MEM_STATS_SEPARATE);
 
     JERRY_WARNING_MSG ("Ignoring memory statistics option because of '!MEM_STATS' build configuration.\n");
 #else /* !MEM_STATS */
-    if (flags & (JERRY_FLAG_MEM_STATS_PER_OPCODE | JERRY_FLAG_MEM_STATS_SEPARATE))
+    if (flags & JERRY_FLAG_MEM_STATS_SEPARATE)
     {
       flags |= JERRY_FLAG_MEM_STATS;
     }
@@ -1735,9 +1733,7 @@ jerry_parse (const jerry_api_char_t *source_p, /**< script source */
   }
 #endif /* MEM_STATS */
 
-  bool is_show_mem_stats_per_instruction = ((jerry_flags & JERRY_FLAG_MEM_STATS_PER_OPCODE) != 0);
-
-  vm_init (bytecode_data_p, is_show_mem_stats_per_instruction);
+  vm_init (bytecode_data_p);
 
   return true;
 } /* jerry_parse */
@@ -2370,7 +2366,7 @@ jerry_exec_snapshot (const void *snapshot_p, /**< snapshot */
 
   if (header_p->is_run_global)
   {
-    vm_init (bytecode_p, false);
+    vm_init (bytecode_p);
 
     ecma_object_t *error_obj_p = NULL;
 

--- a/jerry-core/jerry.h
+++ b/jerry-core/jerry.h
@@ -32,22 +32,20 @@ extern "C"
  * @{
  */
 
-#define JERRY_FLAG_EMPTY                  (0u)      /**< empty flag set */
-#define JERRY_FLAG_SHOW_OPCODES           (1u << 0) /**< dump byte-code to stdout after parse */
-#define JERRY_FLAG_MEM_STATS              (1u << 1) /**< dump memory statistics */
-#define JERRY_FLAG_MEM_STATS_PER_OPCODE   (1u << 2) /**< dump per-instruction memory statistics during execution
-                                                     *   (in the mode full GC is performed after execution of each
-                                                     *   opcode handler) */
-#define JERRY_FLAG_MEM_STATS_SEPARATE     (1u << 3) /**< dump memory statistics and reset peak values after parse */
-#define JERRY_FLAG_PARSE_ONLY             (1u << 4) /**< parse only, prevents script execution (only for testing)
-                                                     *   FIXME: Remove. */
-#define JERRY_FLAG_ENABLE_LOG             (1u << 5) /**< enable logging */
-#define JERRY_FLAG_ABORT_ON_FAIL          (1u << 6) /**< abort instead of exit in case of failure */
-
 /**
  * Jerry flags
  */
-typedef uint32_t jerry_flag_t;
+typedef enum
+{
+  JERRY_FLAG_EMPTY              = (0u),      /**< empty flag set */
+  JERRY_FLAG_SHOW_OPCODES       = (1u << 0), /**< dump byte-code to stdout after parse */
+  JERRY_FLAG_MEM_STATS          = (1u << 1), /**< dump memory statistics */
+  JERRY_FLAG_MEM_STATS_SEPARATE = (1u << 2), /**< dump memory statistics and reset peak values after parse */
+  JERRY_FLAG_PARSE_ONLY         = (1u << 3), /**< parse only, prevents script execution (only for testing)
+                                              *   FIXME: Remove. */
+  JERRY_FLAG_ENABLE_LOG         = (1u << 4), /**< enable logging */
+  JERRY_FLAG_ABORT_ON_FAIL      = (1u << 5), /**< abort instead of exit in case of failure */
+} jerry_flag_t;
 
 /**
  * Error codes

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -141,11 +141,8 @@ vm_op_set_value (ecma_value_t object, /**< base object */
  * Initialize interpreter.
  */
 void
-vm_init (ecma_compiled_code_t *program_p, /**< pointer to byte-code data */
-         bool dump_mem_stats) /**< dump per-instruction memory usage change statistics */
+vm_init (ecma_compiled_code_t *program_p) /**< pointer to byte-code data */
 {
-  JERRY_ASSERT (!dump_mem_stats);
-
   JERRY_ASSERT (__program == NULL);
 
   __program = program_p;

--- a/jerry-core/vm/vm.h
+++ b/jerry-core/vm/vm.h
@@ -192,7 +192,7 @@ typedef enum
   VM_EXEC_CONSTRUCT,             /**< construct a new object */
 } vm_call_operation;
 
-extern void vm_init (ecma_compiled_code_t *, bool);
+extern void vm_init (ecma_compiled_code_t *);
 extern void vm_finalize (void);
 extern jerry_completion_code_t vm_run_global (ecma_object_t **);
 extern ecma_value_t vm_run_eval (ecma_compiled_code_t *, bool);

--- a/main-unix.c
+++ b/main-unix.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,10 +236,6 @@ main (int argc,
     else if (!strcmp ("--mem-stats", argv[i]))
     {
       flags |= JERRY_FLAG_MEM_STATS;
-    }
-    else if (!strcmp ("--mem-stats-per-opcode", argv[i]))
-    {
-      flags |= JERRY_FLAG_MEM_STATS_PER_OPCODE;
     }
     else if (!strcmp ("--mem-stats-separate", argv[i]))
     {

--- a/targets/nuttx-stm32f4/main-nuttx.c
+++ b/targets/nuttx-stm32f4/main-nuttx.c
@@ -185,10 +185,6 @@ int jerryscript_entry (int argc, char *argv[])
     {
       flags |= JERRY_FLAG_MEM_STATS;
     }
-    else if (!strcmp ("--mem-stats-per-opcode", argv[i]))
-    {
-      flags |= JERRY_FLAG_MEM_STATS_PER_OPCODE;
-    }
     else if (!strcmp ("--mem-stats-separate", argv[i]))
     {
       flags |= JERRY_FLAG_MEM_STATS_SEPARATE;


### PR DESCRIPTION
The new CBC interpreter does not support it anymore.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu