### PR TITLE
Add jerry_port_abort API

### DIFF
--- a/jerry-core/jerry-port.c
+++ b/jerry-core/jerry-port.c
@@ -15,6 +15,7 @@
 
 #include "jerry-port.h"
 #include <stdarg.h>
+#include <stdlib.h>
 
 /**
  * Provide log message to filestream implementation for the engine.
@@ -52,3 +53,11 @@ int jerry_port_putchar (int c) /**< character to put */
 {
   return putchar ((unsigned char) c);
 } /* jerry_port_putchar */
+
+/**
+ * Provide abort implementation for the engine
+ */
+void jerry_port_abort (void)
+{
+  abort ();
+} /* jerry_port_abort */

--- a/jerry-core/jerry-port.h
+++ b/jerry-core/jerry-port.h
@@ -35,6 +35,8 @@ int jerry_port_logmsg (FILE *stream, const char *format, ...);
 int jerry_port_errormsg (const char *format, ...);
 int jerry_port_putchar (int c);
 
+void jerry_port_abort (void);
+
 /**
  * @}
  */

--- a/jerry-core/jrt/jrt-fatals.c
+++ b/jerry-core/jrt/jrt-fatals.c
@@ -69,7 +69,7 @@ jerry_fatal (jerry_fatal_code_t code) /**< status code */
       && code != ERR_OUT_OF_MEMORY
       && jerry_is_abort_on_fail ())
   {
-    abort ();
+    jerry_port_abort ();
   }
   else
   {


### PR DESCRIPTION
Calling `abort()` is making assumptions about what the target wants to happen on fatal errors. In fact, I would argue the stdlib definition of `abort` doesn't make much sense on some platforms.

JerryScript-DCO-1.0-Signed-off-by: François Baldassari francois@pebble.com