### PR TITLE
Refactor the printing of memory usage statistics

### DIFF
--- a/jerry-core/mem/mem-allocator.c
+++ b/jerry-core/mem/mem-allocator.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -144,22 +144,7 @@ mem_stats_reset_peak (void)
 void
 mem_stats_print (void)
 {
-  mem_heap_print ();
-
-  mem_pools_stats_t stats;
-  mem_pools_get_stats (&stats);
-
-  printf ("Pools stats:\n");
-  printf ("  Chunk size: %zu\n"
-          "  Pool chunks: %zu\n"
-          "  Peak pool chunks: %zu\n"
-          "  Free chunks: %zu\n"
-          "  Pool reuse ratio: %zu.%04zu\n",
-          MEM_POOL_CHUNK_SIZE,
-          stats.pools_count,
-          stats.peak_pools_count,
-          stats.free_chunks,
-          stats.reused_count / stats.new_alloc_count,
-          stats.reused_count % stats.new_alloc_count * 10000 / stats.new_alloc_count);
+  mem_heap_stats_print ();
+  mem_pools_stats_print ();
 } /* mem_stats_print */
 #endif /* MEM_STATS */

--- a/jerry-core/mem/mem-heap.c
+++ b/jerry-core/mem/mem-heap.c
@@ -607,37 +607,6 @@ mem_is_heap_pointer (const void *pointer) /**< pointer */
 } /* mem_is_heap_pointer */
 #endif /* !JERRY_NDEBUG */
 
-/**
- * Print heap
- */
-void
-mem_heap_print ()
-{
-#ifdef MEM_STATS
-  printf ("Heap stats:\n");
-  printf ("  Heap size = %zu bytes\n"
-          "  Allocated = %zu bytes\n"
-          "  Waste = %zu bytes\n"
-          "  Peak allocated = %zu bytes\n"
-          "  Peak waste = %zu bytes\n"
-          "  Skip-ahead ratio = %zu.%04zu\n"
-          "  Average alloc iteration = %zu.%04zu\n"
-          "  Average free iteration = %zu.%04zu\n",
-          mem_heap_stats.size,
-          mem_heap_stats.allocated_bytes,
-          mem_heap_stats.waste_bytes,
-          mem_heap_stats.peak_allocated_bytes,
-          mem_heap_stats.peak_waste_bytes,
-          mem_heap_stats.skip_count / mem_heap_stats.nonskip_count,
-          mem_heap_stats.skip_count % mem_heap_stats.nonskip_count * 10000 / mem_heap_stats.nonskip_count,
-          mem_heap_stats.alloc_iter_count / mem_heap_stats.alloc_count,
-          mem_heap_stats.alloc_iter_count % mem_heap_stats.alloc_count * 10000 / mem_heap_stats.alloc_count,
-          mem_heap_stats.free_iter_count / mem_heap_stats.free_count,
-          mem_heap_stats.free_iter_count % mem_heap_stats.free_count * 10000 / mem_heap_stats.free_count);
-  printf ("\n");
-#endif /* !MEM_STATS */
-} /* mem_heap_print */
-
 #ifdef MEM_STATS
 /**
  * Get heap memory usage statistics
@@ -645,6 +614,8 @@ mem_heap_print ()
 void
 mem_heap_get_stats (mem_heap_stats_t *out_heap_stats_p) /**< [out] heap stats */
 {
+  JERRY_ASSERT (out_heap_stats_p != NULL);
+
   *out_heap_stats_p = mem_heap_stats;
 } /* mem_heap_get_stats */
 
@@ -657,6 +628,35 @@ mem_heap_stats_reset_peak (void)
   mem_heap_stats.peak_allocated_bytes = mem_heap_stats.allocated_bytes;
   mem_heap_stats.peak_waste_bytes = mem_heap_stats.waste_bytes;
 } /* mem_heap_stats_reset_peak */
+
+/**
+ * Print heap memory usage statistics
+ */
+void
+mem_heap_stats_print (void)
+{
+  printf ("Heap stats:\n"
+          "  Heap size = %zu bytes\n"
+          "  Allocated = %zu bytes\n"
+          "  Waste = %zu bytes\n"
+          "  Peak allocated = %zu bytes\n"
+          "  Peak waste = %zu bytes\n"
+          "  Skip-ahead ratio = %zu.%04zu\n"
+          "  Average alloc iteration = %zu.%04zu\n"
+          "  Average free iteration = %zu.%04zu\n"
+          "\n",
+          mem_heap_stats.size,
+          mem_heap_stats.allocated_bytes,
+          mem_heap_stats.waste_bytes,
+          mem_heap_stats.peak_allocated_bytes,
+          mem_heap_stats.peak_waste_bytes,
+          mem_heap_stats.skip_count / mem_heap_stats.nonskip_count,
+          mem_heap_stats.skip_count % mem_heap_stats.nonskip_count * 10000 / mem_heap_stats.nonskip_count,
+          mem_heap_stats.alloc_iter_count / mem_heap_stats.alloc_count,
+          mem_heap_stats.alloc_iter_count % mem_heap_stats.alloc_count * 10000 / mem_heap_stats.alloc_count,
+          mem_heap_stats.free_iter_count / mem_heap_stats.free_count,
+          mem_heap_stats.free_iter_count % mem_heap_stats.free_count * 10000 / mem_heap_stats.free_count);
+} /* mem_heap_stats_print */
 
 /**
  * Initalize heap memory usage statistics account structure

--- a/jerry-core/mem/mem-heap.h
+++ b/jerry-core/mem/mem-heap.h
@@ -39,7 +39,6 @@ extern void mem_heap_free_block_size_stored (void *);
 extern uintptr_t mem_heap_compress_pointer (const void *);
 extern void *mem_heap_decompress_pointer (uintptr_t);
 extern bool mem_is_heap_pointer (const void *);
-extern void mem_heap_print ();
 
 #ifdef MEM_STATS
 /**

--- a/jerry-core/mem/mem-poolman.c
+++ b/jerry-core/mem/mem-poolman.c
@@ -218,6 +218,26 @@ mem_pools_stats_reset_peak (void)
 } /* mem_pools_stats_reset_peak */
 
 /**
+ * Print pools memory usage statistics
+ */
+void
+mem_pools_stats_print (void)
+{
+  printf ("Pools stats:\n"
+          "  Chunk size: %zu\n"
+          "  Pool chunks: %zu\n"
+          "  Peak pool chunks: %zu\n"
+          "  Free chunks: %zu\n"
+          "  Pool reuse ratio: %zu.%04zu\n",
+          MEM_POOL_CHUNK_SIZE,
+          mem_pools_stats.pools_count,
+          mem_pools_stats.peak_pools_count,
+          mem_pools_stats.free_chunks,
+          mem_pools_stats.reused_count / mem_pools_stats.new_alloc_count,
+          mem_pools_stats.reused_count % mem_pools_stats.new_alloc_count * 10000 / mem_pools_stats.new_alloc_count);
+} /* mem_pools_stats_print */
+
+/**
  * Initalize pools' memory usage statistics account structure
  */
 static void

--- a/jerry-core/mem/mem-poolman.h
+++ b/jerry-core/mem/mem-poolman.h
@@ -63,6 +63,7 @@ typedef struct
 
 extern void mem_pools_get_stats (mem_pools_stats_t *);
 extern void mem_pools_stats_reset_peak (void);
+extern void mem_pools_stats_print (void);
 #endif /* MEM_STATS */
 
 #endif /* !MEM_POOLMAN_H */

--- a/tests/unit/test-heap.c
+++ b/tests/unit/test-heap.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,7 +78,9 @@ main (int __attr_unused___ argc,
 
   mem_register_a_try_give_memory_back_callback (test_heap_give_some_memory_back);
 
-  mem_heap_print ();
+#ifdef MEM_STATS
+  mem_heap_stats_print ();
+#endif /* MEM_STATS */
 
   for (uint32_t i = 0; i < test_iters; i++)
   {
@@ -110,7 +112,9 @@ main (int __attr_unused___ argc,
     }
   }
 
-  mem_heap_print ();
+#ifdef MEM_STATS
+  mem_heap_stats_print ();
+#endif /* MEM_STATS */
 
   return 0;
 } /* main */

--- a/tests/unit/test-poolman.c
+++ b/tests/unit/test-poolman.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
  * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,22 +80,7 @@ main (int __attr_unused___ argc,
   }
 
 #ifdef MEM_STATS
-  mem_pools_stats_t stats;
-  mem_pools_get_stats (&stats);
-
-  printf ("Pools stats:\n");
-  printf (" Chunk size: %u\n"
-          "  Pools: %zu\n"
-          "  Allocated chunks: %zu\n"
-          "  Free chunks: %zu\n"
-          "  Peak pools: %zu\n"
-          "  Peak allocated chunks: %zu\n\n",
-          MEM_POOL_CHUNK_SIZE,
-          stats.pools_count,
-          stats.allocated_chunks,
-          stats.free_chunks,
-          stats.peak_pools_count,
-          stats.peak_allocated_chunks);
+  mem_pools_stats_print ();
 #endif /* MEM_STATS */
 
   mem_finalize (false);


### PR DESCRIPTION
Make the internal heap and pools memory usage statistics APIs more
similar: how the print functions are named, where they are
implemented, and which parts of them are guarded by `MEM_STATS`.
Also, adapt unit tests to the changes.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu