### PR TITLE
Fix `.size longjmp` in the linux port of jerry-libc

### DIFF
--- a/jerry-libc/target/linux/jerry-asm.S
+++ b/jerry-libc/target/linux/jerry-asm.S
@@ -67,4 +67,4 @@ setjmp:
 .type longjmp, %function
 longjmp:
   _LONGJMP
-.size longjmu, . - setjmp
+.size longjmp, . - setjmp


### PR DESCRIPTION
Fixing a typo, which resulted in an undefined (but harmless) symbol
in jerry-asm.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu