### PR TITLE
Fix regexp character classes with \uNNNN and \xNN code points

### DIFF
--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -421,6 +421,7 @@ re_parse_char_class (re_parser_ctx_t *parser_ctx_p, /**< number of classes */
 
         parser_ctx_p->input_curr_p += 2;
         append_char_class (re_ctx_p, code_unit, code_unit);
+        ch = LIT_CHAR_UNDEF;
       }
       else if (ch == LIT_CHAR_LOWERCASE_U)
       {
@@ -433,6 +434,7 @@ re_parse_char_class (re_parser_ctx_t *parser_ctx_p, /**< number of classes */
 
         parser_ctx_p->input_curr_p += 4;
         append_char_class (re_ctx_p, code_unit, code_unit);
+        ch = LIT_CHAR_UNDEF;
       }
       else if (ch == LIT_CHAR_LOWERCASE_D)
       {

--- a/tests/jerry/regression-test-issue-962.js
+++ b/tests/jerry/regression-test-issue-962.js
@@ -1,0 +1,27 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright 2016 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function re_test (pattern, string, expected)
+{
+  assert ((new RegExp(pattern)).exec(string) == expected);
+}
+
+re_test("[\\u0020]", "u", null);
+re_test("[\\u0020]", " ", " ");
+re_test("[\\u0020]", "x", null);
+
+re_test("[\\x20]", "u", null);
+re_test("[\\x20]", " ", " ");
+re_test("[\\x20]", "x", null);


### PR DESCRIPTION
Also adding a regression test covering the issue.

Fixes #962

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu