### PR TITLE
Remove MEM_HEAP_PTR_64 macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,9 +223,6 @@ project (Jerry C ASM)
 
 # Compiler / Linker flags
  set(COMPILE_FLAGS_JERRY "-fno-builtin")
- if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
-   set(COMPILE_FLAGS_JERRY "${COMPILE_FLAGS_JERRY} -DMEM_HEAP_PTR_64")
- endif()
  if(NOT ("${PLATFORM}" STREQUAL "DARWIN"))
   set(LINKER_FLAGS_COMMON "-Wl,-z,noexecstack")
  endif()

--- a/jerry-core/mem/mem-heap.c
+++ b/jerry-core/mem/mem-heap.c
@@ -103,7 +103,7 @@ typedef struct
   uint32_t size; /* Size of region */
 } mem_heap_free_t;
 
-#ifdef MEM_HEAP_PTR_64
+#if UINTPTR_MAX > UINT32_MAX
 #define MEM_HEAP_GET_OFFSET_FROM_ADDR(p) ((uint32_t) ((uint8_t *) (p) - (uint8_t *) mem_heap.area))
 #define MEM_HEAP_GET_ADDR_FROM_OFFSET(u) ((mem_heap_free_t *) &mem_heap.area[u])
 #else

--- a/jerry-core/mem/mem-poolman.c
+++ b/jerry-core/mem/mem-poolman.c
@@ -40,9 +40,6 @@
 typedef struct mem_pools_chunk
 {
   struct mem_pools_chunk *next_p; /* pointer to next pool chunk */
-#ifndef MEM_HEAP_PTR_64
-  uint32_t dummy; /* dummy member for alignment */
-#endif
 } mem_pools_chunk_t;
 
 /**
@@ -107,8 +104,8 @@ static void mem_pools_stat_dealloc (void);
 void
 mem_pools_init (void)
 {
-  JERRY_STATIC_ASSERT (sizeof (mem_pools_chunk_t) == MEM_POOL_CHUNK_SIZE,
-                       size_of_mem_pool_chunk_t_must_be_equal_to_MEM_POOL_CHUNK_SIZE);
+  JERRY_STATIC_ASSERT (sizeof (mem_pools_chunk_t) <= MEM_POOL_CHUNK_SIZE,
+                       size_of_mem_pools_chunk_t_must_be_less_than_or_equal_to_MEM_POOL_CHUNK_SIZE);
 
   mem_free_chunk_p = NULL;
 


### PR DESCRIPTION
MEM_HEAP_PTR_64 is duplicating existing information: stdint.h, which
header is already used by the project, defines various _MAX macros
for upper limits of integer types. The comparison of UINTPTR_MAX and
UINT32_MAX can give the same info as encoded in MEM_HEAP_PTR_64.
The stdint.h-based approach has the benefit that jerry can support
any 64-bit architecture without the need for editing the build
system. (With the existing approach, CMakeLists has to know about
every 64-bit architecture to work properly.)

Thus, removing the extraneous macro from the code.

The patch also changes the mem_pools_chunk_t struct, as it turned
out that the struct does not have to be padded to MEM_POOL_CHUNK_SIZE.
(The padding also depended on MEM_HEAP_PTR_64.) It is enough if the
size of the struct is smaller than (or equal to) MEM_POOL_CHUNK_SIZE.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu