### PR TITLE
Fix compile warnings about always_inline functions in GCC 5.2.0

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -712,7 +712,7 @@ static const uint32_t max_uint32_len = (uint32_t) (sizeof (nums_with_ascending_l
  *
  * @return size in bytes
  */
-static ecma_length_t __attr_always_inline___
+static inline ecma_length_t __attr_always_inline___
 ecma_string_get_number_in_desc_size (const uint32_t uint32_number) /**< number in the string-descriptor */
 {
   ecma_length_t size = 1;
@@ -731,7 +731,7 @@ ecma_string_get_number_in_desc_size (const uint32_t uint32_number) /**< number i
  *
  * @return number of bytes in the buffer
  */
-static lit_utf8_size_t __attr_always_inline___
+static inline lit_utf8_size_t __attr_always_inline___
 ecma_string_get_heap_number_size (mem_cpointer_t number_cp) /**< Compressed pointer to an ecma_number_t */
 {
   const ecma_number_t *num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t, number_cp);

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -94,7 +94,7 @@ ecma_set_value_value_field (ecma_value_t value, /**< ecma value to set field in 
  * @return true - if the value contains implementation-defined empty simple value,
  *         false - otherwise.
  */
-bool __attr_pure___ __attr_always_inline___
+inline bool __attr_pure___ __attr_always_inline___
 ecma_is_value_empty (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
@@ -107,7 +107,7 @@ ecma_is_value_empty (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-undefined simple value,
  *         false - otherwise.
  */
-bool __attr_pure___ __attr_always_inline___
+inline bool __attr_pure___ __attr_always_inline___
 ecma_is_value_undefined (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
@@ -120,7 +120,7 @@ ecma_is_value_undefined (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-null simple value,
  *         false - otherwise.
  */
-bool __attr_pure___ __attr_always_inline___
+inline bool __attr_pure___ __attr_always_inline___
 ecma_is_value_null (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
@@ -133,7 +133,7 @@ ecma_is_value_null (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-true or ecma-false simple values,
  *         false - otherwise.
  */
-bool __attr_pure___ __attr_always_inline___
+inline bool __attr_pure___ __attr_always_inline___
 ecma_is_value_boolean (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
@@ -147,7 +147,7 @@ ecma_is_value_boolean (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-true simple value,
  *         false - otherwise.
  */
-bool __attr_pure___ __attr_always_inline___
+inline bool __attr_pure___ __attr_always_inline___
 ecma_is_value_true (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
@@ -160,7 +160,7 @@ ecma_is_value_true (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-false simple value,
  *         false - otherwise.
  */
-bool __attr_pure___ __attr_always_inline___
+inline bool __attr_pure___ __attr_always_inline___
 ecma_is_value_false (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
@@ -173,7 +173,7 @@ ecma_is_value_false (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-array-hole simple value,
  *         false - otherwise.
  */
-bool __attr_pure___ __attr_always_inline___
+inline bool __attr_pure___ __attr_always_inline___
 ecma_is_value_array_hole (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_SIMPLE
@@ -186,7 +186,7 @@ ecma_is_value_array_hole (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-number value,
  *         false - otherwise.
  */
-bool __attr_pure___ __attr_always_inline___
+inline bool __attr_pure___ __attr_always_inline___
 ecma_is_value_number (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_NUMBER);
@@ -198,7 +198,7 @@ ecma_is_value_number (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-string value,
  *         false - otherwise.
  */
-bool __attr_pure___ __attr_always_inline___
+inline bool __attr_pure___ __attr_always_inline___
 ecma_is_value_string (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_STRING);
@@ -210,7 +210,7 @@ ecma_is_value_string (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains object value,
  *         false - otherwise.
  */
-bool __attr_pure___ __attr_always_inline___
+inline bool __attr_pure___ __attr_always_inline___
 ecma_is_value_object (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_OBJECT);
@@ -222,7 +222,7 @@ ecma_is_value_object (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains an error value,
  *         false - otherwise.
  */
-bool __attr_pure___ __attr_always_inline___
+inline bool __attr_pure___ __attr_always_inline___
 ecma_is_value_error (ecma_value_t value) /**< ecma value */
 {
   return (value & (1u << ECMA_VALUE_ERROR_POS)) != 0;
@@ -246,7 +246,7 @@ ecma_check_value_type_is_spec_defined (ecma_value_t value) /**< ecma value */
 /**
  * Simple value constructor
  */
-ecma_value_t __attr_const___ __attr_always_inline___
+inline ecma_value_t __attr_const___ __attr_always_inline___
 ecma_make_simple_value (const ecma_simple_value_t value) /**< simple value */
 {
   ecma_value_t ret_value = 0;

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -952,7 +952,7 @@ JERRY_STATIC_ASSERT (ECMA_VALUE_SIZE <= 24,
  *
  * @return ecma value
  */
-ecma_value_t __attr_always_inline___
+inline ecma_value_t __attr_always_inline___
 ecma_get_named_data_property_value (const ecma_property_t *prop_p) /**< property */
 {
   JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
@@ -964,7 +964,7 @@ ecma_get_named_data_property_value (const ecma_property_t *prop_p) /**< property
 /**
  * Set value field of named data property
  */
-void __attr_always_inline___
+inline void __attr_always_inline___
 ecma_set_named_data_property_value (ecma_property_t *prop_p, /**< property */
                                     ecma_value_t value) /**< value to set */
 {
@@ -1081,7 +1081,7 @@ ecma_set_named_accessor_property_setter (ecma_object_t *object_p, /**< the prope
  * @return true - property is writable,
  *         false - otherwise.
  */
-bool __attr_always_inline___
+inline bool __attr_always_inline___
 ecma_is_property_writable (ecma_property_t *prop_p) /**< property */
 {
   JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
@@ -1115,7 +1115,7 @@ ecma_set_property_writable_attr (ecma_property_t *prop_p, /**< property */
  * @return true - property is enumerable,
  *         false - otherwise.
  */
-bool __attr_always_inline___
+inline bool __attr_always_inline___
 ecma_is_property_enumerable (ecma_property_t *prop_p) /**< property */
 {
   JERRY_ASSERT (prop_p->flags & (ECMA_PROPERTY_FLAG_NAMEDDATA | ECMA_PROPERTY_FLAG_NAMEDACCESSOR));
@@ -1149,7 +1149,7 @@ ecma_set_property_enumerable_attr (ecma_property_t *prop_p, /**< property */
  * @return true - property is configurable,
  *         false - otherwise.
  */
-bool __attr_always_inline___
+inline bool __attr_always_inline___
 ecma_is_property_configurable (ecma_property_t *prop_p) /**< property */
 {
   JERRY_ASSERT (prop_p->flags & (ECMA_PROPERTY_FLAG_NAMEDDATA | ECMA_PROPERTY_FLAG_NAMEDACCESSOR));
@@ -1182,7 +1182,7 @@ ecma_set_property_configurable_attr (ecma_property_t *prop_p, /**< property */
  *
  * @return true / false
  */
-bool __attr_always_inline___
+inline bool __attr_always_inline___
 ecma_is_property_lcached (ecma_property_t *prop_p) /**< property */
 {
   JERRY_ASSERT (prop_p->flags & (ECMA_PROPERTY_FLAG_NAMEDDATA | ECMA_PROPERTY_FLAG_NAMEDACCESSOR));

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -234,7 +234,7 @@ ecma_lcache_insert (ecma_object_t *object_p, /**< object */
  * @return true - if (object, property name) pair is registered in LCache,
  *         false - probably, not registered.
  */
-bool __attr_always_inline___
+inline bool __attr_always_inline___
 ecma_lcache_lookup (ecma_object_t *object_p, /**< object */
                     const ecma_string_t *prop_name_p, /**< property's name */
                     ecma_property_t **prop_p_p) /**< [out] if return value is true,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -56,7 +56,7 @@
  *
  * @return  time value for day number
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_day (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -83,7 +83,7 @@ ecma_date_day (ecma_number_t time) /**< time value */
  *
  * @return  time value within the day
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_time_within_day (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -102,7 +102,7 @@ ecma_date_time_within_day (ecma_number_t time) /**< time value */
  *
  * @return  number of days
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_days_in_year (ecma_number_t year) /**< year value */
 {
   if (ecma_number_is_nan (year))
@@ -136,7 +136,7 @@ ecma_date_days_in_year (ecma_number_t year) /**< year value */
  *
  * @return  day number of the first day of a year
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_day_from_year (ecma_number_t year) /**< year value */
 {
   if (ecma_number_is_nan (year))
@@ -158,7 +158,7 @@ ecma_date_day_from_year (ecma_number_t year) /**< year value */
  *
  * @return  time value of the start of a year
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_time_from_year (ecma_number_t year) /**< year value */
 {
   if (ecma_number_is_nan (year))
@@ -224,7 +224,7 @@ ecma_date_year_from_time (ecma_number_t time) /**< time value */
  *
  * @return  1 if time within a leap year and otherwise is zero
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_in_leap_year (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -243,7 +243,7 @@ ecma_date_in_leap_year (ecma_number_t time) /**< time value */
  *
  * @return  number of days within year
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_day_within_year (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -428,7 +428,7 @@ ecma_date_date_from_time (ecma_number_t time) /**< time value */
  *
  * @return  weekday number
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_week_day (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -447,7 +447,7 @@ ecma_date_week_day (ecma_number_t time) /**< time value */
  *
  * @return  local time zone adjustment
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_local_tza ()
 {
 #ifdef JERRY_ENABLE_DATE_SYS_CALLS
@@ -475,7 +475,7 @@ ecma_date_local_tza ()
  *
  * @return  daylight saving time adjustment
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_daylight_saving_ta (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -520,7 +520,7 @@ ecma_date_daylight_saving_ta (ecma_number_t time) /**< time value */
  *
  * @return  local time
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_local_time (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -543,7 +543,7 @@ ecma_date_local_time (ecma_number_t time) /**< time value */
  *
  * @return  utc value
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_utc (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -573,7 +573,7 @@ ecma_date_utc (ecma_number_t time) /**< time value */
  *
  * @return  hour value
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_hour_from_time (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -604,7 +604,7 @@ ecma_date_hour_from_time (ecma_number_t time) /**< time value */
  *
  * @return  minute value
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_min_from_time (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -635,7 +635,7 @@ ecma_date_min_from_time (ecma_number_t time) /**< time value */
  *
  * @return  second value
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_sec_from_time (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -666,7 +666,7 @@ ecma_date_sec_from_time (ecma_number_t time) /**< time value */
  *
  * @return  millisecond value
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_ms_from_time (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))
@@ -828,7 +828,7 @@ ecma_date_make_day (ecma_number_t year, /**< year value */
  *
  * @return  date value
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_make_date (ecma_number_t day, /**< day value */
                      ecma_number_t time) /**< time value */
 {
@@ -855,7 +855,7 @@ ecma_date_make_date (ecma_number_t day, /**< day value */
  *
  * @return  number of milliseconds
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_time_clip (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time)
@@ -879,7 +879,7 @@ ecma_date_time_clip (ecma_number_t time) /**< time value */
  *
  * @return  timezone offset
  */
-ecma_number_t __attr_always_inline___
+inline ecma_number_t __attr_always_inline___
 ecma_date_timezone_offset (ecma_number_t time) /**< time value */
 {
   if (ecma_number_is_nan (time))

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -329,7 +329,7 @@ ecma_op_create_regexp_object (ecma_string_t *pattern_p, /**< input pattern */
  *
  * @return ecma_char_t canonicalized character
  */
-ecma_char_t __attr_always_inline___
+inline ecma_char_t __attr_always_inline___
 re_canonicalize (ecma_char_t ch, /**< character */
                  bool is_ignorecase) /**< IgnoreCase flag */
 {

--- a/jerry-core/jrt/jrt.c
+++ b/jerry-core/jrt/jrt.c
@@ -25,7 +25,7 @@
  * @return true, if read was successful, i.e. offset + data_size doesn't exceed buffer size,
  *         false - otherwise.
  */
-bool __attr_always_inline___
+inline bool __attr_always_inline___
 jrt_read_from_buffer_by_offset (const uint8_t *buffer_p, /**< buffer */
                                 size_t buffer_size, /**< size of buffer */
                                 size_t *in_out_buffer_offset_p, /**< [in,out] offset to read from /
@@ -53,7 +53,7 @@ jrt_read_from_buffer_by_offset (const uint8_t *buffer_p, /**< buffer */
  * @return true, if write was successful, i.e. offset + data_size doesn't exceed buffer size,
  *         false - otherwise.
  */
-bool __attr_always_inline___
+inline bool __attr_always_inline___
 jrt_write_to_buffer_by_offset (uint8_t *buffer_p, /**< buffer */
                                size_t buffer_size, /**< size of buffer */
                                size_t *in_out_buffer_offset_p,  /**< [in,out] offset to read from /

--- a/jerry-core/lit/lit-cpointer.c
+++ b/jerry-core/lit/lit-cpointer.c
@@ -22,7 +22,7 @@
  *
  * @return dynamic storage-specific extended compressed pointer
  */
-lit_cpointer_t __attr_pure___ __attr_always_inline___
+inline lit_cpointer_t __attr_pure___ __attr_always_inline___
 lit_cpointer_compress (lit_record_t *pointer) /**< pointer to compress */
 {
   if (pointer == NULL)
@@ -38,7 +38,7 @@ lit_cpointer_compress (lit_record_t *pointer) /**< pointer to compress */
  *
  * @return decompressed pointer
  */
-lit_record_t * __attr_pure___ __attr_always_inline___
+inline lit_record_t * __attr_pure___ __attr_always_inline___
 lit_cpointer_decompress (lit_cpointer_t compressed_pointer) /**< recordset-specific compressed pointer */
 {
   if (compressed_pointer == MEM_CP_NULL)
@@ -54,7 +54,7 @@ lit_cpointer_decompress (lit_cpointer_t compressed_pointer) /**< recordset-speci
  *
  * @return NULL compressed pointer
  */
-lit_cpointer_t __attr_pure___ __attr_always_inline___
+inline lit_cpointer_t __attr_pure___ __attr_always_inline___
 lit_cpointer_null_cp (void)
 {
   return MEM_CP_NULL;

--- a/jerry-core/lit/lit-literal.c
+++ b/jerry-core/lit/lit-literal.c
@@ -211,7 +211,7 @@ lit_find_or_create_literal_from_utf8_string (const lit_utf8_byte_t *str_p, /**< 
  *
  * @return pointer to a newly created record
  */
-lit_literal_t __attr_always_inline___
+inline lit_literal_t __attr_always_inline___
 lit_create_literal_from_num (const ecma_number_t num) /**< number to initialize a new number literal */
 {
   return lit_create_number_literal (num);
@@ -592,7 +592,7 @@ lit_magic_literal_get_magic_str_ex_id (lit_literal_t lit) /**< literal */
   return (lit_magic_string_ex_id_t) rec_p->magic_id;
 } /* lit_magic_literal_get_magic_str_ex_id */
 
-lit_utf8_size_t __attr_always_inline___ __attr_pure___
+inline lit_utf8_size_t __attr_always_inline___ __attr_pure___
 lit_charset_literal_get_size (lit_literal_t lit) /**< literal */
 {
   JERRY_ASSERT (lit->type == LIT_RECORD_TYPE_CHARSET);
@@ -607,7 +607,7 @@ lit_charset_literal_get_size (lit_literal_t lit) /**< literal */
  *
  * @return code units count
  */
-ecma_length_t __attr_always_inline___ __attr_pure___
+inline ecma_length_t __attr_always_inline___ __attr_pure___
 lit_charset_literal_get_length (lit_literal_t lit) /**< literal */
 {
   JERRY_ASSERT (lit->type == LIT_RECORD_TYPE_CHARSET);
@@ -617,7 +617,7 @@ lit_charset_literal_get_length (lit_literal_t lit) /**< literal */
   return (ecma_length_t) rec_p->length;
 } /* lit_charset_literal_get_length */
 
-ecma_number_t __attr_always_inline___ __attr_pure___
+inline ecma_number_t __attr_always_inline___ __attr_pure___
 lit_number_literal_get_number (lit_literal_t lit) /**< literal */
 {
   JERRY_ASSERT (lit->type == LIT_RECORD_TYPE_NUMBER);
@@ -627,7 +627,7 @@ lit_number_literal_get_number (lit_literal_t lit) /**< literal */
   return rec_p->number;
 } /* lit_number_literal_get_number */
 
-lit_utf8_byte_t * __attr_always_inline___ __attr_pure___
+inline lit_utf8_byte_t * __attr_always_inline___ __attr_pure___
 lit_charset_literal_get_charset (lit_literal_t lit) /**< literal */
 {
   JERRY_ASSERT (lit->type == LIT_RECORD_TYPE_CHARSET);

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -699,7 +699,7 @@ lit_utf8_decr (lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
  *
  * @return ecma-string's hash
  */
-lit_string_hash_t __attr_always_inline___
+inline lit_string_hash_t __attr_always_inline___
 lit_utf8_string_hash_combine (lit_string_hash_t hash_basis, /**< hash to be combined with */
                               const lit_utf8_byte_t *utf8_buf_p, /**< characters buffer */
                               lit_utf8_size_t utf8_buf_size) /**< number of characters in the buffer */
@@ -722,7 +722,7 @@ lit_utf8_string_hash_combine (lit_string_hash_t hash_basis, /**< hash to be comb
  *
  * @return ecma-string's hash
  */
-lit_string_hash_t __attr_always_inline___
+inline lit_string_hash_t __attr_always_inline___
 lit_utf8_string_calc_hash (const lit_utf8_byte_t *utf8_buf_p, /**< characters buffer */
                            lit_utf8_size_t utf8_buf_size) /**< number of characters in the buffer */
 {
@@ -763,7 +763,7 @@ lit_utf8_string_code_unit_at (const lit_utf8_byte_t *utf8_buf_p, /**< utf-8 stri
  *
  * @return number of bytes occupied in CESU-8
  */
-lit_utf8_size_t __attr_always_inline___
+inline lit_utf8_size_t __attr_always_inline___
 lit_get_unicode_char_size_by_utf8_first_byte (const lit_utf8_byte_t first_byte) /**< buffer with characters */
 {
   if ((first_byte & LIT_UTF8_1_BYTE_MASK) == LIT_UTF8_1_BYTE_MARKER)

--- a/jerry-core/mem/mem-heap.c
+++ b/jerry-core/mem/mem-heap.c
@@ -115,7 +115,7 @@ typedef struct
 /**
  * Get end of region
  */
-static mem_heap_free_t *  __attr_always_inline___ __attr_pure___
+static inline mem_heap_free_t *  __attr_always_inline___ __attr_pure___
 mem_heap_get_region_end (mem_heap_free_t *curr_p) /**< current region */
 {
   return (mem_heap_free_t *)((uint8_t *) curr_p + curr_p->size);
@@ -413,7 +413,7 @@ mem_heap_alloc_block (const size_t size)
  *
  * Note: block will only be aligned to 4 bytes.
  */
-void * __attr_always_inline___
+inline void * __attr_always_inline___
 mem_heap_alloc_block_store_size (size_t size) /**< required size */
 {
   if (unlikely (size == 0))
@@ -537,7 +537,7 @@ mem_heap_free_block (void *ptr, /**< pointer to beginning of data space of the b
 /**
  * Free block with stored size
  */
-void __attr_always_inline___
+inline void __attr_always_inline___
 mem_heap_free_block_size_stored (void *ptr) /**< pointer to the memory block */
 {
   mem_heap_free_t *const original_p = ((mem_heap_free_t *) ptr) - 1;

--- a/jerry-core/mem/mem-poolman.c
+++ b/jerry-core/mem/mem-poolman.c
@@ -129,7 +129,7 @@ mem_pools_finalize (void)
  * @return pointer to allocated chunk, if allocation was successful,
  *         or NULL - if not enough memory.
  */
-void * __attribute__((hot)) __attr_always_inline___
+inline void * __attribute__((hot)) __attr_always_inline___
 mem_pools_alloc (void)
 {
 #ifdef MEM_GC_BEFORE_EACH_ALLOC

--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -68,7 +68,7 @@ re_hex_lookup (re_parser_ctx_t *parser_ctx_p, /**< RegExp parser context */
  * @return true, if non-greedy character found
  *         false, otherwise
  */
-static bool __attr_always_inline___
+static inline bool __attr_always_inline___
 re_parse_non_greedy_char (re_parser_ctx_t *parser_ctx_p) /**< RegExp parser context */
 {
   if (parser_ctx_p->input_curr_p < parser_ctx_p->input_end_p

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -304,7 +304,7 @@ vm_construct_literal_object (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
  * @return true, if the implicit 'this' value is updated,
  *         false - otherwise.
  */
-static bool __attr_always_inline___
+static inline bool __attr_always_inline___
 vm_get_implicit_this_value (ecma_value_t *this_value_p) /**< [in,out] this value */
 {
   if (ecma_is_value_object (*this_value_p))


### PR DESCRIPTION
The warning is "always_inline function might not be inlinable", fixed by
adding inline keyword. See:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55830

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>