### PR TITLE
Introduce ECMA_STRING_TO_UTF8_STRING and ECMA_FINALIZE_UTF8_STRING

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -355,7 +355,7 @@ ecma_utf8_string_to_number (const lit_utf8_byte_t *str_p, /**< utf-8 string */
     return ECMA_NUMBER_ZERO;
   }
 
-  lit_utf8_byte_t *str_curr_p = (lit_utf8_byte_t *) str_p;
+  const lit_utf8_byte_t *str_curr_p = str_p;
   const lit_utf8_byte_t *str_end_p = str_p + str_size;
   ecma_char_t code_unit;
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -205,14 +205,10 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
 
   ecma_string_t *date_str_p = ecma_get_string_from_value (date_str_value);
 
-  lit_utf8_size_t date_str_size = ecma_string_get_size (date_str_p);
-  MEM_DEFINE_LOCAL_ARRAY (date_start_p, date_str_size, lit_utf8_byte_t);
+  ECMA_STRING_TO_UTF8_STRING (date_str_p, date_start_p, date_start_size);
 
-  lit_utf8_size_t sz = ecma_string_to_utf8_string (date_str_p, date_start_p, date_str_size);
-  JERRY_ASSERT (sz == date_str_size);
-
-  lit_utf8_byte_t *date_str_curr_p = date_start_p;
-  const lit_utf8_byte_t *date_str_end_p = date_start_p + date_str_size;
+  lit_utf8_byte_t *date_str_curr_p = (lit_utf8_byte_t *) date_start_p;
+  const lit_utf8_byte_t *date_str_end_p = date_start_p + date_start_size;
 
   /* 1. read year */
   ecma_number_t year = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 4);
@@ -396,7 +392,7 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
 
   ret_value = ecma_make_number_value (date_num_p);
 
-  MEM_FINALIZE_LOCAL_ARRAY (date_start_p);
+  ECMA_FINALIZE_UTF8_STRING (date_start_p, date_start_size);
   ECMA_FINALIZE (date_str_value);
 
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -53,7 +53,7 @@
  * @return NaN if cannot read from string, ToNumber() otherwise
  */
 static ecma_number_t
-ecma_date_parse_date_chars (lit_utf8_byte_t **str_p, /**< pointer to the cesu8 string */
+ecma_date_parse_date_chars (const lit_utf8_byte_t **str_p, /**< pointer to the cesu8 string */
                             const lit_utf8_byte_t *str_end_p, /**< pointer to the end of the string */
                             uint32_t num_of_chars) /**< number of characters to read and convert */
 {
@@ -207,7 +207,7 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
 
   ECMA_STRING_TO_UTF8_STRING (date_str_p, date_start_p, date_start_size);
 
-  lit_utf8_byte_t *date_str_curr_p = (lit_utf8_byte_t *) date_start_p;
+  const lit_utf8_byte_t *date_str_curr_p = date_start_p;
   const lit_utf8_byte_t *date_str_end_p = date_start_p + date_start_size;
 
   /* 1. read year */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -203,23 +203,17 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
   ECMA_TRY_CATCH (string_var, ecma_op_to_string (string), ret_value);
 
   ecma_string_t *number_str_p = ecma_get_string_from_value (string_var);
-  lit_utf8_size_t str_size = ecma_string_get_size (number_str_p);
+  ECMA_STRING_TO_UTF8_STRING (number_str_p, string_buff, string_buff_size);
 
-  if (str_size > 0)
+  if (string_buff_size > 0)
   {
-    MEM_DEFINE_LOCAL_ARRAY (string_buff, str_size, lit_utf8_byte_t);
-
-    lit_utf8_size_t bytes_copied = ecma_string_to_utf8_string (number_str_p,
-                                                               string_buff,
-                                                               str_size);
-    JERRY_ASSERT (bytes_copied == str_size);
-    lit_utf8_byte_t *string_curr_p = string_buff;
-    lit_utf8_byte_t *string_end_p = string_buff + str_size;
+    lit_utf8_byte_t *string_curr_p = (lit_utf8_byte_t *) string_buff;
+    const lit_utf8_byte_t *string_end_p = string_buff + string_buff_size;
 
     /* 2. Remove leading whitespace. */
 
-    lit_utf8_byte_t *start_p = string_end_p;
-    lit_utf8_byte_t *end_p = string_end_p;
+    lit_utf8_byte_t *start_p = (lit_utf8_byte_t *) string_end_p;
+    lit_utf8_byte_t *end_p = start_p;
 
     while (string_curr_p < string_end_p)
     {
@@ -396,7 +390,6 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
       ret_value = ecma_make_number_value (ret_num_p);
     }
 
-    MEM_FINALIZE_LOCAL_ARRAY (string_buff);
   }
   else
   {
@@ -405,6 +398,7 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
     ret_value = ecma_make_number_value (ret_num_p);
   }
 
+  ECMA_FINALIZE_UTF8_STRING (string_buff, string_buff_size);
   ECMA_FINALIZE (string_var);
   return ret_value;
 } /* ecma_builtin_global_object_parse_int */
@@ -428,22 +422,15 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
   ECMA_TRY_CATCH (string_var, ecma_op_to_string (string), ret_value);
 
   ecma_string_t *number_str_p = ecma_get_string_from_value (string_var);
-  lit_utf8_size_t str_size = ecma_string_get_size (number_str_p);
+  ECMA_STRING_TO_UTF8_STRING (number_str_p, string_buff, string_buff_size);
 
-  if (str_size > 0)
+  if (string_buff_size > 0)
   {
-    MEM_DEFINE_LOCAL_ARRAY (string_buff, str_size, lit_utf8_byte_t);
+    lit_utf8_byte_t *str_curr_p = (lit_utf8_byte_t *) string_buff;
+    const lit_utf8_byte_t *str_end_p = string_buff + string_buff_size;
 
-    lit_utf8_size_t bytes_copied = ecma_string_to_utf8_string (number_str_p,
-                                                               string_buff,
-                                                               str_size);
-    JERRY_ASSERT (bytes_copied == str_size);
-
-    lit_utf8_byte_t *str_curr_p = string_buff;
-    lit_utf8_byte_t *str_end_p = string_buff + str_size;
-
-    lit_utf8_byte_t *start_p = str_end_p;
-    lit_utf8_byte_t *end_p = str_end_p;
+    lit_utf8_byte_t *start_p = (lit_utf8_byte_t *) str_end_p;
+    lit_utf8_byte_t *end_p = (lit_utf8_byte_t *) str_end_p;
 
     /* 2. Find first non whitespace char and set starting position. */
     while (str_curr_p < str_end_p)
@@ -626,7 +613,6 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
       *ret_num_p = ecma_number_make_nan ();
       ret_value = ecma_make_number_value (ret_num_p);
     }
-    MEM_FINALIZE_LOCAL_ARRAY (string_buff);
   }
   /* String length is zero. */
   else
@@ -636,6 +622,7 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
     ret_value = ecma_make_number_value (ret_num_p);
   }
 
+  ECMA_FINALIZE_UTF8_STRING (string_buff, string_buff_size);
   ECMA_FINALIZE (string_var);
 
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -88,7 +88,7 @@ ecma_builtin_global_object_print (ecma_value_t this_arg __attr_unused___, /**< t
     lit_utf8_size_t actual_sz = ecma_string_to_utf8_string (str_p, utf8_str_p, utf8_str_size);
     JERRY_ASSERT (actual_sz == utf8_str_size);
 
-    lit_utf8_byte_t *utf8_str_curr_p = utf8_str_p;
+    const lit_utf8_byte_t *utf8_str_curr_p = utf8_str_p;
     const lit_utf8_byte_t *utf8_str_end_p = utf8_str_p + utf8_str_size;
 
     while (utf8_str_curr_p < utf8_str_end_p)
@@ -207,13 +207,13 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
 
   if (string_buff_size > 0)
   {
-    lit_utf8_byte_t *string_curr_p = (lit_utf8_byte_t *) string_buff;
+    const lit_utf8_byte_t *string_curr_p = (lit_utf8_byte_t *) string_buff;
     const lit_utf8_byte_t *string_end_p = string_buff + string_buff_size;
 
     /* 2. Remove leading whitespace. */
 
-    lit_utf8_byte_t *start_p = (lit_utf8_byte_t *) string_end_p;
-    lit_utf8_byte_t *end_p = start_p;
+    const lit_utf8_byte_t *start_p = string_end_p;
+    const lit_utf8_byte_t *end_p = start_p;
 
     while (string_curr_p < string_end_p)
     {
@@ -426,11 +426,11 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
 
   if (string_buff_size > 0)
   {
-    lit_utf8_byte_t *str_curr_p = (lit_utf8_byte_t *) string_buff;
+    const lit_utf8_byte_t *str_curr_p = string_buff;
     const lit_utf8_byte_t *str_end_p = string_buff + string_buff_size;
 
-    lit_utf8_byte_t *start_p = (lit_utf8_byte_t *) str_end_p;
-    lit_utf8_byte_t *end_p = (lit_utf8_byte_t *) str_end_p;
+    const lit_utf8_byte_t *start_p = str_end_p;
+    const lit_utf8_byte_t *end_p = str_end_p;
 
     /* 2. Find first non whitespace char and set starting position. */
     while (str_curr_p < str_end_p)
@@ -1263,8 +1263,8 @@ ecma_builtin_global_object_escape (ecma_value_t this_arg __attr_unused___, /**< 
    * The escape routine has two major phases: first we compute
    * the length of the output, then we encode the input.
    */
-  lit_utf8_byte_t *input_curr_p = input_start_p;
-  lit_utf8_byte_t *input_end_p = input_start_p + input_size;
+  const lit_utf8_byte_t *input_curr_p = input_start_p;
+  const lit_utf8_byte_t *input_end_p = input_start_p + input_size;
   lit_utf8_size_t output_length = 0;
 
   while (input_curr_p < input_end_p)
@@ -1377,8 +1377,8 @@ ecma_builtin_global_object_unescape (ecma_value_t this_arg __attr_unused___, /**
   lit_utf8_size_t sz = ecma_string_to_utf8_string (input_string_p, input_start_p, input_size);
   JERRY_ASSERT (sz == input_size);
 
-  lit_utf8_byte_t *input_curr_p = input_start_p;
-  lit_utf8_byte_t *input_end_p = input_start_p + input_size;
+  const lit_utf8_byte_t *input_curr_p = input_start_p;
+  const lit_utf8_byte_t *input_end_p = input_start_p + input_size;
   /* 4. */
   /* The length of input string is always greater than output string
    * so we re-use the input string buffer.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -565,12 +565,8 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index
                                        ecma_length_t *ret_index_p) /**< position found in original string */
 {
   bool match_found = false;
-
   const ecma_length_t original_len = ecma_string_get_length (original_str_p);
-  const lit_utf8_size_t original_size = ecma_string_get_size (original_str_p);
-
   const ecma_length_t search_len = ecma_string_get_length (search_str_p);
-  const lit_utf8_size_t search_size = ecma_string_get_size (search_str_p);
 
   if (search_len <= original_len)
   {
@@ -582,34 +578,20 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index
     else
     {
       /* create utf8 string from original string and advance to position */
-      MEM_DEFINE_LOCAL_ARRAY (original_str_utf8_p,
-                              original_size,
-                              lit_utf8_byte_t);
-
-      lit_utf8_size_t sz = ecma_string_to_utf8_string (original_str_p,
-                                                       original_str_utf8_p,
-                                                       original_size);
-      JERRY_ASSERT (sz == original_size);
+      ECMA_STRING_TO_UTF8_STRING (original_str_p, original_str_utf8_p, original_str_size);
 
       ecma_length_t index = start_pos;
 
-      lit_utf8_byte_t *original_str_curr_p = original_str_utf8_p;
+      lit_utf8_byte_t *original_str_curr_p = (lit_utf8_byte_t *) original_str_utf8_p;
       for (ecma_length_t idx = 0; idx < index; idx++)
       {
         lit_utf8_incr (&original_str_curr_p);
       }
 
       /* create utf8 string from search string */
-      MEM_DEFINE_LOCAL_ARRAY (search_str_utf8_p,
-                              search_size,
-                              lit_utf8_byte_t);
+      ECMA_STRING_TO_UTF8_STRING (search_str_p, search_str_utf8_p, search_str_size);
 
-      lit_utf8_size_t sz = ecma_string_to_utf8_string (search_str_p,
-                                                       search_str_utf8_p,
-                                                       search_size);
-      JERRY_ASSERT (sz == search_size);
-
-      lit_utf8_byte_t *search_str_curr_p = search_str_utf8_p;
+      lit_utf8_byte_t *search_str_curr_p = (lit_utf8_byte_t *) search_str_utf8_p;
 
       /* iterate original string and try to match at each position */
       bool searching = true;
@@ -667,8 +649,8 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index
         }
       }
 
-      MEM_FINALIZE_LOCAL_ARRAY (search_str_utf8_p);
-      MEM_FINALIZE_LOCAL_ARRAY (original_str_utf8_p);
+      ECMA_FINALIZE_UTF8_STRING (search_str_utf8_p, search_str_size);
+      ECMA_FINALIZE_UTF8_STRING (original_str_utf8_p, original_str_size);
     }
   }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -582,7 +582,7 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index
 
       ecma_length_t index = start_pos;
 
-      lit_utf8_byte_t *original_str_curr_p = (lit_utf8_byte_t *) original_str_utf8_p;
+      const lit_utf8_byte_t *original_str_curr_p = original_str_utf8_p;
       for (ecma_length_t idx = 0; idx < index; idx++)
       {
         lit_utf8_incr (&original_str_curr_p);
@@ -591,7 +591,7 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index
       /* create utf8 string from search string */
       ECMA_STRING_TO_UTF8_STRING (search_str_p, search_str_utf8_p, search_str_size);
 
-      lit_utf8_byte_t *search_str_curr_p = (lit_utf8_byte_t *) search_str_utf8_p;
+      const lit_utf8_byte_t *search_str_curr_p = search_str_utf8_p;
 
       /* iterate original string and try to match at each position */
       bool searching = true;
@@ -600,13 +600,13 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index
       {
         /* match as long as possible */
         ecma_length_t match_len = 0;
-        lit_utf8_byte_t *stored_original_str_curr_p = original_str_curr_p;
+        const lit_utf8_byte_t *stored_original_str_curr_p = original_str_curr_p;
 
         if (match_len < search_len &&
             index + match_len < original_len &&
             lit_utf8_read_next (&original_str_curr_p) == first_char)
         {
-          lit_utf8_byte_t *nested_search_str_curr_p = search_str_curr_p;
+          const lit_utf8_byte_t *nested_search_str_curr_p = search_str_curr_p;
           match_len++;
 
           while (match_len < search_len &&

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1059,7 +1059,7 @@ ecma_builtin_json_quote (ecma_string_t *string_p) /**< string that should be quo
 
   ECMA_STRING_TO_UTF8_STRING (string_p, string_buff, string_buff_size);
 
-  lit_utf8_byte_t *str_p = (lit_utf8_byte_t *) string_buff;
+  const lit_utf8_byte_t *str_p = string_buff;
   const lit_utf8_byte_t *str_end_p = string_buff + string_buff_size;
 
   while (str_p < str_end_p)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1198,23 +1198,15 @@ ecma_builtin_string_prototype_object_replace_main (ecma_builtin_replace_search_c
                     ret_value);
 
     ecma_string_t *replace_string_p = ecma_get_string_from_value (to_string_replace_val);
-    lit_utf8_size_t replace_size = ecma_string_get_size (replace_string_p);
 
-    MEM_DEFINE_LOCAL_ARRAY (replace_start_p,
-                            replace_size,
-                            lit_utf8_byte_t);
-
-    lit_utf8_size_t sz = ecma_string_to_utf8_string (replace_string_p,
-                                                     replace_start_p,
-                                                     replace_size);
-    JERRY_ASSERT (sz == replace_size);
+    ECMA_STRING_TO_UTF8_STRING (replace_string_p, replace_start_p, replace_start_size);
 
     context_p->replace_string_p = replace_string_p;
-    context_p->replace_str_curr_p = replace_start_p;
+    context_p->replace_str_curr_p = (lit_utf8_byte_t *) replace_start_p;
 
     ret_value = ecma_builtin_string_prototype_object_replace_loop (context_p);
 
-    MEM_FINALIZE_LOCAL_ARRAY (replace_start_p);
+    ECMA_FINALIZE_UTF8_STRING (replace_start_p, replace_start_size);
     ECMA_FINALIZE (to_string_replace_val);
   }
 
@@ -2073,16 +2065,8 @@ ecma_builtin_string_prototype_object_conversion_helper (ecma_value_t this_arg, /
 
   /* 3. */
   ecma_string_t *input_string_p = ecma_get_string_from_value (to_string_val);
-  lit_utf8_size_t input_size = ecma_string_get_size (input_string_p);
 
-  MEM_DEFINE_LOCAL_ARRAY (input_start_p,
-                          input_size,
-                          lit_utf8_byte_t);
-
-  lit_utf8_size_t sz = ecma_string_to_utf8_string (input_string_p,
-                                                   input_start_p,
-                                                   input_size);
-  JERRY_ASSERT (sz == input_size);
+  ECMA_STRING_TO_UTF8_STRING (input_string_p, input_start_p, input_start_size);
 
   /*
    * The URI encoding has two major phases: first we compute
@@ -2090,8 +2074,8 @@ ecma_builtin_string_prototype_object_conversion_helper (ecma_value_t this_arg, /
    */
 
   lit_utf8_size_t output_length = 0;
-  lit_utf8_byte_t *input_str_curr_p = input_start_p;
-  const lit_utf8_byte_t *input_str_end_p = input_start_p + input_size;
+  lit_utf8_byte_t *input_str_curr_p = (lit_utf8_byte_t *) input_start_p;
+  const lit_utf8_byte_t *input_str_end_p = input_start_p + input_start_size;
 
   while (input_str_curr_p < input_str_end_p)
   {
@@ -2130,7 +2114,7 @@ ecma_builtin_string_prototype_object_conversion_helper (ecma_value_t this_arg, /
   lit_utf8_byte_t *output_char_p = output_start_p;
 
   /* Encoding the output. */
-  input_str_curr_p = input_start_p;
+  input_str_curr_p = (lit_utf8_byte_t *) input_start_p;
 
   while (input_str_curr_p < input_str_end_p)
   {
@@ -2166,7 +2150,7 @@ ecma_builtin_string_prototype_object_conversion_helper (ecma_value_t this_arg, /
   ret_value = ecma_make_string_value (output_string_p);
 
   MEM_FINALIZE_LOCAL_ARRAY (output_start_p);
-  MEM_FINALIZE_LOCAL_ARRAY (input_start_p);
+  ECMA_FINALIZE_UTF8_STRING (input_start_p, input_start_size);
 
   ECMA_FINALIZE (to_string_val);
   ECMA_FINALIZE (check_coercible_val);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -2074,7 +2074,7 @@ ecma_builtin_string_prototype_object_conversion_helper (ecma_value_t this_arg, /
    */
 
   lit_utf8_size_t output_length = 0;
-  lit_utf8_byte_t *input_str_curr_p = (lit_utf8_byte_t *) input_start_p;
+  const lit_utf8_byte_t *input_str_curr_p = input_start_p;
   const lit_utf8_byte_t *input_str_end_p = input_start_p + input_start_size;
 
   while (input_str_curr_p < input_str_end_p)
@@ -2114,7 +2114,7 @@ ecma_builtin_string_prototype_object_conversion_helper (ecma_value_t this_arg, /
   lit_utf8_byte_t *output_char_p = output_start_p;
 
   /* Encoding the output. */
-  input_str_curr_p = (lit_utf8_byte_t *) input_start_p;
+  input_str_curr_p = input_start_p;
 
   while (input_str_curr_p < input_str_end_p)
   {

--- a/jerry-core/ecma/operations/ecma-eval.c
+++ b/jerry-core/ecma/operations/ecma-eval.c
@@ -1,4 +1,5 @@
 /* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-eval.c
+++ b/jerry-core/ecma/operations/ecma-eval.c
@@ -52,21 +52,14 @@ ecma_op_eval (ecma_string_t *code_p, /**< code string */
   }
   else
   {
-    MEM_DEFINE_LOCAL_ARRAY (code_utf8_buffer_p,
-                            chars_num,
-                            lit_utf8_byte_t);
-
-    lit_utf8_size_t buffer_size_req = ecma_string_to_utf8_string (code_p,
-                                                                  code_utf8_buffer_p,
-                                                                  chars_num);
-    JERRY_ASSERT (buffer_size_req == chars_num);
+    ECMA_STRING_TO_UTF8_STRING (code_p, code_utf8_buffer_p, code_utf8_buffer_size);
 
     ret_value = ecma_op_eval_chars_buffer ((jerry_api_char_t *) code_utf8_buffer_p,
                                            chars_num,
                                            is_direct,
                                            is_called_from_strict_mode_code);
 
-    MEM_FINALIZE_LOCAL_ARRAY (code_utf8_buffer_p);
+    ECMA_FINALIZE_UTF8_STRING (code_utf8_buffer_p, code_utf8_buffer_size);
   }
 
   return ret_value;

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -380,13 +380,13 @@ re_canonicalize (ecma_char_t ch, /**< character */
 static ecma_value_t
 re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
                  uint8_t *bc_p, /**< pointer to the current RegExp bytecode */
-                 lit_utf8_byte_t *str_p, /**< input string pointer */
-                 lit_utf8_byte_t **out_str_p) /**< [out] matching substring iterator */
+                 const lit_utf8_byte_t *str_p, /**< input string pointer */
+                 const lit_utf8_byte_t **out_str_p) /**< [out] matching substring iterator */
 {
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   re_opcode_t op;
 
-  lit_utf8_byte_t *str_curr_p = str_p;
+  const lit_utf8_byte_t *str_curr_p = str_p;
 
   while ((op = re_get_opcode (&bc_p)))
   {
@@ -541,7 +541,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_LOOKAHEAD_NEG:
       {
         ecma_value_t match_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
-        lit_utf8_byte_t *sub_str_p = NULL;
+        const lit_utf8_byte_t *sub_str_p = NULL;
 
         uint32_t array_size = re_ctx_p->num_of_captures + re_ctx_p->num_of_non_captures;
         MEM_DEFINE_LOCAL_ARRAY (saved_bck_p, array_size, lit_utf8_byte_t *);
@@ -668,7 +668,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
           break; /* capture is 'undefined', always matches! */
         }
 
-        lit_utf8_byte_t *sub_str_p = re_ctx_p->saved_p[backref_idx];
+        const lit_utf8_byte_t *sub_str_p = re_ctx_p->saved_p[backref_idx];
 
         while (sub_str_p < re_ctx_p->saved_p[backref_idx + 1])
         {
@@ -697,13 +697,13 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         uint8_t *old_bc_p;
 
         JERRY_DDLOG ("Execute RE_OP_SAVE_AT_START\n");
-        lit_utf8_byte_t *old_start_p = re_ctx_p->saved_p[RE_GLOBAL_START_IDX];
+        const lit_utf8_byte_t *old_start_p = re_ctx_p->saved_p[RE_GLOBAL_START_IDX];
         re_ctx_p->saved_p[RE_GLOBAL_START_IDX] = str_curr_p;
 
         do
         {
           uint32_t offset = re_get_value (&bc_p);
-          lit_utf8_byte_t *sub_str_p = NULL;
+          const lit_utf8_byte_t *sub_str_p = NULL;
           ecma_value_t match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
 
           if (ecma_is_value_true (match_value))
@@ -760,8 +760,8 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         *  after the group first, if zero iteration is allowed.
         */
         uint32_t start_idx, iter_idx, offset;
-        lit_utf8_byte_t *old_start_p = NULL;
-        lit_utf8_byte_t *sub_str_p = NULL;
+        const lit_utf8_byte_t *old_start_p = NULL;
+        const lit_utf8_byte_t *sub_str_p = NULL;
         uint8_t *old_bc_p;
 
         old_bc_p = bc_p; /* save the bytecode start position of the group start */
@@ -814,7 +814,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_NON_CAPTURE_GREEDY_ZERO_GROUP_START:
       {
         uint32_t start_idx, iter_idx, old_iteration_cnt, offset;
-        lit_utf8_byte_t *sub_str_p = NULL;
+        const lit_utf8_byte_t *sub_str_p = NULL;
         uint8_t *old_bc_p;
         uint8_t *end_bc_p = NULL;
         start_idx = re_get_value (&bc_p);
@@ -839,7 +839,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
           start_idx += re_ctx_p->num_of_captures;
         }
 
-        lit_utf8_byte_t *old_start_p = re_ctx_p->saved_p[start_idx];
+        const lit_utf8_byte_t *old_start_p = re_ctx_p->saved_p[start_idx];
         old_iteration_cnt = re_ctx_p->num_of_iterations_p[iter_idx];
         re_ctx_p->saved_p[start_idx] = str_curr_p;
         re_ctx_p->num_of_iterations_p[iter_idx] = 0;
@@ -921,10 +921,10 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         if (re_ctx_p->num_of_iterations_p[iter_idx] >= min
             && re_ctx_p->num_of_iterations_p[iter_idx] <= max)
         {
-          lit_utf8_byte_t *old_end_p = re_ctx_p->saved_p[end_idx];
+          const lit_utf8_byte_t *old_end_p = re_ctx_p->saved_p[end_idx];
           re_ctx_p->saved_p[end_idx] = str_curr_p;
 
-          lit_utf8_byte_t *sub_str_p = NULL;
+          const lit_utf8_byte_t *sub_str_p = NULL;
           ecma_value_t match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
 
           if (ecma_is_value_true (match_value))
@@ -949,9 +949,9 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_NON_CAPTURE_GREEDY_GROUP_END:
       {
         uint32_t start_idx, end_idx, iter_idx, min, max, offset;
-        lit_utf8_byte_t *old_start_p = NULL;
-        lit_utf8_byte_t *old_end_p = NULL;
-        lit_utf8_byte_t *sub_str_p = NULL;
+        const lit_utf8_byte_t *old_start_p = NULL;
+        const lit_utf8_byte_t *old_end_p = NULL;
+        const lit_utf8_byte_t *sub_str_p = NULL;
         uint8_t *old_bc_p;
 
         end_idx = re_get_value (&bc_p);
@@ -1060,7 +1060,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_NON_GREEDY_ITERATOR:
       {
         uint32_t min, max, offset, num_of_iter;
-        lit_utf8_byte_t *sub_str_p = NULL;
+        const lit_utf8_byte_t *sub_str_p = NULL;
 
         min = re_get_value (&bc_p);
         max = re_get_value (&bc_p);
@@ -1107,7 +1107,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_GREEDY_ITERATOR:
       {
         uint32_t min, max, offset, num_of_iter;
-        lit_utf8_byte_t *sub_str_p = NULL;
+        const lit_utf8_byte_t *sub_str_p = NULL;
 
         min = re_get_value (&bc_p);
         max = re_get_value (&bc_p);
@@ -1271,18 +1271,18 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
   }
 
   re_matcher_ctx_t re_ctx;
-  lit_utf8_byte_t *input_curr_p = NULL;
+  const lit_utf8_byte_t *input_curr_p = NULL;
 
   ecma_string_t *input_string_p = ecma_get_string_from_value (input_string);
   ECMA_STRING_TO_UTF8_STRING (input_string_p, input_buffer_p, input_buffer_size);
 
   if (input_buffer_size == 0u)
   {
-    input_curr_p = (lit_utf8_byte_t *) lit_get_magic_string_utf8 (LIT_MAGIC_STRING__EMPTY);
+    input_curr_p = lit_get_magic_string_utf8 (LIT_MAGIC_STRING__EMPTY);
   }
   else
   {
-    input_curr_p = (lit_utf8_byte_t *) input_buffer_p;
+    input_curr_p = input_buffer_p;
   }
 
   re_ctx.input_start_p = input_curr_p;
@@ -1306,7 +1306,7 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
   JERRY_ASSERT (re_ctx.num_of_captures % 2 == 0);
   re_ctx.num_of_non_captures = bc_p->num_of_non_captures;
 
-  MEM_DEFINE_LOCAL_ARRAY (saved_p, re_ctx.num_of_captures + re_ctx.num_of_non_captures, lit_utf8_byte_t *);
+  MEM_DEFINE_LOCAL_ARRAY (saved_p, re_ctx.num_of_captures + re_ctx.num_of_non_captures, const lit_utf8_byte_t *);
 
   for (uint32_t i = 0; i < re_ctx.num_of_captures + re_ctx.num_of_non_captures; i++)
   {
@@ -1356,7 +1356,7 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
   }
 
   /* 2. Try to match */
-  lit_utf8_byte_t *sub_str_p = NULL;
+  const lit_utf8_byte_t *sub_str_p = NULL;
   uint8_t *bc_start_p = (uint8_t *) (bc_p + 1);
 
   while (ecma_is_value_empty (ret_value))

--- a/jerry-core/ecma/operations/ecma-regexp-object.h
+++ b/jerry-core/ecma/operations/ecma-regexp-object.h
@@ -44,7 +44,7 @@ typedef enum
  */
 typedef struct
 {
-  lit_utf8_byte_t **saved_p;            /**< saved result string pointers, ECMA 262 v5, 15.10.2.1, State */
+  const lit_utf8_byte_t **saved_p;      /**< saved result string pointers, ECMA 262 v5, 15.10.2.1, State */
   const lit_utf8_byte_t *input_start_p; /**< start of input pattern string */
   const lit_utf8_byte_t *input_end_p;   /**< end of input pattern string */
   uint32_t num_of_captures;             /**< number of capture groups */

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -1886,23 +1886,22 @@ snapshot_add_compiled_code (ecma_compiled_code_t *compiled_code_p) /**< compiled
     ecma_string_t *pattern_string_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
                                                                  pattern_cp);
 
-    ecma_length_t pattern_size = ecma_string_get_size (pattern_string_p);
+    ecma_length_t pattern_size = 0;
 
-    MEM_DEFINE_LOCAL_ARRAY (buffer_p, pattern_size, lit_utf8_byte_t);
+    ECMA_STRING_TO_UTF8_STRING (pattern_string_p, buffer_p, buffer_size);
 
-    lit_utf8_size_t sz = ecma_string_to_utf8_string (pattern_string_p, buffer_p, pattern_size);
-    JERRY_ASSERT (sz == pattern_size);
+    pattern_size = buffer_size;
 
     if (!jrt_write_to_buffer_by_offset (snapshot_buffer_p,
                                         snapshot_buffer_size,
                                         &snapshot_buffer_write_offset,
                                         buffer_p,
-                                        pattern_size))
+                                        buffer_size))
     {
       snapshot_error_occured = true;
     }
 
-    MEM_FINALIZE_LOCAL_ARRAY (buffer_p);
+    ECMA_FINALIZE_UTF8_STRING (buffer_p, buffer_size);
 
     snapshot_buffer_write_offset = JERRY_ALIGNUP (snapshot_buffer_write_offset, MEM_ALIGNMENT);
 

--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -290,7 +290,7 @@ lit_char_hex_to_int (ecma_char_t c) /**< code unit, corresponding to
  * @return true if decoding was successful, false otherwise
  */
 bool
-lit_read_code_unit_from_hex (lit_utf8_byte_t *buf_p, /**< buffer with characters */
+lit_read_code_unit_from_hex (const lit_utf8_byte_t *buf_p, /**< buffer with characters */
                              lit_utf8_size_t number_of_characters, /**< number of characters to be read */
                              ecma_char_ptr_t out_code_unit_p) /**< [out] decoded result */
 {

--- a/jerry-core/lit/lit-char-helpers.h
+++ b/jerry-core/lit/lit-char-helpers.h
@@ -216,7 +216,7 @@ extern bool lit_char_is_hex_digit (ecma_char_t);
 extern uint32_t lit_char_hex_to_int (ecma_char_t);
 
 /* read a hex encoded code point from a zero terminated buffer */
-bool lit_read_code_unit_from_hex (lit_utf8_byte_t *, lit_utf8_size_t, ecma_char_ptr_t);
+bool lit_read_code_unit_from_hex (const lit_utf8_byte_t *, lit_utf8_size_t, ecma_char_ptr_t);
 
 /**
  * Null character

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -1,4 +1,5 @@
 /* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -591,10 +592,8 @@ lit_read_prev_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer wit
 {
   JERRY_ASSERT (buf_p);
 
-  lit_utf8_byte_t *current_p = (lit_utf8_byte_t *) buf_p;
-
-  lit_utf8_decr (&current_p);
-  return lit_read_code_unit_from_utf8 (current_p, code_point);
+  lit_utf8_decr (&buf_p);
+  return lit_read_code_unit_from_utf8 (buf_p, code_point);
 } /* lit_read_prev_code_unit_from_utf8 */
 
 /**
@@ -603,7 +602,7 @@ lit_read_prev_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer wit
  * @return next code unit
  */
 ecma_char_t
-lit_utf8_read_next (lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
+lit_utf8_read_next (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
 {
   JERRY_ASSERT (*buf_p);
   ecma_char_t ch;
@@ -619,7 +618,7 @@ lit_utf8_read_next (lit_utf8_byte_t **buf_p) /**< [in,out] buffer with character
  * @return previous code unit
  */
 ecma_char_t
-lit_utf8_read_prev (lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
+lit_utf8_read_prev (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
 {
   JERRY_ASSERT (*buf_p);
   ecma_char_t ch;
@@ -666,7 +665,7 @@ lit_utf8_peek_prev (const lit_utf8_byte_t *buf_p) /**< [in,out] buffer with char
  * Increase cesu-8 encoded string pointer by one code unit.
  */
 void
-lit_utf8_incr (lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
+lit_utf8_incr (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
 {
   JERRY_ASSERT (*buf_p);
 
@@ -677,15 +676,17 @@ lit_utf8_incr (lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
  * Decrease cesu-8 encoded string pointer by one code unit.
  */
 void
-lit_utf8_decr (lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
+lit_utf8_decr (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
 {
   JERRY_ASSERT (*buf_p);
-  lit_utf8_byte_t *current_p = *buf_p;
+  const lit_utf8_byte_t *current_p = *buf_p;
+
   do
   {
     current_p--;
   }
   while ((*(current_p) & LIT_UTF8_EXTRA_BYTE_MASK) == LIT_UTF8_EXTRA_BYTE_MARKER);
+
   *buf_p = current_p;
 } /* lit_utf8_decr */
 

--- a/jerry-core/lit/lit-strings.h
+++ b/jerry-core/lit/lit-strings.h
@@ -1,4 +1,5 @@
 /* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -181,12 +182,12 @@ lit_utf8_size_t lit_read_code_unit_from_utf8 (const lit_utf8_byte_t *,
 lit_utf8_size_t lit_read_prev_code_unit_from_utf8 (const lit_utf8_byte_t *,
                                                    ecma_char_t *);
 
-ecma_char_t lit_utf8_read_next (lit_utf8_byte_t **);
-ecma_char_t lit_utf8_read_prev (lit_utf8_byte_t **);
+ecma_char_t lit_utf8_read_next (const lit_utf8_byte_t **);
+ecma_char_t lit_utf8_read_prev (const lit_utf8_byte_t **);
 ecma_char_t lit_utf8_peek_next (const lit_utf8_byte_t *);
 ecma_char_t lit_utf8_peek_prev (const lit_utf8_byte_t *);
-void lit_utf8_incr (lit_utf8_byte_t **);
-void lit_utf8_decr (lit_utf8_byte_t **);
+void lit_utf8_incr (const lit_utf8_byte_t **);
+void lit_utf8_decr (const lit_utf8_byte_t **);
 
 /* print */
 void lit_put_ecma_char (ecma_char_t);

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -546,16 +546,12 @@ re_compile_bytecode (const re_compiled_code_t **out_bytecode_p, /**< [out] point
 
   re_ctx.bytecode_ctx_p = &bc_ctx;
 
-  lit_utf8_size_t pattern_str_size = ecma_string_get_size (pattern_str_p);
-  MEM_DEFINE_LOCAL_ARRAY (pattern_start_p, pattern_str_size, lit_utf8_byte_t);
-
-  lit_utf8_size_t sz = ecma_string_to_utf8_string (pattern_str_p, pattern_start_p, pattern_str_size);
-  JERRY_ASSERT (sz == pattern_str_size);
+  ECMA_STRING_TO_UTF8_STRING (pattern_str_p, pattern_start_p, pattern_start_size);
 
   re_parser_ctx_t parser_ctx;
   parser_ctx.input_start_p = pattern_start_p;
-  parser_ctx.input_curr_p = pattern_start_p;
-  parser_ctx.input_end_p = pattern_start_p + pattern_str_size;
+  parser_ctx.input_curr_p = (lit_utf8_byte_t *) pattern_start_p;
+  parser_ctx.input_end_p = pattern_start_p + pattern_start_size;
   parser_ctx.num_of_groups = -1;
   re_ctx.parser_ctx_p = &parser_ctx;
 
@@ -593,7 +589,7 @@ re_compile_bytecode (const re_compiled_code_t **out_bytecode_p, /**< [out] point
 
   ECMA_FINALIZE (empty);
 
-  MEM_FINALIZE_LOCAL_ARRAY (pattern_start_p);
+  ECMA_FINALIZE_UTF8_STRING (pattern_start_p, pattern_start_size);
 
   size_t byte_code_size = (size_t) (bc_ctx.block_end_p - bc_ctx.block_start_p);
 

--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -259,7 +259,7 @@ re_count_num_of_groups (re_parser_ctx_t *parser_ctx_p) /**< RegExp parser contex
 {
   int char_class_in = 0;
   parser_ctx_p->num_of_groups = 0;
-  lit_utf8_byte_t *curr_p = parser_ctx_p->input_start_p;
+  lit_utf8_byte_t *curr_p = (lit_utf8_byte_t *) parser_ctx_p->input_start_p;
 
   while (curr_p < parser_ctx_p->input_end_p)
   {

--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -45,7 +45,7 @@ re_hex_lookup (re_parser_ctx_t *parser_ctx_p, /**< RegExp parser context */
                uint32_t lookup) /**< size of lookup */
 {
   bool is_digit = true;
-  lit_utf8_byte_t *curr_p = parser_ctx_p->input_curr_p;
+  const lit_utf8_byte_t *curr_p = parser_ctx_p->input_curr_p;
 
   for (uint32_t i = 0; is_digit && i < lookup; i++)
   {
@@ -259,7 +259,7 @@ re_count_num_of_groups (re_parser_ctx_t *parser_ctx_p) /**< RegExp parser contex
 {
   int char_class_in = 0;
   parser_ctx_p->num_of_groups = 0;
-  lit_utf8_byte_t *curr_p = (lit_utf8_byte_t *) parser_ctx_p->input_start_p;
+  const lit_utf8_byte_t *curr_p = parser_ctx_p->input_start_p;
 
   while (curr_p < parser_ctx_p->input_end_p)
   {

--- a/jerry-core/parser/regexp/re-parser.h
+++ b/jerry-core/parser/regexp/re-parser.h
@@ -92,9 +92,9 @@ typedef struct
   */
 typedef struct
 {
-  lit_utf8_byte_t *input_start_p; /**< start of input pattern */
+  const lit_utf8_byte_t *input_start_p; /**< start of input pattern */
   lit_utf8_byte_t *input_curr_p;  /**< current position in input pattern */
-  lit_utf8_byte_t *input_end_p;   /**< end of input pattern */
+  const lit_utf8_byte_t *input_end_p;   /**< end of input pattern */
   int num_of_groups;              /**< number of groups */
   uint32_t num_of_classes;        /**< number of character classes */
 } re_parser_ctx_t;

--- a/jerry-core/parser/regexp/re-parser.h
+++ b/jerry-core/parser/regexp/re-parser.h
@@ -93,7 +93,7 @@ typedef struct
 typedef struct
 {
   const lit_utf8_byte_t *input_start_p; /**< start of input pattern */
-  lit_utf8_byte_t *input_curr_p;  /**< current position in input pattern */
+  const lit_utf8_byte_t *input_curr_p;  /**< current position in input pattern */
   const lit_utf8_byte_t *input_end_p;   /**< end of input pattern */
   int num_of_groups;              /**< number of groups */
   uint32_t num_of_classes;        /**< number of character classes */

--- a/tests/unit/test-strings.c
+++ b/tests/unit/test-strings.c
@@ -1,4 +1,5 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +113,7 @@ main (int __attr_unused___ argc,
 
   lit_utf8_byte_t cesu8_string[max_bytes_in_string];
   ecma_char_t code_units[max_code_units_in_string];
-  lit_utf8_byte_t *saved_positions[max_code_units_in_string];
+  const lit_utf8_byte_t *saved_positions[max_code_units_in_string];
 
   for (int i = 0; i < test_iters; i++)
   {
@@ -126,7 +127,7 @@ main (int __attr_unused___ argc,
 
     JERRY_ASSERT (lit_utf8_string_length (cesu8_string, cesu8_string_size) == length);
 
-    lit_utf8_byte_t *curr_p = cesu8_string;
+    const lit_utf8_byte_t *curr_p = cesu8_string;
     const lit_utf8_byte_t *end_p = cesu8_string + cesu8_string_size;
 
     ecma_length_t calculated_length = 0;


### PR DESCRIPTION
Benefits:
 * Better readability and maintenance
 * Better heap consumption on 'date-format-xparb.js' test of SunSpider

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com