### PR TITLE
Eliminate TODO and FIXME macros

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -39,10 +39,7 @@
 #define JERRY_INTERNAL
 #include "jerry-internal.h"
 
-/**
- * TODO:
- *      Extract GC to a separate component
- */
+/* TODO: Extract GC to a separate component */
 
 /**
  * An object's GC color

--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -339,7 +339,7 @@ ecma_number_t
 ecma_utf8_string_to_number (const lit_utf8_byte_t *str_p, /**< utf-8 string */
                             lit_utf8_size_t str_size) /**< string size */
 {
-  TODO (Check license issues);
+  /* TODO: Check license issues */
 
   const lit_utf8_byte_t dec_digits_range[10] = { '0', '9' };
   const lit_utf8_byte_t hex_lower_digits_range[10] = { 'a', 'f' };

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -67,10 +67,7 @@ ecma_builtin_global_object_print (ecma_value_t this_arg __attr_unused___, /**< t
 {
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
-  /*
-   * TODO:
-   *      Move the 'print' routine out of engine core.
-   */
+  /* TODO: Move the 'print' routine out of engine core. */
 
   for (ecma_length_t arg_index = 0;
        ecma_is_value_empty (ret_value) && arg_index < args_number;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -129,9 +129,8 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
         ecma_property_t *bc_prop_p = ecma_get_internal_property (this_obj_p,
                                                                  ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
 
-        /* FIXME: "We currently have to re-compile the bytecode, because
-         * we can't copy it without knowing its length."
-         */
+        /* TODO: We currently have to re-compile the bytecode, because
+         * we can't copy it without knowing its length. */
         const re_compiled_code_t *new_bc_p = NULL;
         ecma_value_t bc_comp = re_compile_bytecode (&new_bc_p, pattern_string_p, flags);
         /* Should always succeed, since we're compiling from a source that has been compiled previously. */

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -68,10 +68,7 @@ static bool jerry_api_available;
  */
 
 #ifdef JERRY_ENABLE_LOG
-/**
- * TODO:
- *      Move logging-related functionality to separate module, like jerry-log.c
- */
+/* TODO: Move logging-related functionality to separate module, like jerry-log.c */
 
 /**
  * Verbosity level of logging

--- a/jerry-core/jerry.h
+++ b/jerry-core/jerry.h
@@ -42,7 +42,7 @@ typedef enum
   JERRY_FLAG_MEM_STATS          = (1u << 1), /**< dump memory statistics */
   JERRY_FLAG_MEM_STATS_SEPARATE = (1u << 2), /**< dump memory statistics and reset peak values after parse */
   JERRY_FLAG_PARSE_ONLY         = (1u << 3), /**< parse only, prevents script execution (only for testing)
-                                              *   FIXME: Remove. */
+                                              *   TODO: Remove. */
   JERRY_FLAG_ENABLE_LOG         = (1u << 4), /**< enable logging */
   JERRY_FLAG_ABORT_ON_FAIL      = (1u << 5), /**< abort instead of exit in case of failure */
 } jerry_flag_t;

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -66,20 +66,6 @@
   typedef char JERRY_STATIC_ASSERT_GLUE (static_assertion_failed_, __LINE__, msg) \
   [ (x) ? 1 : -1 ] __attr_unused___
 
-#define CALL_PRAGMA(x) _Pragma (#x)
-
-#ifdef JERRY_PRINT_TODO
-#define TODO(x) CALL_PRAGMA (message ("TODO - " #x))
-#else /* !JERRY_PRINT_TODO */
-#define TODO(X)
-#endif /* !JERRY_PRINT_TODO */
-
-#ifdef JERRY_PRINT_FIXME
-#define FIXME(x) CALL_PRAGMA (message ("FIXME - " #x))
-#else /* !JERRY_PRINT_FIXME */
-#define FIXME(X)
-#endif /* !JERRY_PRINT_FIXME */
-
 /**
  * Variable that must not be referenced.
  *

--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -359,7 +359,7 @@ lit_char_to_lower_case (ecma_char_t character, /**< input character value */
                         ecma_char_t *output_buffer_p, /**< [out] buffer for the result characters */
                         ecma_length_t buffer_size) /**< buffer size */
 {
-  TODO ("Needs a proper lower case implementation. See issue #323.");
+  /* TODO: Needs a proper lower case implementation. See issue #323. */
 
   JERRY_ASSERT (buffer_size >= LIT_MAXIMUM_OTHER_CASE_LENGTH);
 
@@ -393,7 +393,7 @@ lit_char_to_upper_case (ecma_char_t character, /**< input character value */
                         ecma_char_t *output_buffer_p, /**< buffer for the result characters */
                         ecma_length_t buffer_size) /**< buffer size */
 {
-  TODO ("Needs a proper upper case implementation. See issue #323.");
+  /* TODO: Needs a proper upper case implementation. See issue #323. */
 
   JERRY_ASSERT (buffer_size >= LIT_MAXIMUM_OTHER_CASE_LENGTH);
 

--- a/jerry-core/lit/lit-literal-storage.c
+++ b/jerry-core/lit/lit-literal-storage.c
@@ -205,7 +205,7 @@ lit_dump_literals ()
         char *str = (char *) (record_p + 1);
         for (i = 0; i < record_p->size; ++i, ++str)
         {
-          FIXME ("Support proper printing of characters which occupy more than one byte.")
+          /* TODO: Support proper printing of characters which occupy more than one byte. */
 
           JERRY_DLOG ("%c", *str);
         }

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -162,7 +162,7 @@ lit_is_utf8_string_magic (const lit_utf8_byte_t *string_p, /**< utf-8 string */
                           lit_utf8_size_t string_size, /**< string size in bytes */
                           lit_magic_string_id_t *out_id_p) /**< [out] magic string's id */
 {
-  TODO (Improve performance of search);
+  /* TODO: Improve performance of search */
 
   for (lit_magic_string_id_t id = (lit_magic_string_id_t) 0;
        id < LIT_MAGIC_STRING__COUNT;
@@ -192,7 +192,7 @@ bool lit_is_ex_utf8_string_magic (const lit_utf8_byte_t *string_p, /**< utf-8 st
                                   lit_utf8_size_t string_size, /**< string size in bytes */
                                   lit_magic_string_ex_id_t *out_id_p) /**< [out] magic string's id */
 {
-  TODO (Improve performance of search);
+  /* TODO: Improve performance of search */
 
   for (lit_magic_string_ex_id_t id = (lit_magic_string_ex_id_t) 0;
        id < lit_magic_string_ex_count;

--- a/jerry-core/lit/lit-snapshot.c
+++ b/jerry-core/lit/lit-snapshot.c
@@ -340,10 +340,7 @@ lit_load_literals_from_snapshot (const uint8_t *lit_table_p, /**< buffer with li
       const lit_utf8_byte_t *magic_str_p = lit_get_magic_string_utf8 (id);
       lit_utf8_size_t magic_str_sz = lit_get_magic_string_size (id);
 
-      /*
-       * TODO:
-       *      Consider searching literal storage by magic string identifier instead of by its value
-       */
+      /* TODO: Consider searching literal storage by magic string identifier instead of by its value */
       lit = (lit_literal_t) lit_find_or_create_literal_from_utf8_string (magic_str_p, magic_str_sz);
     }
     else if (type == LIT_RECORD_TYPE_MAGIC_STR_EX)
@@ -362,10 +359,7 @@ lit_load_literals_from_snapshot (const uint8_t *lit_table_p, /**< buffer with li
       const lit_utf8_byte_t *magic_str_ex_p = lit_get_magic_string_ex_utf8 (id);
       lit_utf8_size_t magic_str_ex_sz = lit_get_magic_string_ex_size (id);
 
-      /*
-       * TODO:
-       *      Consider searching literal storage by magic string identifier instead of by its value
-       */
+      /* TODO: Consider searching literal storage by magic string identifier instead of by its value */
       lit = (lit_literal_t) lit_find_or_create_literal_from_utf8_string (magic_str_ex_p, magic_str_ex_sz);
     }
     else if (type == LIT_RECORD_TYPE_NUMBER)

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -1013,7 +1013,7 @@ lit_put_ecma_char (ecma_char_t ecma_char) /**< code unit */
   }
   else
   {
-    FIXME ("Support unicode characters printing.");
+    /* TODO: Support unicode characters printing. */
     jerry_port_putchar ('_');
   }
 } /* lit_put_ecma_char */

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -1740,7 +1740,7 @@ lexer_construct_regexp_object (parser_context_t *context_p, /**< context */
     }
   }
 
-  /* FIXME: This is duplicate of 're_parse_regexp_flags'. Move this to a helper function. */
+  /* TODO: This is duplicate of 're_parse_regexp_flags'. Move this to a helper function. */
   current_flags = 0;
   while (source_p < source_end_p)
   {

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -65,7 +65,7 @@ re_insert_simple_iterator (re_compiler_ctx_t *re_ctx_p, /**< RegExp compiler con
   qmax = re_ctx_p->current_token.qmax;
   JERRY_ASSERT (qmin <= qmax);
 
-  /* FIXME: optimize bytecode length. Store 0 rather than INF */
+  /* TODO: optimize bytecode length. Store 0 rather than INF */
 
   re_append_opcode (re_ctx_p->bytecode_ctx_p, RE_OP_MATCH);   /* complete 'sub atom' */
   uint32_t bytecode_length = re_get_bytecode_length (re_ctx_p->bytecode_ctx_p);

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -287,7 +287,7 @@ vm_construct_literal_object (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
 
     if (ecma_is_value_error (ret_value))
     {
-      // FIXME: throw exception instead of define an 'undefined' value.
+      /* TODO: throw exception instead of define an 'undefined' value. */
       return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
     }
 
@@ -466,7 +466,7 @@ enum
   } \
   while (0)
 
-/* FIXME: For performance reasons, we define this as a macro.
+/* TODO: For performance reasons, we define this as a macro.
  * When we are able to construct a function with similar speed,
  * we can remove this macro. */
 #define READ_LITERAL(literal_index, target_value, target_free_op) \
@@ -649,7 +649,7 @@ vm_init_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                                      literal_start_p[value_index]);
           }
 
-          // FIXME: check the return value
+          /* TODO: check the return value */
           ecma_op_put_value_lex_env_base (ref_base_lex_env_p,
                                           name_p,
                                           is_strict,


### PR DESCRIPTION
Those macros are legacy and are not used consitently throughout the
code base. This patch eliminates their definitions and rewrites
their remaining occurrences (mostly in lit/) to comments.

All occurrences of the words "todo" and "fixme" have been checked
(case insensitively) and made sure that the comments used a
consistent style.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu