### PR TITLE
Add AArch64 support to fdlibm

### DIFF
--- a/third-party/fdlibm/include/fdlibm.h
+++ b/third-party/fdlibm/include/fdlibm.h
@@ -17,7 +17,7 @@
      defined (i486) || defined (__i486) || defined (__i486__) || \
      defined (intel) || defined (x86) || defined (i86pc) || \
      defined (__alpha) || defined (__osf__) || \
-     defined (__x86_64__) || defined (__arm__))
+     defined (__x86_64__) || defined (__arm__) || defined (__aarch64__))
 #define __LITTLE_ENDIAN
 #endif
 


### PR DESCRIPTION
Endianness was not properly set/detected for AArch64. Once that is
fixed, the platform is well-supported.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu