### PR TITLE
Remove `jerry_reg_err_callback` API function

### DIFF
--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -1713,17 +1713,6 @@ jerry_is_abort_on_fail (void)
 } /* jerry_is_abort_on_fail */
 
 /**
- * Register Jerry's fatal error callback
- */
-void
-jerry_reg_err_callback (jerry_error_callback_t callback) /**< pointer to callback function */
-{
-  jerry_assert_api_available ();
-
-  JERRY_UNIMPLEMENTED_REF_UNUSED_VARS ("Error callback is not implemented", callback);
-} /* jerry_reg_err_callback */
-
-/**
  * Parse script for specified context
  *
  * @return true - if script was parsed successfully,

--- a/jerry-core/jerry.h
+++ b/jerry-core/jerry.h
@@ -79,17 +79,10 @@ extern int jerry_debug_level;
 extern FILE *jerry_log_file;
 #endif /* JERRY_ENABLE_LOG */
 
-/**
- * Jerry error callback type
- */
-typedef void (*jerry_error_callback_t) (jerry_fatal_code_t);
-
-
 void jerry_init (jerry_flag_t);
 void jerry_cleanup (void);
 
 void jerry_get_memory_limits (size_t *, size_t *);
-void jerry_reg_err_callback (jerry_error_callback_t);
 
 bool jerry_parse (const jerry_api_char_t *, size_t, jerry_api_object_t **);
 jerry_completion_code_t jerry_run (jerry_api_object_t **);


### PR DESCRIPTION
Discussions on Termination Port API point in a different direction
than what's already in the API. Moreover, since the function has
been throwing unimplemented assert error since its introduction,
we should remove it from the code base.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu