### PR TITLE
Refactor object property chain to use property pairs.

### DIFF
--- a/jerry-core/ecma/base/ecma-alloc.c
+++ b/jerry-core/ecma/base/ecma-alloc.c
@@ -21,8 +21,12 @@
 #include "jrt.h"
 #include "mem-poolman.h"
 
-JERRY_STATIC_ASSERT (sizeof (ecma_property_t) <= sizeof (uint64_t),
-                     size_of_ecma_property_t_must_be_less_than_or_equal_to_8_bytes);
+JERRY_STATIC_ASSERT (sizeof (ecma_property_value_t) == sizeof (ecma_value_t),
+                     size_of_ecma_property_value_t_must_be_equal_to_size_of_ecma_value_t);
+JERRY_STATIC_ASSERT (((sizeof (ecma_property_value_t) - 1) & sizeof (ecma_property_value_t)) == 0,
+                     size_of_ecma_property_value_t_must_be_power_of_2);
+JERRY_STATIC_ASSERT (sizeof (ecma_property_pair_t) == sizeof (uint64_t) * 2,
+                     size_of_ecma_property_pair_t_must_be_equal_to_16_bytes);
 
 JERRY_STATIC_ASSERT (sizeof (ecma_object_t) <= sizeof (uint64_t),
                      size_of_ecma_object_t_must_be_less_than_or_equal_to_8_bytes);
@@ -85,13 +89,32 @@ JERRY_STATIC_ASSERT (sizeof (ecma_getter_setter_pointers_t) <= sizeof (uint64_t)
   DEALLOC (ecma_type)
 
 DECLARE_ROUTINES_FOR (object)
-DECLARE_ROUTINES_FOR (property)
 DECLARE_ROUTINES_FOR (number)
 DECLARE_ROUTINES_FOR (collection_header)
 DECLARE_ROUTINES_FOR (collection_chunk)
 DECLARE_ROUTINES_FOR (string)
 DECLARE_ROUTINES_FOR (getter_setter_pointers)
 DECLARE_ROUTINES_FOR (external_pointer)
+
+/**
+ * Allocate memory for ecma-property pair
+ *
+ * @return pointer to allocated memory
+ */
+ecma_property_pair_t *
+ecma_alloc_property_pair (void)
+{
+  return mem_heap_alloc_block (sizeof (ecma_property_pair_t));
+} /* ecma_alloc_property_pair */
+
+/**
+ * Dealloc memory from an ecma-property
+ */
+extern void
+ecma_dealloc_property_pair (ecma_property_pair_t *property_pair_p) /**< property pair to be freed */
+{
+  mem_heap_free_block (property_pair_p, sizeof (ecma_property_pair_t));
+} /* ecma_dealloc_property_pair */
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-alloc.h
+++ b/jerry-core/ecma/base/ecma-alloc.h
@@ -38,18 +38,6 @@ extern ecma_object_t *ecma_alloc_object (void);
 extern void ecma_dealloc_object (ecma_object_t *);
 
 /**
- * Allocate memory for ecma-property
- *
- * @return pointer to allocated memory
- */
-extern ecma_property_t *ecma_alloc_property (void);
-
-/**
- * Dealloc memory from an ecma-property
- */
-extern void ecma_dealloc_property (ecma_property_t *);
-
-/**
  * Allocate memory for ecma-number
  *
  * @return pointer to allocated memory
@@ -120,6 +108,18 @@ extern ecma_external_pointer_t *ecma_alloc_external_pointer (void);
 * Dealloc memory from external pointer
 */
 extern void ecma_dealloc_external_pointer (ecma_external_pointer_t *);
+
+/**
+ * Allocate memory for ecma-property pair
+ *
+ * @return pointer to allocated memory
+ */
+extern ecma_property_pair_t *ecma_alloc_property_pair (void);
+
+/**
+ * Dealloc memory from an ecma-property pair
+ */
+extern void ecma_dealloc_property_pair (ecma_property_pair_t *);
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-helpers-external-pointers.c
+++ b/jerry-core/ecma/base/ecma-helpers-external-pointers.c
@@ -61,12 +61,12 @@ ecma_create_external_pointer_property (ecma_object_t *obj_p, /**< object to crea
     is_new = false;
   }
 
-  JERRY_STATIC_ASSERT (sizeof (uint32_t) <= sizeof (prop_p->v.internal_property.value),
+  JERRY_STATIC_ASSERT (sizeof (uint32_t) <= sizeof (ECMA_PROPERTY_VALUE_PTR (prop_p)->value),
                        size_of_internal_property_value_must_be_greater_than_or_equal_to_4_bytes);
 
   if (sizeof (ecma_external_pointer_t) == sizeof (uint32_t))
   {
-    prop_p->v.internal_property.value = (uint32_t) ptr_value;
+    ECMA_PROPERTY_VALUE_PTR (prop_p)->value = (uint32_t) ptr_value;
   }
   else
   {
@@ -76,12 +76,12 @@ ecma_create_external_pointer_property (ecma_object_t *obj_p, /**< object to crea
     {
       handler_p = ecma_alloc_external_pointer ();
 
-      ECMA_SET_NON_NULL_POINTER (prop_p->v.internal_property.value, handler_p);
+      ECMA_SET_NON_NULL_POINTER (ECMA_PROPERTY_VALUE_PTR (prop_p)->value, handler_p);
     }
     else
     {
       handler_p = ECMA_GET_NON_NULL_POINTER (ecma_external_pointer_t,
-                                             prop_p->v.internal_property.value);
+                                             ECMA_PROPERTY_VALUE_PTR (prop_p)->value);
     }
 
     *handler_p = ptr_value;
@@ -123,12 +123,12 @@ ecma_get_external_pointer_value (ecma_object_t *obj_p, /**< object to get proper
 
   if (sizeof (ecma_external_pointer_t) == sizeof (uint32_t))
   {
-    *out_pointer_p = (ecma_external_pointer_t) prop_p->v.internal_property.value;
+    *out_pointer_p = ECMA_PROPERTY_VALUE_PTR (prop_p)->value;
   }
   else
   {
     ecma_external_pointer_t *handler_p = ECMA_GET_NON_NULL_POINTER (ecma_external_pointer_t,
-                                                                    prop_p->v.internal_property.value);
+                                                                    ECMA_PROPERTY_VALUE_PTR (prop_p)->value);
     *out_pointer_p = *handler_p;
   }
 
@@ -147,9 +147,9 @@ ecma_get_external_pointer_value (ecma_object_t *obj_p, /**< object to get proper
 void
 ecma_free_external_pointer_in_property (ecma_property_t *prop_p) /**< internal property */
 {
-  JERRY_ASSERT (prop_p->h.internal_property_type == ECMA_INTERNAL_PROPERTY_NATIVE_CODE
-                || prop_p->h.internal_property_type == ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE
-                || prop_p->h.internal_property_type == ECMA_INTERNAL_PROPERTY_FREE_CALLBACK);
+  JERRY_ASSERT (ECMA_PROPERTY_GET_INTERNAL_PROPERTY_TYPE (prop_p) == ECMA_INTERNAL_PROPERTY_NATIVE_CODE
+                || ECMA_PROPERTY_GET_INTERNAL_PROPERTY_TYPE (prop_p) == ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE
+                || ECMA_PROPERTY_GET_INTERNAL_PROPERTY_TYPE (prop_p) == ECMA_INTERNAL_PROPERTY_FREE_CALLBACK);
 
   if (sizeof (ecma_external_pointer_t) == sizeof (uint32_t))
   {
@@ -158,7 +158,7 @@ ecma_free_external_pointer_in_property (ecma_property_t *prop_p) /**< internal p
   else
   {
     ecma_external_pointer_t *handler_p = ECMA_GET_NON_NULL_POINTER (ecma_external_pointer_t,
-                                                                    prop_p->v.internal_property.value);
+                                                                    ECMA_PROPERTY_VALUE_PTR (prop_p)->value);
 
     ecma_dealloc_external_pointer (handler_p);
   }

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -213,7 +213,7 @@ extern bool ecma_get_object_is_builtin (const ecma_object_t *) __attr_pure___;
 extern void ecma_set_object_is_builtin (ecma_object_t *);
 extern ecma_lexical_environment_type_t ecma_get_lex_env_type (const ecma_object_t *) __attr_pure___;
 extern ecma_object_t *ecma_get_lex_env_outer_reference (const ecma_object_t *) __attr_pure___;
-extern ecma_property_t *ecma_get_property_list (const ecma_object_t *) __attr_pure___;
+extern ecma_property_header_t *ecma_get_property_list (const ecma_object_t *) __attr_pure___;
 extern ecma_object_t *ecma_get_lex_env_binding_object (const ecma_object_t *) __attr_pure___;
 extern bool ecma_get_lex_env_provide_this (const ecma_object_t *) __attr_pure___;
 
@@ -232,13 +232,16 @@ ecma_get_named_property (ecma_object_t *, ecma_string_t *);
 extern ecma_property_t *
 ecma_get_named_data_property (ecma_object_t *, ecma_string_t *);
 
-extern void ecma_free_property (ecma_object_t *, ecma_property_t *);
+extern void ecma_free_property (ecma_object_t *, ecma_string_t *, ecma_property_t *);
 
 extern void ecma_delete_property (ecma_object_t *, ecma_property_t *);
 
 extern ecma_value_t ecma_get_named_data_property_value (const ecma_property_t *);
 extern void ecma_set_named_data_property_value (ecma_property_t *, ecma_value_t);
 extern void ecma_named_data_property_assign_value (ecma_object_t *, ecma_property_t *, ecma_value_t);
+
+extern ecma_value_t ecma_get_internal_property_value (const ecma_property_t *);
+extern void ecma_set_internal_property_value (ecma_property_t *, ecma_value_t);
 
 extern ecma_object_t *ecma_get_named_accessor_property_getter (const ecma_property_t *);
 extern ecma_object_t *ecma_get_named_accessor_property_setter (const ecma_property_t *);
@@ -257,6 +260,8 @@ extern void ecma_set_property_lcached (ecma_property_t *, bool);
 extern ecma_property_descriptor_t ecma_make_empty_property_descriptor (void);
 extern void ecma_free_property_descriptor (ecma_property_descriptor_t *);
 extern ecma_property_descriptor_t ecma_get_property_descriptor_from_property (ecma_property_t *);
+
+extern ecma_property_t *ecma_get_next_property_pair (ecma_property_pair_t *);
 
 extern void ecma_bytecode_ref (ecma_compiled_code_t *);
 extern void ecma_bytecode_deref (ecma_compiled_code_t *);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
@@ -107,9 +107,10 @@ ecma_builtin_boolean_prototype_object_value_of (ecma_value_t this_arg) /**< this
       ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                        ECMA_INTERNAL_PROPERTY_PRIMITIVE_BOOLEAN_VALUE);
 
-      JERRY_ASSERT (prim_value_prop_p->v.internal_property.value < ECMA_SIMPLE_VALUE__COUNT);
+      JERRY_ASSERT (ecma_get_internal_property_value (prim_value_prop_p) < ECMA_SIMPLE_VALUE__COUNT);
 
-      ecma_simple_value_t prim_simple_value = (ecma_simple_value_t) prim_value_prop_p->v.internal_property.value;
+      ecma_simple_value_t prim_simple_value;
+      prim_simple_value = (ecma_simple_value_t) ecma_get_internal_property_value (prim_value_prop_p);
 
       ecma_value_t ret_boolean_value = ecma_make_simple_value (prim_simple_value);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -105,10 +105,10 @@ ecma_builtin_date_prototype_to_date_string (ecma_value_t this_arg) /**< this arg
                     ret_value);
 
     ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-    ecma_property_t *prim_value_prop_p;
-    prim_value_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
+    ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
+                                                               ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
     ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                 prim_value_prop_p->v.internal_property.value);
+                                                                 ecma_get_internal_property_value (prim_prop_p));
 
     if (ecma_number_is_nan (*prim_value_num_p))
     {
@@ -152,10 +152,10 @@ ecma_builtin_date_prototype_to_time_string (ecma_value_t this_arg) /**< this arg
                     ret_value);
 
     ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-    ecma_property_t *prim_value_prop_p;
-    prim_value_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
+    ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
+                                                               ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
     ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                 prim_value_prop_p->v.internal_property.value);
+                                                                 ecma_get_internal_property_value (prim_prop_p));
 
     if (ecma_number_is_nan (*prim_value_num_p))
     {
@@ -250,11 +250,11 @@ ecma_builtin_date_prototype_get_time (ecma_value_t this_arg) /**< this argument 
     ecma_object_t *obj_p = ecma_get_object_from_value (this_arg);
     if (ecma_object_get_class_name (obj_p) == LIT_MAGIC_STRING_DATE_UL)
     {
-      ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
-                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
+      ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
+                                                                 ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
       ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                   prim_value_prop_p->v.internal_property.value);
+                                                                   ecma_get_internal_property_value (prim_prop_p));
 
       ecma_number_t *ret_num_p = ecma_alloc_number ();
       *ret_num_p = *prim_value_num_p;
@@ -363,11 +363,11 @@ ecma_builtin_date_prototype_set_time (ecma_value_t this_arg, /**< this argument 
     /* 2. */
     ecma_object_t *obj_p = ecma_get_object_from_value (this_arg);
 
-    ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
-                                                                     ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
+    ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
+                                                               ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
     ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                               prim_value_prop_p->v.internal_property.value);
+                                                                 ecma_get_internal_property_value (prim_prop_p));
     *prim_value_num_p = *value_p;
 
     /* 3. */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -579,11 +579,11 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
 
     ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p,
                                                                    ECMA_INTERNAL_PROPERTY_CLASS);
-    class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_DATE_UL;
+    ecma_set_internal_property_value (class_prop_p, LIT_MAGIC_STRING_DATE_UL);
 
     ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                         ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-    ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_value_num_p);
+    ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_value_num_p);
 
     ret_value = ecma_make_object_value (obj_p);
   }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -247,7 +247,7 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
                                                             ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
     ecma_object_t *this_arg_obj_p = ecma_get_object_from_value (this_arg);
-    ECMA_SET_NON_NULL_POINTER (target_function_prop_p->v.internal_property.value, this_arg_obj_p);
+    ECMA_SET_NON_NULL_POINTER (ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value, this_arg_obj_p);
 
     /* 8. */
     ecma_property_t *bound_this_prop_p;
@@ -256,11 +256,13 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
 
     if (arg_count > 0)
     {
-      bound_this_prop_p->v.internal_property.value = ecma_copy_value_if_not_object (arguments_list_p[0]);
+      ecma_set_internal_property_value (bound_this_prop_p,
+                                        ecma_copy_value_if_not_object (arguments_list_p[0]));
     }
     else
     {
-      bound_this_prop_p->v.internal_property.value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+      ecma_set_internal_property_value (bound_this_prop_p,
+                                        ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED));
     }
 
     if (arg_count > 1)
@@ -270,7 +272,7 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
 
       ecma_property_t *bound_args_prop_p;
       bound_args_prop_p = ecma_create_internal_property (function_p, ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS);
-      ECMA_SET_NON_NULL_POINTER (bound_args_prop_p->v.internal_property.value, bound_args_collection_p);
+      ECMA_SET_NON_NULL_POINTER (ECMA_PROPERTY_VALUE_PTR (bound_args_prop_p)->value, bound_args_collection_p);
     }
 
     /*

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -922,7 +922,7 @@ ecma_date_set_internal_property (ecma_value_t this_arg, /**< this argument */
                                                                    ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
   ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                               prim_value_prop_p->v.internal_property.value);
+                                                               ecma_get_internal_property_value (prim_value_prop_p));
   *prim_value_num_p = *value_p;
 
   return ecma_make_number_value (value_p);
@@ -1349,7 +1349,7 @@ ecma_date_get_primitive_value (ecma_value_t this_arg) /**< this argument */
 
     ecma_number_t *prim_value_num_p = ecma_alloc_number ();
     *prim_value_num_p = *ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                    prim_value_prop_p->v.internal_property.value);
+                                                    ecma_get_internal_property_value (prim_value_prop_p));
     ret_value = ecma_make_number_value (prim_value_num_p);
   }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
@@ -194,10 +194,10 @@ TRY_TO_INSTANTIATE_PROPERTY_ROUTINE_NAME (ecma_object_t *obj_p, /**< object */
   if (mask_prop_p == NULL)
   {
     mask_prop_p = ecma_create_internal_property (obj_p, mask_prop_id);
-    mask_prop_p->v.internal_property.value = 0;
+    ecma_set_internal_property_value (mask_prop_p, 0);
   }
 
-  uint32_t bit_mask = mask_prop_p->v.internal_property.value;
+  uint32_t bit_mask = ecma_get_internal_property_value (mask_prop_p);
 
   if (bit_mask & bit)
   {
@@ -206,7 +206,7 @@ TRY_TO_INSTANTIATE_PROPERTY_ROUTINE_NAME (ecma_object_t *obj_p, /**< object */
 
   bit_mask |= bit;
 
-  mask_prop_p->v.internal_property.value = bit_mask;
+  ecma_set_internal_property_value (mask_prop_p, bit_mask);
 
   ecma_value_t value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
   ecma_property_writable_value_t writable;
@@ -379,7 +379,7 @@ LIST_LAZY_PROPERTY_NAMES_ROUTINE_NAME (ecma_object_t *object_p, /**< a built-in 
     }
     else
     {
-      uint32_t bit_mask = mask_prop_p->v.internal_property.value;
+      uint32_t bit_mask = ecma_get_internal_property_value (mask_prop_p);
 
       if (bit_mask & bit)
       {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1440,7 +1440,7 @@ ecma_builtin_json_object (ecma_object_t *obj_p, /**< the object*/
 
       JERRY_ASSERT (ecma_is_property_enumerable (property_p));
 
-      if (property_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA)
+      if (ECMA_PROPERTY_GET_TYPE (property_p) == ECMA_PROPERTY_TYPE_NAMEDDATA)
       {
         ecma_append_to_values_collection (property_keys_p, *iter.current_value_p, true);
       }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -358,8 +358,9 @@ ecma_builtin_number_prototype_object_value_of (ecma_value_t this_arg) /**< this 
       ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                        ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
-      ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                   prim_value_prop_p->v.internal_property.value);
+      ecma_number_t *prim_value_num_p;
+      prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
+                                                    ecma_get_internal_property_value (prim_value_prop_p));
 
       ecma_number_t *ret_num_p = ecma_alloc_number ();
       *ret_num_p = *prim_value_num_p;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -278,7 +278,8 @@ ecma_builtin_object_object_freeze (ecma_value_t this_arg __attr_unused___, /**< 
       ecma_property_descriptor_t prop_desc = ecma_get_property_descriptor_from_property (property_p);
 
       // 2.b
-      if ((property_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA) && ecma_is_property_writable (property_p))
+      if (ECMA_PROPERTY_GET_TYPE (property_p) == ECMA_PROPERTY_TYPE_NAMEDDATA
+          && ecma_is_property_writable (property_p))
       {
         prop_desc.is_writable = false;
       }
@@ -462,10 +463,12 @@ ecma_builtin_object_object_is_frozen (ecma_value_t this_arg __attr_unused___, /*
         // 2.a
         ecma_property_t *property_p = ecma_op_object_get_own_property (obj_p, property_name_p);
 
-        JERRY_ASSERT (property_p->flags & (ECMA_PROPERTY_FLAG_NAMEDDATA | ECMA_PROPERTY_FLAG_NAMEDACCESSOR));
+        JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (property_p) == ECMA_PROPERTY_TYPE_NAMEDDATA
+                      || ECMA_PROPERTY_GET_TYPE (property_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR);
 
         // 2.b
-        if ((property_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA) && ecma_is_property_writable (property_p))
+        if (ECMA_PROPERTY_GET_TYPE (property_p) == ECMA_PROPERTY_TYPE_NAMEDDATA
+            && ecma_is_property_writable (property_p))
         {
           is_frozen = false;
           break;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -137,14 +137,14 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
         JERRY_ASSERT (ecma_is_value_empty (bc_comp));
 
         re_compiled_code_t *old_bc_p = ECMA_GET_POINTER (re_compiled_code_t,
-                                                         bc_prop_p->v.internal_property.value);
+                                                         ecma_get_internal_property_value (bc_prop_p));
         if (old_bc_p != NULL)
         {
           /* Free the old bytecode */
           ecma_bytecode_deref ((ecma_compiled_code_t *) old_bc_p);
         }
 
-        ECMA_SET_POINTER (bc_prop_p->v.internal_property.value, new_bc_p);
+        ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (bc_prop_p)->value, new_bc_p);
 
         re_initialize_props (this_obj_p, pattern_string_p, flags);
 
@@ -206,7 +206,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
                         ret_value);
 
         re_compiled_code_t *old_bc_p = ECMA_GET_POINTER (re_compiled_code_t,
-                                                         bc_prop_p->v.internal_property.value);
+                                                         ecma_get_internal_property_value (bc_prop_p));
 
         if (old_bc_p != NULL)
         {
@@ -214,7 +214,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
           ecma_bytecode_deref ((ecma_compiled_code_t *) old_bc_p);
         }
 
-        ECMA_SET_POINTER (bc_prop_p->v.internal_property.value, new_bc_p);
+        ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (bc_prop_p)->value, new_bc_p);
         re_initialize_props (this_obj_p, pattern_string_p, flags);
         ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 
@@ -269,7 +269,7 @@ ecma_builtin_regexp_prototype_exec (ecma_value_t this_arg, /**< this argument */
     ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
     bytecode_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
 
-    void *bytecode_p = ECMA_GET_POINTER (void, bytecode_prop_p->v.internal_property.value);
+    void *bytecode_p = ECMA_GET_POINTER (void, ecma_get_internal_property_value (bytecode_prop_p));
 
     if (bytecode_p == NULL)
     {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -79,8 +79,9 @@ ecma_builtin_string_prototype_object_to_string (ecma_value_t this_arg) /**< this
       ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                        ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
 
-      ecma_string_t *prim_value_str_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                                                   prim_value_prop_p->v.internal_property.value);
+      ecma_string_t *prim_value_str_p;
+      prim_value_str_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
+                                                    ecma_get_internal_property_value (prim_value_prop_p));
 
       prim_value_str_p = ecma_copy_or_ref_ecma_string (prim_value_str_p);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -111,7 +111,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
 
   ecma_property_t *built_in_id_prop_p = ecma_create_internal_property (object_obj_p,
                                                                        ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
-  built_in_id_prop_p->v.internal_property.value = obj_builtin_id;
+  ecma_set_internal_property_value (built_in_id_prop_p, obj_builtin_id);
 
   ecma_set_object_is_builtin (object_obj_p);
 
@@ -126,7 +126,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *prim_value_prop_p;
       prim_value_prop_p = ecma_create_internal_property (object_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
-      ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_prop_str_value_p);
+      ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_str_value_p);
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_STRING_BUILTIN */
@@ -140,7 +140,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *prim_value_prop_p;
       prim_value_prop_p = ecma_create_internal_property (object_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-      ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_prop_num_value_p);
+      ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_num_value_p);
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_NUMBER_BUILTIN */
@@ -151,7 +151,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *prim_value_prop_p;
       prim_value_prop_p = ecma_create_internal_property (object_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_PRIMITIVE_BOOLEAN_VALUE);
-      prim_value_prop_p->v.internal_property.value = ECMA_SIMPLE_VALUE_FALSE;
+      ecma_set_internal_property_value (prim_value_prop_p, ECMA_SIMPLE_VALUE_FALSE);
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_BOOLEAN_BUILTIN */
@@ -165,7 +165,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *prim_value_prop_p;
       prim_value_prop_p = ecma_create_internal_property (object_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-      ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_prop_num_value_p);
+      ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_num_value_p);
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_DATE_BUILTIN */
@@ -176,7 +176,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *bytecode_prop_p;
       bytecode_prop_p = ecma_create_internal_property (object_obj_p,
                                                        ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
-      bytecode_prop_p->v.internal_property.value = ECMA_NULL_POINTER;
+      ecma_set_internal_property_value (bytecode_prop_p, ECMA_NULL_POINTER);
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_REGEXP_BUILTIN */
@@ -309,7 +309,7 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
 
       ecma_property_t *desc_prop_p = ecma_get_internal_property (object_p,
                                                                ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC);
-      uint64_t builtin_routine_desc = desc_prop_p->v.internal_property.value;
+      uint64_t builtin_routine_desc = ecma_get_internal_property_value (desc_prop_p);
 
       JERRY_STATIC_ASSERT (sizeof (uint8_t) * JERRY_BITSINBYTE == ECMA_BUILTIN_ROUTINE_ID_LENGTH_VALUE_WIDTH,
                            bits_in_uint8_t_must_be_equal_to_ECMA_BUILTIN_ROUTINE_ID_LENGTH_VALUE_WIDTH);
@@ -337,7 +337,7 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
   {
     ecma_property_t *built_in_id_prop_p = ecma_get_internal_property (object_p,
                                                                       ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
-    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->v.internal_property.value;
+    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) ecma_get_internal_property_value (built_in_id_prop_p);
 
     JERRY_ASSERT (ecma_builtin_is (object_p, builtin_id));
 
@@ -411,7 +411,7 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
   {
     ecma_property_t *built_in_id_prop_p = ecma_get_internal_property (object_p,
                                                                       ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
-    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->v.internal_property.value;
+    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) ecma_get_internal_property_value (built_in_id_prop_p);
 
     JERRY_ASSERT (ecma_builtin_is (object_p, builtin_id));
 
@@ -493,7 +493,7 @@ ecma_builtin_make_function_object_for_routine (ecma_builtin_id_t builtin_id, /**
                                                                         ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC);
 
   JERRY_ASSERT ((uint32_t) packed_value == packed_value);
-  routine_desc_prop_p->v.internal_property.value = (uint32_t) packed_value;
+  ecma_set_internal_property_value (routine_desc_prop_p, (uint32_t) packed_value);
 
   return func_obj_p;
 } /* ecma_builtin_make_function_object_for_routine */
@@ -517,7 +517,7 @@ ecma_builtin_dispatch_call (ecma_object_t *obj_p, /**< built-in object */
   {
     ecma_property_t *desc_prop_p = ecma_get_internal_property (obj_p,
                                                                ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC);
-    uint64_t builtin_routine_desc = desc_prop_p->v.internal_property.value;
+    uint64_t builtin_routine_desc = ecma_get_internal_property_value (desc_prop_p);
 
     uint64_t built_in_id_field = JRT_EXTRACT_BIT_FIELD (uint64_t, builtin_routine_desc,
                                                         ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_OBJECT_ID_POS,
@@ -544,7 +544,7 @@ ecma_builtin_dispatch_call (ecma_object_t *obj_p, /**< built-in object */
 
     ecma_property_t *built_in_id_prop_p = ecma_get_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
-    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->v.internal_property.value;
+    ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) ecma_get_internal_property_value (built_in_id_prop_p);
 
     JERRY_ASSERT (ecma_builtin_is (obj_p, builtin_id));
 
@@ -605,7 +605,7 @@ ecma_builtin_dispatch_construct (ecma_object_t *obj_p, /**< built-in object */
 
   ecma_property_t *built_in_id_prop_p = ecma_get_internal_property (obj_p,
                                                                     ECMA_INTERNAL_PROPERTY_BUILT_IN_ID);
-  ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) built_in_id_prop_p->v.internal_property.value;
+  ecma_builtin_id_t builtin_id = (ecma_builtin_id_t) ecma_get_internal_property_value (built_in_id_prop_p);
 
   JERRY_ASSERT (ecma_builtin_is (obj_p, builtin_id));
 

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -157,7 +157,7 @@ ecma_op_array_object_define_own_property (ecma_object_t *obj_p, /**< the array o
   // 1.
   ecma_string_t *magic_string_length_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
   ecma_property_t *len_prop_p = ecma_op_object_get_own_property (obj_p, magic_string_length_p);
-  JERRY_ASSERT (len_prop_p != NULL && (len_prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA));
+  JERRY_ASSERT (len_prop_p != NULL && ECMA_PROPERTY_GET_TYPE (len_prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
 
   // 2.
   ecma_value_t old_len_value = ecma_get_named_data_property_value (len_prop_p);

--- a/jerry-core/ecma/operations/ecma-boolean-object.c
+++ b/jerry-core/ecma/operations/ecma-boolean-object.c
@@ -63,11 +63,11 @@ ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boo
   ecma_deref_object (prototype_obj_p);
 
   ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_BOOLEAN_UL;
+  ECMA_PROPERTY_VALUE_PTR (class_prop_p)->value = LIT_MAGIC_STRING_BOOLEAN_UL;
 
   ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_BOOLEAN_VALUE);
-  prim_value_prop_p->v.internal_property.value = bool_value;
+  ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value = bool_value;
 
   return ecma_make_object_value (obj_p);
 } /* ecma_op_create_boolean_object */

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -95,7 +95,7 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
 
   ecma_property_t *class_prop_p = ecma_create_internal_property (new_error_obj_p,
                                                                  ECMA_INTERNAL_PROPERTY_CLASS);
-  class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_ERROR_UL;
+  ECMA_PROPERTY_VALUE_PTR (class_prop_p)->value = LIT_MAGIC_STRING_ERROR_UL;
 
   return new_error_obj_p;
 #else /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_ERROR_BUILTINS */

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -168,11 +168,11 @@ ecma_op_create_function_object (ecma_object_t *scope_p, /**< function's scope */
 
   // 9.
   ecma_property_t *scope_prop_p = ecma_create_internal_property (f, ECMA_INTERNAL_PROPERTY_SCOPE);
-  ECMA_SET_POINTER (scope_prop_p->v.internal_property.value, scope_p);
+  ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value, scope_p);
 
   // 10., 11., 12.
   ecma_property_t *bytecode_prop_p = ecma_create_internal_property (f, ECMA_INTERNAL_PROPERTY_CODE_BYTECODE);
-  MEM_CP_SET_NON_NULL_POINTER (bytecode_prop_p->v.internal_property.value, bytecode_data_p);
+  MEM_CP_SET_NON_NULL_POINTER (ECMA_PROPERTY_VALUE_PTR (bytecode_prop_p)->value, bytecode_data_p);
   ecma_bytecode_ref ((ecma_compiled_code_t *) bytecode_data_p);
 
   // 14., 15., 16., 17., 18.
@@ -294,7 +294,8 @@ ecma_op_function_try_lazy_instantiate_property (ecma_object_t *obj_p, /**< the f
     ecma_property_t *bytecode_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CODE_BYTECODE);
 
     const ecma_compiled_code_t *bytecode_data_p;
-    bytecode_data_p = MEM_CP_GET_POINTER (const ecma_compiled_code_t, bytecode_prop_p->v.internal_property.value);
+    bytecode_data_p = MEM_CP_GET_POINTER (const ecma_compiled_code_t,
+                                          ECMA_PROPERTY_VALUE_PTR (bytecode_prop_p)->value);
 
     if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_UINT16_ARGUMENTS)
     {
@@ -527,8 +528,9 @@ ecma_op_function_has_instance (ecma_object_t *func_obj_p, /**< Function object *
     target_function_prop_p = ecma_get_internal_property (func_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
-    ecma_object_t *target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                                  target_function_prop_p->v.internal_property.value);
+    ecma_object_t *target_func_obj_p;
+    target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
+                                                   ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
 
     /* 3. */
     ret_value = ecma_op_object_has_instance (target_func_obj_p, value);
@@ -575,7 +577,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       ecma_property_t *bytecode_prop_p = ecma_get_internal_property (func_obj_p, ECMA_INTERNAL_PROPERTY_CODE_BYTECODE);
 
       ecma_object_t *scope_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                          scope_prop_p->v.internal_property.value);
+                                                          ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value);
 
       // 8.
       ecma_value_t this_binding;
@@ -583,7 +585,8 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       bool is_no_lex_env;
 
       const ecma_compiled_code_t *bytecode_data_p;
-      bytecode_data_p = MEM_CP_GET_POINTER (const ecma_compiled_code_t, bytecode_prop_p->v.internal_property.value);
+      bytecode_data_p = MEM_CP_GET_POINTER (const ecma_compiled_code_t,
+                                            ECMA_PROPERTY_VALUE_PTR (bytecode_prop_p)->value);
 
       is_strict = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE) ? true : false;
       is_no_lex_env = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_LEXICAL_ENV_NOT_NEEDED) ? true : false;
@@ -681,19 +684,20 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
     target_function_prop_p = ecma_get_internal_property (func_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
-    ecma_object_t *target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                                  target_function_prop_p->v.internal_property.value);
+    ecma_object_t *target_func_obj_p;
+    target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
+                                                   ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
 
     /* 4. */
     ecma_property_t *bound_args_prop_p;
-    ecma_value_t bound_this_value = bound_this_prop_p->v.internal_property.value;
+    ecma_value_t bound_this_value = ECMA_PROPERTY_VALUE_PTR (bound_this_prop_p)->value;
     bound_args_prop_p = ecma_find_internal_property (func_obj_p, ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS);
 
     if (bound_args_prop_p != NULL)
     {
       ecma_collection_header_t *bound_arg_list_p;
       bound_arg_list_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_header_t,
-                                                    bound_args_prop_p->v.internal_property.value);
+                                                    ECMA_PROPERTY_VALUE_PTR (bound_args_prop_p)->value);
 
       JERRY_ASSERT (bound_arg_list_p->unit_number > 0);
 
@@ -865,8 +869,9 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
     target_function_prop_p = ecma_get_internal_property (func_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
-    ecma_object_t *target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                                  target_function_prop_p->v.internal_property.value);
+    ecma_object_t *target_func_obj_p;
+    target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
+                                                   ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
 
     /* 2. */
     if (!ecma_is_constructor (ecma_make_object_value (target_func_obj_p)))
@@ -883,8 +888,7 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
       {
         ecma_collection_header_t *bound_arg_list_p;
         bound_arg_list_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_header_t,
-                                                      bound_args_prop_p->v.internal_property.value);
-
+                                                      ECMA_PROPERTY_VALUE_PTR (bound_args_prop_p)->value);
 
         JERRY_ASSERT (bound_arg_list_p->unit_number > 0);
 
@@ -973,13 +977,13 @@ ecma_op_function_declaration (ecma_object_t *lex_env_p, /**< lexical environment
 
       JERRY_ASSERT (ecma_is_value_true (completion));
     }
-    else if (existing_prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR)
+    else if (ECMA_PROPERTY_GET_TYPE (existing_prop_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR)
     {
       ret_value = ecma_raise_type_error (ECMA_ERR_MSG (""));
     }
     else
     {
-      JERRY_ASSERT (existing_prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+      JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (existing_prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
 
       if (!ecma_is_property_writable (existing_prop_p)
           || !ecma_is_property_enumerable (existing_prop_p))

--- a/jerry-core/ecma/operations/ecma-get-put-value.c
+++ b/jerry-core/ecma/operations/ecma-get-put-value.c
@@ -124,7 +124,7 @@ ecma_op_get_value_object_base (ecma_reference_t ref) /**< ECMA-reference */
       // 3.
       ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
     }
-    else if (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA)
+    else if (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA)
     {
       // 4.
       ret_value = ecma_copy_value (ecma_get_named_data_property_value (prop_p));
@@ -132,7 +132,7 @@ ecma_op_get_value_object_base (ecma_reference_t ref) /**< ECMA-reference */
     else
     {
       // 5.
-      JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR);
+      JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR);
 
       ecma_object_t *obj_p = ecma_get_named_accessor_property_getter (prop_p);
 
@@ -304,16 +304,16 @@ ecma_op_put_value_object_base (ecma_reference_t ref, /**< ECMA-reference */
       ecma_property_t *prop_p = ecma_op_object_get_property (obj_p, referenced_name_p);
 
       // sub_4., sub_7
-      if ((own_prop_p != NULL && (own_prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA))
+      if ((own_prop_p != NULL && ECMA_PROPERTY_GET_TYPE (own_prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA)
           || (prop_p == NULL)
-          || !(prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR))
+          || ECMA_PROPERTY_GET_TYPE (prop_p) != ECMA_PROPERTY_TYPE_NAMEDACCESSOR)
       {
         ret_value = ecma_reject_put (ref.is_strict);
       }
       else
       {
         // sub_6.
-        JERRY_ASSERT (prop_p != NULL && (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR));
+        JERRY_ASSERT (prop_p != NULL && ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR);
 
         ecma_object_t *setter_p = ecma_get_named_accessor_property_setter (prop_p);
         JERRY_ASSERT (setter_p != NULL);

--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -331,7 +331,7 @@ ecma_op_delete_binding (ecma_object_t *lex_env_p, /**< lexical environment */
     }
     else
     {
-      JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+      JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
 
       if (!ecma_is_property_configurable (prop_p))
       {

--- a/jerry-core/ecma/operations/ecma-number-object.c
+++ b/jerry-core/ecma/operations/ecma-number-object.c
@@ -62,11 +62,11 @@ ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Numb
   ecma_deref_object (prototype_obj_p);
 
   ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_NUMBER_UL;
+  ECMA_PROPERTY_VALUE_PTR (class_prop_p)->value = LIT_MAGIC_STRING_NUMBER_UL;
 
   ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-  ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_value_p);
+  ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_value_p);
 
   return ecma_make_object_value (obj_p);
 } /* ecma_op_create_number_object */

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -84,7 +84,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
 
   // 4.
   ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_ARGUMENTS_UL;
+  ECMA_PROPERTY_VALUE_PTR (class_prop_p)->value = LIT_MAGIC_STRING_ARGUMENTS_UL;
 
   // 7.
   ecma_string_t *length_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
@@ -174,11 +174,11 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
 
       ecma_property_t *parameters_map_prop_p = ecma_create_internal_property (obj_p,
                                                                               ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
-      ECMA_SET_POINTER (parameters_map_prop_p->v.internal_property.value, map_p);
+      ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (parameters_map_prop_p)->value, map_p);
 
       ecma_property_t *scope_prop_p = ecma_create_internal_property (map_p,
                                                                      ECMA_INTERNAL_PROPERTY_SCOPE);
-      ECMA_SET_POINTER (scope_prop_p->v.internal_property.value, lex_env_p);
+      ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value, lex_env_p);
 
       ecma_deref_object (map_p);
     }
@@ -286,7 +286,7 @@ ecma_arguments_get_mapped_arg_value (ecma_object_t *map_p, /**< [[ParametersMap]
 {
   ecma_property_t *scope_prop_p = ecma_get_internal_property (map_p, ECMA_INTERNAL_PROPERTY_SCOPE);
   ecma_object_t *lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                        scope_prop_p->v.internal_property.value);
+                                                        ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value);
   JERRY_ASSERT (lex_env_p != NULL
                 && ecma_is_lexical_environment (lex_env_p));
 
@@ -317,7 +317,7 @@ ecma_op_arguments_object_get (ecma_object_t *obj_p, /**< the object */
   // 1.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
   ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    map_prop_p->v.internal_property.value);
+                                                    ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
 
   // 2.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
@@ -363,7 +363,7 @@ ecma_op_arguments_object_get_own_property (ecma_object_t *obj_p, /**< the object
   // 3.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
   ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    map_prop_p->v.internal_property.value);
+                                                    ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
 
   // 4.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
@@ -403,7 +403,7 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the obj
   // 1.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
   ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    map_prop_p->v.internal_property.value);
+                                                    ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
 
   // 2.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
@@ -444,7 +444,7 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the obj
         /* emulating execution of function described by MakeArgSetter */
         ecma_property_t *scope_prop_p = ecma_get_internal_property (map_p, ECMA_INTERNAL_PROPERTY_SCOPE);
         ecma_object_t *lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                              scope_prop_p->v.internal_property.value);
+                                                              ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value);
 
         ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
         ecma_value_t arg_name_prop_value = ecma_get_named_data_property_value (mapped_prop_p);
@@ -501,7 +501,7 @@ ecma_op_arguments_object_delete (ecma_object_t *obj_p, /**< the object */
   // 1.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
   ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    map_prop_p->v.internal_property.value);
+                                                    ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
 
   // 2.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -157,7 +157,7 @@ ecma_op_general_object_get (ecma_object_t *obj_p, /**< the object */
   }
 
   // 3.
-  if (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA)
+  if (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA)
   {
     return ecma_copy_value (ecma_get_named_data_property_value (prop_p));
   }
@@ -284,7 +284,7 @@ ecma_op_general_object_put (ecma_object_t *obj_p, /**< the object */
   ecma_property_t *own_desc_p = ecma_op_object_get_own_property (obj_p, property_name_p);
 
   // 3.
-  if (own_desc_p != NULL && (own_desc_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA))
+  if (own_desc_p != NULL && ECMA_PROPERTY_GET_TYPE (own_desc_p) == ECMA_PROPERTY_TYPE_NAMEDDATA)
   {
     // a.
     ecma_property_descriptor_t value_desc = ecma_make_empty_property_descriptor ();
@@ -304,7 +304,7 @@ ecma_op_general_object_put (ecma_object_t *obj_p, /**< the object */
   ecma_property_t *desc_p = ecma_op_object_get_property (obj_p, property_name_p);
 
   // 5.
-  if (desc_p != NULL && (desc_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR))
+  if (desc_p != NULL && ECMA_PROPERTY_GET_TYPE (desc_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR)
   {
     // a.
     ecma_object_t *setter_p = ecma_get_named_accessor_property_setter (desc_p);
@@ -365,7 +365,7 @@ ecma_op_general_object_can_put (ecma_object_t *obj_p, /**< the object */
   if (prop_p != NULL)
   {
     // a.
-    if (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR)
+    if (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR)
     {
       ecma_object_t *setter_p = ecma_get_named_accessor_property_setter (prop_p);
 
@@ -381,7 +381,7 @@ ecma_op_general_object_can_put (ecma_object_t *obj_p, /**< the object */
     else
     {
       // b.
-      JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+      JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
 
       return ecma_is_property_writable (prop_p);
     }
@@ -406,7 +406,7 @@ ecma_op_general_object_can_put (ecma_object_t *obj_p, /**< the object */
   }
 
   // 7.
-  if (inherited_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR)
+  if (ECMA_PROPERTY_GET_TYPE (inherited_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR)
   {
     ecma_object_t *setter_p = ecma_get_named_accessor_property_setter (inherited_p);
 
@@ -422,7 +422,7 @@ ecma_op_general_object_can_put (ecma_object_t *obj_p, /**< the object */
   else
   {
     // 8.
-    JERRY_ASSERT (inherited_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+    JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (inherited_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
 
     // a.
     if (!ecma_get_object_extensible (obj_p))
@@ -655,8 +655,9 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
   }
 
   // 6.
-  const bool is_current_data_descriptor = (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
-  const bool is_current_accessor_descriptor = (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR);
+  ecma_property_types_t current_type = ECMA_PROPERTY_GET_TYPE (current_p);
+  const bool is_current_data_descriptor = (current_type == ECMA_PROPERTY_TYPE_NAMEDDATA);
+  const bool is_current_accessor_descriptor = (current_type == ECMA_PROPERTY_TYPE_NAMEDACCESSOR);
 
   JERRY_ASSERT (is_current_data_descriptor || is_current_accessor_descriptor);
 
@@ -820,28 +821,28 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
   // 12.
   if (property_desc_p->is_value_defined)
   {
-    JERRY_ASSERT (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+    JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (current_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
 
     ecma_named_data_property_assign_value (obj_p, current_p, property_desc_p->value);
   }
 
   if (property_desc_p->is_writable_defined)
   {
-    JERRY_ASSERT (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+    JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (current_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
 
     ecma_set_property_writable_attr (current_p, property_desc_p->is_writable);
   }
 
   if (property_desc_p->is_get_defined)
   {
-    JERRY_ASSERT (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR);
+    JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (current_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR);
 
     ecma_set_named_accessor_property_getter (obj_p, current_p, property_desc_p->get_p);
   }
 
   if (property_desc_p->is_set_defined)
   {
-    JERRY_ASSERT (current_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR);
+    JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (current_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR);
 
     ecma_set_named_accessor_property_setter (obj_p, current_p, property_desc_p->set_p);
   }

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -146,7 +146,7 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp obejct */
   }
 
   ecma_deref_ecma_string (magic_string_p);
-  JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+  JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
   ecma_named_data_property_assign_value (re_obj_p,
                                          prop_p,
                                          ecma_make_string_value (source_p));
@@ -166,7 +166,7 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp obejct */
 
   ecma_deref_ecma_string (magic_string_p);
   prop_value = (flags & RE_FLAG_GLOBAL) ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE;
-  JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+  JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
   ecma_set_named_data_property_value (prop_p, ecma_make_simple_value (prop_value));
 
   /* Set ignoreCase property. ECMA-262 v5, 15.10.7.3 */
@@ -182,7 +182,7 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp obejct */
 
   ecma_deref_ecma_string (magic_string_p);
   prop_value = (flags & RE_FLAG_IGNORE_CASE) ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE;
-  JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+  JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
   ecma_set_named_data_property_value (prop_p, ecma_make_simple_value (prop_value));
 
   /* Set multiline property. ECMA-262 v5, 15.10.7.4 */
@@ -198,7 +198,7 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp obejct */
 
   ecma_deref_ecma_string (magic_string_p);
   prop_value = (flags & RE_FLAG_MULTILINE) ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE;
-  JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+  JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
   ecma_set_named_data_property_value (prop_p, ecma_make_simple_value (prop_value));
 
   /* Set lastIndex property. ECMA-262 v5, 15.10.7.5 */
@@ -216,7 +216,7 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp obejct */
 
   ecma_number_t *lastindex_num_p = ecma_alloc_number ();
   *lastindex_num_p = ECMA_NUMBER_ZERO;
-  JERRY_ASSERT (prop_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA);
+  JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
   ecma_named_data_property_assign_value (re_obj_p, prop_p, ecma_make_number_value (lastindex_num_p));
   ecma_dealloc_number (lastindex_num_p);
 } /* re_initialize_props */
@@ -241,12 +241,12 @@ ecma_op_create_regexp_object_from_bytecode (re_compiled_code_t *bytecode_p) /**<
 
   /* Set the internal [[Class]] property */
   ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_REGEXP_UL;
+  ECMA_PROPERTY_VALUE_PTR (class_prop_p)->value = LIT_MAGIC_STRING_REGEXP_UL;
 
   /* Set bytecode internal property. */
   ecma_property_t *bytecode_prop_p;
   bytecode_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
-  ECMA_SET_NON_NULL_POINTER (bytecode_prop_p->v.internal_property.value, bytecode_p);
+  ECMA_SET_NON_NULL_POINTER (ECMA_PROPERTY_VALUE_PTR (bytecode_prop_p)->value, bytecode_p);
   ecma_bytecode_ref ((ecma_compiled_code_t *) bytecode_p);
 
   /* Initialize RegExp object properties */
@@ -293,7 +293,7 @@ ecma_op_create_regexp_object (ecma_string_t *pattern_p, /**< input pattern */
 
   /* Set the internal [[Class]] property */
   ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  class_prop_p->v.internal_property.value = LIT_MAGIC_STRING_REGEXP_UL;
+  ECMA_PROPERTY_VALUE_PTR (class_prop_p)->value = LIT_MAGIC_STRING_REGEXP_UL;
 
   re_initialize_props (obj_p, pattern_p, flags);
 
@@ -305,7 +305,7 @@ ecma_op_create_regexp_object (ecma_string_t *pattern_p, /**< input pattern */
   const re_compiled_code_t *bc_p = NULL;
   ECMA_TRY_CATCH (empty, re_compile_bytecode (&bc_p, pattern_p, flags), ret_value);
 
-  ECMA_SET_POINTER (bytecode_prop_p->v.internal_property.value, bc_p);
+  ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (bytecode_prop_p)->value, bc_p);
   ret_value = ecma_make_object_value (obj_p);
 
   ECMA_FINALIZE (empty);
@@ -1263,7 +1263,7 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
   ecma_property_t *bytecode_prop_p = ecma_get_internal_property (regexp_object_p,
                                                                  ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
   re_compiled_code_t *bc_p = ECMA_GET_POINTER (re_compiled_code_t,
-                                               bytecode_prop_p->v.internal_property.value);
+                                               ECMA_PROPERTY_VALUE_PTR (bytecode_prop_p)->value);
 
   if (bc_p == NULL)
   {

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -95,7 +95,7 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
 
   ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
-  ECMA_SET_POINTER (prim_value_prop_p->v.internal_property.value, prim_prop_str_value_p);
+  ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_str_value_p);
 
   // 15.5.5.1
   ecma_string_t *length_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
@@ -170,7 +170,7 @@ ecma_op_string_object_get_own_property (ecma_object_t *obj_p, /**< a String obje
   ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                    ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
   ecma_string_t *prim_value_str_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                                               prim_value_prop_p->v.internal_property.value);
+                                                               ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value);
 
   // 6.
   ecma_length_t length = ecma_string_get_length (prim_value_str_p);
@@ -237,7 +237,7 @@ ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p, /**< a String obj
   ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                    ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
   ecma_string_t *prim_value_str_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                                               prim_value_prop_p->v.internal_property.value);
+                                                               ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value);
 
   ecma_length_t length = ecma_string_get_length (prim_value_str_p);
 

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -157,7 +157,7 @@ opfunc_set_accessor (bool is_getter, /**< is getter accessor */
   ecma_string_t *accessor_name_p = ecma_get_string_from_value (accessor_name);
   ecma_property_t *property_p = ecma_find_named_property (object_p, accessor_name_p);
 
-  if (property_p != NULL && !(property_p->flags & ECMA_PROPERTY_FLAG_NAMEDACCESSOR))
+  if (property_p != NULL && ECMA_PROPERTY_GET_TYPE (property_p) != ECMA_PROPERTY_TYPE_NAMEDACCESSOR)
   {
     ecma_delete_property (object_p, property_p);
     property_p = NULL;

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1013,7 +1013,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
             property_p = ecma_find_named_property (object_p, prop_name_p);
           }
 
-          if (property_p != NULL && !(property_p->flags & ECMA_PROPERTY_FLAG_NAMEDDATA))
+          if (property_p != NULL && ECMA_PROPERTY_GET_TYPE (property_p) != ECMA_PROPERTY_TYPE_NAMEDDATA)
           {
             ecma_delete_property (object_p, property_p);
             property_p = NULL;


### PR DESCRIPTION
The patch itself seems a step back, but the primary aim is opening future
optimization opportunities. The list of changes follows:

 - Property is changed to be an abstract type, which has type, flags,
   and a value. It does not have a name anymore and property pointers
   cannot be compressed.
 - Full (32 bit) ecma values can be property values. This allows
   using non-compressed pointers for ecma values in the future.
 - The property chain is not restricted to the same item anymore,
   it can contain hash maps, arrays in the future.