### PR TITLE
Remove syscall trampolines from jerry-libc

### DIFF
--- a/jerry-libc/target/darwin/jerry-asm.S
+++ b/jerry-libc/target/darwin/jerry-asm.S
@@ -12,20 +12,20 @@
 _start:
   _START
 
-.global syscall_0_asm
-syscall_0_asm:
+.global syscall_0
+syscall_0:
   SYSCALL_0
 
-.global syscall_1_asm
-syscall_1_asm:
+.global syscall_1
+syscall_1:
   SYSCALL_1
 
-.global syscall_2_asm
-syscall_2_asm:
+.global syscall_2
+syscall_2:
   SYSCALL_2
 
-.global syscall_3_asm
-syscall_3_asm:
+.global syscall_3
+syscall_3:
   SYSCALL_3
 
 /**

--- a/jerry-libc/target/darwin/jerry-libc-target.c
+++ b/jerry-libc/target/darwin/jerry-libc-target.c
@@ -33,65 +33,10 @@
 
 LIBC_UNREACHABLE_STUB_FOR (int raise (int sig_no __attr_unused___))
 
-static long int syscall_0 (long int syscall_no);
-static long int syscall_1 (long int syscall_no, long int arg1);
-static long int syscall_2 (long int syscall_no, long int arg1, long int arg2);
-static long int syscall_3 (long int syscall_no, long int arg1, long int arg2, long int arg3);
-
-extern long int syscall_0_asm (long int syscall_no);
-extern long int syscall_1_asm (long int syscall_no, long int arg1);
-extern long int syscall_2_asm (long int syscall_no, long int arg1, long int arg2);
-extern long int syscall_3_asm (long int syscall_no, long int arg1, long int arg2, long int arg3);
-
-/**
- * System call with no argument.
- *
- * @return syscall's return value
- */
-static __attr_noinline___ long int
-syscall_0 (long int syscall_no) /**< syscall number */
-{
-  return syscall_0_asm (syscall_no);
-} /* syscall_0 */
-
-/**
- * System call with one argument.
- *
- * @return syscall's return value
- */
-static __attr_noinline___ long int
-syscall_1 (long int syscall_no, /**< syscall number */
-           long int arg1) /**< argument */
-{
-  return syscall_1_asm (syscall_no, arg1);
-} /* syscall_1 */
-
-/**
- * System call with two arguments.
- *
- * @return syscall's return value
- */
-static __attr_noinline___ long int
-syscall_2 (long int syscall_no, /**< syscall number */
-           long int arg1, /**< first argument */
-           long int arg2) /**< second argument */
-{
-  return syscall_2_asm (syscall_no, arg1, arg2);
-} /* syscall_2 */
-
-/**
- * System call with three arguments.
- *
- * @return syscall's return value
- */
-static __attr_noinline___ long int
-syscall_3 (long int syscall_no, /**< syscall number */
-           long int arg1, /**< first argument */
-           long int arg2, /**< second argument */
-           long int arg3) /**< third argument */
-{
-  return syscall_3_asm (syscall_no, arg1, arg2, arg3);
-} /* syscall_3 */
+extern long int syscall_0 (long int syscall_no);
+extern long int syscall_1 (long int syscall_no, long int arg1);
+extern long int syscall_2 (long int syscall_no, long int arg1, long int arg2);
+extern long int syscall_3 (long int syscall_no, long int arg1, long int arg2, long int arg3);
 
 /** Output of character. Writes the character c, cast to an unsigned char, to stdout.  */
 int

--- a/jerry-libc/target/linux/jerry-asm.S
+++ b/jerry-libc/target/linux/jerry-asm.S
@@ -14,29 +14,29 @@ _start:
   _START
 .size _start, . - _start
 
-.global syscall_0_asm
-.type syscall_0_asm, %function
-syscall_0_asm:
+.global syscall_0
+.type syscall_0, %function
+syscall_0:
   SYSCALL_0
-.size syscall_0_asm, . - syscall_0_asm
+.size syscall_0, . - syscall_0
 
-.global syscall_1_asm
-.type syscall_1_asm, %function
-syscall_1_asm:
+.global syscall_1
+.type syscall_1, %function
+syscall_1:
   SYSCALL_1
-.size syscall_1_asm, . - syscall_1_asm
+.size syscall_1, . - syscall_1
 
-.global syscall_2_asm
-.type syscall_2_asm, %function
-syscall_2_asm:
+.global syscall_2
+.type syscall_2, %function
+syscall_2:
   SYSCALL_2
-.size syscall_2_asm, . - syscall_2_asm
+.size syscall_2, . - syscall_2
 
-.global syscall_3_asm
-.type syscall_3_asm, %function
-syscall_3_asm:
+.global syscall_3
+.type syscall_3, %function
+syscall_3:
   SYSCALL_3
-.size syscall_3_asm, . - syscall_3_asm
+.size syscall_3, . - syscall_3
 
 /**
  * setjmp (jmp_buf env)

--- a/jerry-libc/target/linux/jerry-libc-target.c
+++ b/jerry-libc/target/linux/jerry-libc-target.c
@@ -33,65 +33,10 @@
 
 LIBC_UNREACHABLE_STUB_FOR (int raise (int sig_no __attr_unused___))
 
-static long int syscall_0 (long int syscall_no);
-static long int syscall_1 (long int syscall_no, long int arg1);
-static long int syscall_2 (long int syscall_no, long int arg1, long int arg2);
-static long int syscall_3 (long int syscall_no, long int arg1, long int arg2, long int arg3);
-
-extern long int syscall_0_asm (long int syscall_no);
-extern long int syscall_1_asm (long int syscall_no, long int arg1);
-extern long int syscall_2_asm (long int syscall_no, long int arg1, long int arg2);
-extern long int syscall_3_asm (long int syscall_no, long int arg1, long int arg2, long int arg3);
-
-/**
- * System call with no argument.
- *
- * @return syscall's return value
- */
-static __attr_noinline___ long int
-syscall_0 (long int syscall_no) /**< syscall number */
-{
-  return syscall_0_asm (syscall_no);
-} /* syscall_0 */
-
-/**
- * System call with one argument.
- *
- * @return syscall's return value
- */
-static __attr_noinline___ long int
-syscall_1 (long int syscall_no, /**< syscall number */
-           long int arg1) /**< argument */
-{
-  return syscall_1_asm (syscall_no, arg1);
-} /* syscall_1 */
-
-/**
- * System call with two arguments.
- *
- * @return syscall's return value
- */
-static __attr_noinline___ long int
-syscall_2 (long int syscall_no, /**< syscall number */
-           long int arg1, /**< first argument */
-           long int arg2) /**< second argument */
-{
-  return syscall_2_asm (syscall_no, arg1, arg2);
-} /* syscall_2 */
-
-/**
- * System call with three arguments.
- *
- * @return syscall's return value
- */
-static __attr_noinline___ long int
-syscall_3 (long int syscall_no, /**< syscall number */
-           long int arg1, /**< first argument */
-           long int arg2, /**< second argument */
-           long int arg3) /**< third argument */
-{
-  return syscall_3_asm (syscall_no, arg1, arg2, arg3);
-} /* syscall_3 */
+extern long int syscall_0 (long int syscall_no);
+extern long int syscall_1 (long int syscall_no, long int arg1);
+extern long int syscall_2 (long int syscall_no, long int arg1, long int arg2);
+extern long int syscall_3 (long int syscall_no, long int arg1, long int arg2, long int arg3);
 
 /** Output of character. Writes the character c, cast to an unsigned char, to stdout.  */
 int


### PR DESCRIPTION
After recent changes to jerry-libc, `syscall_N` C functions became
pure trampolines to their appropriate `syscall_N_asm` counterparts
written in assembly. Removing the C functions and renaming the
assembly functions to take their place simplifies the code.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu