### PR TITLE
Implement `raise ()` in libc

### DIFF
--- a/jerry-libc/jerry-libc-defs.h
+++ b/jerry-libc/jerry-libc-defs.h
@@ -54,19 +54,4 @@ libc_fatal (const char *msg,
    } while (0)
 #endif /* !LIBC_NDEBUG */
 
-/**
- * Stubs declaration
- */
-
-/**
- * Unreachable stubs for routines that are never called,
- * but referenced from third-party libraries.
- */
-#define LIBC_UNREACHABLE_STUB_FOR(...) \
-extern __VA_ARGS__; \
-__attr_used___ __VA_ARGS__ \
-{ \
-  LIBC_UNREACHABLE (); \
-}
-
 #endif /* !DEFS_H */

--- a/jerry-libc/target/darwin/jerry-libc-target.c
+++ b/jerry-libc/target/darwin/jerry-libc-target.c
@@ -31,8 +31,6 @@
 
 #include "jerry-libc-defs.h"
 
-LIBC_UNREACHABLE_STUB_FOR (int raise (int sig_no __attr_unused___))
-
 extern long int syscall_0 (long int syscall_no);
 extern long int syscall_1 (long int syscall_no, long int arg1);
 extern long int syscall_2 (long int syscall_no, long int arg1, long int arg2);
@@ -92,13 +90,22 @@ abort (void)
   syscall_1 (SYS_close, (long int) stdout);
   syscall_1 (SYS_close, (long int) stderr);
 
-  syscall_2 (SYS_kill, syscall_0 (SYS_getpid), SIGABRT);
+  raise (SIGABRT);
 
   while (true)
   {
     /* unreachable */
   }
 } /* abort */
+
+/**
+ * Send a signal to the current process.
+ */
+int __attr_used___
+raise (int sig)
+{
+  return (int) syscall_2 (SYS_kill, syscall_0 (SYS_getpid), sig);
+} /* raise */
 
 /**
  * fopen

--- a/jerry-libc/target/linux/jerry-libc-target.c
+++ b/jerry-libc/target/linux/jerry-libc-target.c
@@ -31,8 +31,6 @@
 
 #include "jerry-libc-defs.h"
 
-LIBC_UNREACHABLE_STUB_FOR (int raise (int sig_no __attr_unused___))
-
 extern long int syscall_0 (long int syscall_no);
 extern long int syscall_1 (long int syscall_no, long int arg1);
 extern long int syscall_2 (long int syscall_no, long int arg1, long int arg2);
@@ -92,13 +90,22 @@ abort (void)
   syscall_1 (__NR_close, (long int) stdout);
   syscall_1 (__NR_close, (long int) stderr);
 
-  syscall_2 (__NR_kill, syscall_0 (__NR_getpid), SIGABRT);
+  raise (SIGABRT);
 
   while (true)
   {
     /* unreachable */
   }
 } /* abort */
+
+/**
+ * Send a signal to the current process.
+ */
+int __attr_used___
+raise (int sig)
+{
+  return (int) syscall_2 (__NR_kill, syscall_0 (__NR_getpid), sig);
+} /* raise */
 
 /**
  * fopen


### PR DESCRIPTION
It is used for defining an asserting stub for the function `raise`
only, which is not used anywhere.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu