### PR TITLE
Refactor ecma value to store pointers directly in ecma values rather than compressing them.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -58,7 +58,8 @@ typedef enum
   ECMA_TYPE_SIMPLE, /**< simple value */
   ECMA_TYPE_NUMBER, /**< 64-bit integer */
   ECMA_TYPE_STRING, /**< pointer to description of a string */
-  ECMA_TYPE_OBJECT /**< pointer to description of an object */
+  ECMA_TYPE_OBJECT, /**< pointer to description of an object */
+  ECMA_TYPE___MAX = ECMA_TYPE_OBJECT /** highest value for ecma types */
 } ecma_type_t;
 
 /**
@@ -85,34 +86,33 @@ typedef enum
 /**
  * Description of an ecma value
  *
- * Bit-field structure: type (2) | error (1) | value (ECMA_POINTER_FIELD_WIDTH)
+ * Bit-field structure: type (2) | error (1) | value (29)
  */
 typedef uint32_t ecma_value_t;
 
-/**
- * Value type (ecma_type_t)
- */
-#define ECMA_VALUE_TYPE_POS (0)
-#define ECMA_VALUE_TYPE_WIDTH (2)
+#if UINTPTR_MAX <= UINT32_MAX
 
 /**
- * Value is error (boolean)
+ * MEM_ALIGNMENT_LOG aligned pointers can be stored directly in ecma_value_t
  */
-#define ECMA_VALUE_ERROR_POS (ECMA_VALUE_TYPE_POS + \
-                              ECMA_VALUE_TYPE_WIDTH)
-#define ECMA_VALUE_ERROR_WIDTH (1)
+#define ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY
+
+#endif /* UINTPTR_MAX <= UINT32_MAX */
 
 /**
- * Simple value (ecma_simple_value_t) or compressed pointer to value (depending on value_type)
+ * Mask for ecma types in ecma_type_t
  */
-#define ECMA_VALUE_VALUE_POS (ECMA_VALUE_ERROR_POS + \
-                              ECMA_VALUE_ERROR_WIDTH)
-#define ECMA_VALUE_VALUE_WIDTH (ECMA_POINTER_FIELD_WIDTH)
+#define ECMA_VALUE_TYPE_MASK 0x3u
 
 /**
- * Size of ecma value description, in bits
+ * Error flag in ecma_type_t
  */
-#define ECMA_VALUE_SIZE (ECMA_VALUE_VALUE_POS + ECMA_VALUE_VALUE_WIDTH)
+#define ECMA_VALUE_ERROR_FLAG 0x4u
+
+/**
+ * Shift for value part in ecma_type_t
+ */
+#define ECMA_VALUE_SHIFT 3
 
 /**
  * Internal properties' identifiers.

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -83,8 +83,6 @@
   }
 
 /* ecma-helpers-value.c */
-extern ecma_type_t ecma_get_value_type_field (ecma_value_t) __attr_pure___;
-
 extern bool ecma_is_value_empty (ecma_value_t);
 extern bool ecma_is_value_undefined (ecma_value_t);
 extern bool ecma_is_value_null (ecma_value_t);

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -1766,7 +1766,7 @@ jerry_run (jerry_api_value_t *error_value_p) /**< [out] error value */
   ecma_value_t error_value;
   jerry_completion_code_t ret_code = vm_run_global (&error_value);
 
-  error_value &= ~(1u << ECMA_VALUE_ERROR_POS);
+  error_value &= ~ECMA_VALUE_ERROR_FLAG;
   jerry_api_convert_ecma_value_to_api_value (error_value_p, error_value);
   ecma_free_value (error_value);
 
@@ -2385,7 +2385,7 @@ jerry_exec_snapshot (const void *snapshot_p, /**< snapshot */
     if (ret_code == JERRY_COMPLETION_CODE_UNHANDLED_EXCEPTION)
     {
       JERRY_ASSERT (ecma_is_value_error (error_value));
-      error_value = error_value & ~(1u << ECMA_VALUE_ERROR_POS);
+      error_value = error_value & ~ECMA_VALUE_ERROR_FLAG;
       ecma_free_value (error_value);
     }
     else


### PR DESCRIPTION
Ecma value is 32 bit long, and only 3 bits are used for type and flags. The rest is enough for encoding 8 byte aligned pointers without compressing them.