### PR TITLE
Remove the unused LIT_STRING_HASH_LAST_BYTES_COUNT define macro

### DIFF
--- a/jerry-core/lit/lit-globals.h
+++ b/jerry-core/lit/lit-globals.h
@@ -133,9 +133,4 @@ typedef uint8_t lit_string_hash_t;
  */
 #define LIT_STRING_HASH_BITS (sizeof (lit_string_hash_t) * JERRY_BITSINBYTE)
 
-/**
- * Number of string's last characters to use for hash calculation
- */
-#define LIT_STRING_HASH_LAST_BYTES_COUNT (2)
-
 #endif /* !LIT_GLOBALS_H */


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Robert Sipka rsipka.uszeged@partner.samsung.com