### PR TITLE
Update existing and add missing copyright & license notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014-2015 Samsung Electronics Co., Ltd.
+Copyright 2014-2016 Samsung Electronics Co., Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/jerry-libc/target/posix/jerry-asm.S
+++ b/jerry-libc/target/posix/jerry-asm.S
@@ -1,3 +1,19 @@
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ * Copyright 2015-2016 University of Szeged
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #if defined (__TARGET_HOST_x64)
 #include "arch/x86-64.h"
 #elif defined (__TARGET_HOST_x86)

--- a/tests/jerry/fail/1/throw-error-object.js
+++ b/tests/jerry/fail/1/throw-error-object.js
@@ -1,1 +1,16 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright 2016 University of Szeged
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 throw new SyntaxError("error");

--- a/tests/jerry/fail/1/throw-number.js
+++ b/tests/jerry/fail/1/throw-number.js
@@ -1,1 +1,16 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright 2016 University of Szeged
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 throw 0.1234;

--- a/tests/jerry/fail/1/throw-string.js
+++ b/tests/jerry/fail/1/throw-string.js
@@ -1,1 +1,16 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright 2016 University of Szeged
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 throw "SyntaxError"


### PR DESCRIPTION
* LICENSE needed year update.

* The asm component of the posix target of jerry-libc had no
  copyright & license notice since it has been introduced in 2015.
  Traced back history and added missing header with correct years.

* Three tests in jerry/fail/1 also missed header. Added.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu