### PR TITLE
Don't use pointer compression where the ecma_value can store pointer …

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -316,7 +316,7 @@ ecma_gc_mark_property (ecma_property_t *property_p) /**< property */
         case ECMA_INTERNAL_PROPERTY_SCOPE: /* a lexical environment */
         case ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP: /* an object */
         {
-          ecma_object_t *obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, property_value);
+          ecma_object_t *obj_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t, property_value);
 
           ecma_gc_set_object_visited (obj_p, true);
 

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -71,6 +71,37 @@
     utf8_ptr ## must_be_freed = true; \
   }
 
+#ifdef ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY
+
+/**
+ * Set an internal property value of pointer
+ */
+#define ECMA_SET_INTERNAL_VALUE_POINTER(field, pointer) \
+  (field) = ((ecma_value_t) pointer)
+
+/**
+ * Get an internal property value of pointer
+ */
+#define ECMA_GET_INTERNAL_VALUE_POINTER(type, field) \
+  ((type *) field)
+
+#else /* !ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY */
+
+/**
+ * Set an internal property value of non-null pointer so that it will correspond
+ * to specified non_compressed_pointer.
+ */
+#define ECMA_SET_INTERNAL_VALUE_POINTER(field, non_compressed_pointer) \
+  ECMA_SET_NON_NULL_POINTER (field, non_compressed_pointer)
+
+/**
+ * Get an internal property value of pointer from specified non-null compressed pointer.
+ */
+#define ECMA_GET_INTERNAL_VALUE_POINTER(type, field) \
+  ECMA_GET_NON_NULL_POINTER (type, field)
+
+#endif /* ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY */
+
 /**
  * Free the cesu-8 string buffer allocated by 'ECMA_STRING_TO_UTF8_STRING'
  */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -247,7 +247,7 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
                                                             ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
     ecma_object_t *this_arg_obj_p = ecma_get_object_from_value (this_arg);
-    ECMA_SET_NON_NULL_POINTER (ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value, this_arg_obj_p);
+    ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value, this_arg_obj_p);
 
     /* 8. */
     ecma_property_t *bound_this_prop_p;

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -168,7 +168,7 @@ ecma_op_create_function_object (ecma_object_t *scope_p, /**< function's scope */
 
   // 9.
   ecma_property_t *scope_prop_p = ecma_create_internal_property (f, ECMA_INTERNAL_PROPERTY_SCOPE);
-  ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value, scope_p);
+  ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value, scope_p);
 
   // 10., 11., 12.
   ecma_property_t *bytecode_prop_p = ecma_create_internal_property (f, ECMA_INTERNAL_PROPERTY_CODE_BYTECODE);
@@ -529,8 +529,8 @@ ecma_op_function_has_instance (ecma_object_t *func_obj_p, /**< Function object *
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
     ecma_object_t *target_func_obj_p;
-    target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                   ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
+    target_func_obj_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
+                                                         ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
 
     /* 3. */
     ret_value = ecma_op_object_has_instance (target_func_obj_p, value);
@@ -576,8 +576,8 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       ecma_property_t *scope_prop_p = ecma_get_internal_property (func_obj_p, ECMA_INTERNAL_PROPERTY_SCOPE);
       ecma_property_t *bytecode_prop_p = ecma_get_internal_property (func_obj_p, ECMA_INTERNAL_PROPERTY_CODE_BYTECODE);
 
-      ecma_object_t *scope_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                          ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value);
+      ecma_object_t *scope_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
+                                                                ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value);
 
       // 8.
       ecma_value_t this_binding;
@@ -685,8 +685,8 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
     ecma_object_t *target_func_obj_p;
-    target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                   ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
+    target_func_obj_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
+                                                         ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
 
     /* 4. */
     ecma_property_t *bound_args_prop_p;
@@ -870,8 +870,8 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
     ecma_object_t *target_func_obj_p;
-    target_func_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                   ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
+    target_func_obj_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
+                                                         ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
 
     /* 2. */
     if (!ecma_is_constructor (ecma_make_object_value (target_func_obj_p)))

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -174,11 +174,11 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
 
       ecma_property_t *parameters_map_prop_p = ecma_create_internal_property (obj_p,
                                                                               ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
-      ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (parameters_map_prop_p)->value, map_p);
+      ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (parameters_map_prop_p)->value, map_p);
 
       ecma_property_t *scope_prop_p = ecma_create_internal_property (map_p,
                                                                      ECMA_INTERNAL_PROPERTY_SCOPE);
-      ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value, lex_env_p);
+      ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value, lex_env_p);
 
       ecma_deref_object (map_p);
     }
@@ -285,8 +285,8 @@ ecma_arguments_get_mapped_arg_value (ecma_object_t *map_p, /**< [[ParametersMap]
                                                                             equal to mapped argument's name */
 {
   ecma_property_t *scope_prop_p = ecma_get_internal_property (map_p, ECMA_INTERNAL_PROPERTY_SCOPE);
-  ecma_object_t *lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                        ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value);
+  ecma_object_t *lex_env_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
+                                                              ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value);
   JERRY_ASSERT (lex_env_p != NULL
                 && ecma_is_lexical_environment (lex_env_p));
 
@@ -316,8 +316,8 @@ ecma_op_arguments_object_get (ecma_object_t *obj_p, /**< the object */
 {
   // 1.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
-  ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
+  ecma_object_t *map_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
+                                                          ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
 
   // 2.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
@@ -362,8 +362,8 @@ ecma_op_arguments_object_get_own_property (ecma_object_t *obj_p, /**< the object
 
   // 3.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
-  ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
+  ecma_object_t *map_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
+                                                          ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
 
   // 4.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
@@ -402,8 +402,7 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the obj
 {
   // 1.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
-  ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
+  ecma_object_t *map_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t, ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
 
   // 2.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
@@ -443,8 +442,8 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *obj_p, /**< the obj
       {
         /* emulating execution of function described by MakeArgSetter */
         ecma_property_t *scope_prop_p = ecma_get_internal_property (map_p, ECMA_INTERNAL_PROPERTY_SCOPE);
-        ecma_object_t *lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                              ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value);
+        ecma_object_t *lex_env_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
+                                                                   ECMA_PROPERTY_VALUE_PTR (scope_prop_p)->value);
 
         ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);
         ecma_value_t arg_name_prop_value = ecma_get_named_data_property_value (mapped_prop_p);
@@ -500,8 +499,7 @@ ecma_op_arguments_object_delete (ecma_object_t *obj_p, /**< the object */
 {
   // 1.
   ecma_property_t *map_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
-  ecma_object_t *map_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
-                                                    ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
+  ecma_object_t *map_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t, ECMA_PROPERTY_VALUE_PTR (map_prop_p)->value);
 
   // 2.
   ecma_property_t *mapped_prop_p = ecma_op_object_get_own_property (map_p, property_name_p);


### PR DESCRIPTION
…value directly.

This changes affects those internal properties where the property value type is an ecma_object_t ptr.

JerryScript-DCO-1.0-Signed-off-by: Robert Sipka rsipka.uszeged@partner.samsung.com