### PR TITLE
Store aligned pointers directly in ecma_value_t if it is possible.

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -816,8 +816,7 @@ ecma_free_internal_property (ecma_property_t *property_p) /**< the property */
 
     case ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE: /* compressed pointer to a ecma_string_t */
     {
-      ecma_string_t *str_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                                        property_value);
+      ecma_string_t *str_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_string_t, property_value);
       ecma_deref_ecma_string (str_p);
 
       break;
@@ -825,8 +824,7 @@ ecma_free_internal_property (ecma_property_t *property_p) /**< the property */
 
     case ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE: /* pointer to a ecma_number_t */
     {
-      ecma_number_t *num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                        property_value);
+      ecma_number_t *num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t, property_value);
       ecma_dealloc_number (num_p);
 
       break;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -107,8 +107,8 @@ ecma_builtin_date_prototype_to_date_string (ecma_value_t this_arg) /**< this arg
     ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
     ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
                                                                ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-    ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                 ecma_get_internal_property_value (prim_prop_p));
+    ecma_number_t *prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
+                                                                       ecma_get_internal_property_value (prim_prop_p));
 
     if (ecma_number_is_nan (*prim_value_num_p))
     {
@@ -154,8 +154,8 @@ ecma_builtin_date_prototype_to_time_string (ecma_value_t this_arg) /**< this arg
     ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
     ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
                                                                ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-    ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                 ecma_get_internal_property_value (prim_prop_p));
+    ecma_number_t *prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
+                                                                       ecma_get_internal_property_value (prim_prop_p));
 
     if (ecma_number_is_nan (*prim_value_num_p))
     {
@@ -253,8 +253,9 @@ ecma_builtin_date_prototype_get_time (ecma_value_t this_arg) /**< this argument 
       ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
                                                                  ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
-      ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                   ecma_get_internal_property_value (prim_prop_p));
+      ecma_number_t *prim_value_num_p;
+      prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
+                                                          ecma_get_internal_property_value (prim_prop_p));
 
       ecma_number_t *ret_num_p = ecma_alloc_number ();
       *ret_num_p = *prim_value_num_p;
@@ -366,8 +367,8 @@ ecma_builtin_date_prototype_set_time (ecma_value_t this_arg, /**< this argument 
     ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
                                                                ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
-    ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                                 ecma_get_internal_property_value (prim_prop_p));
+    ecma_number_t *prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
+                                                                       ecma_get_internal_property_value (prim_prop_p));
     *prim_value_num_p = *value_p;
 
     /* 3. */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -569,7 +569,7 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
 
     ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                         ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-    ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_value_num_p);
+    ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_value_num_p);
 
     ret_value = ecma_make_object_value (obj_p);
   }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -902,8 +902,9 @@ ecma_date_set_internal_property (ecma_value_t this_arg, /**< this argument */
   ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                    ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
-  ecma_number_t *prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                               ecma_get_internal_property_value (prim_value_prop_p));
+  ecma_number_t *prim_value_num_p;
+  prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
+                                                      ecma_get_internal_property_value (prim_value_prop_p));
   *prim_value_num_p = *value_p;
 
   return ecma_make_number_value (value_p);
@@ -1306,8 +1307,8 @@ ecma_date_get_primitive_value (ecma_value_t this_arg) /**< this argument */
     JERRY_ASSERT (prim_value_prop_p != NULL);
 
     ecma_number_t *prim_value_num_p = ecma_alloc_number ();
-    *prim_value_num_p = *ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                    ecma_get_internal_property_value (prim_value_prop_p));
+    *prim_value_num_p = *ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
+                                                          ecma_get_internal_property_value (prim_value_prop_p));
     ret_value = ecma_make_number_value (prim_value_num_p);
   }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -359,8 +359,8 @@ ecma_builtin_number_prototype_object_value_of (ecma_value_t this_arg) /**< this 
                                                                        ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
 
       ecma_number_t *prim_value_num_p;
-      prim_value_num_p = ECMA_GET_NON_NULL_POINTER (ecma_number_t,
-                                                    ecma_get_internal_property_value (prim_value_prop_p));
+      prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
+                                                          ecma_get_internal_property_value (prim_value_prop_p));
 
       ecma_number_t *ret_num_p = ecma_alloc_number ();
       *ret_num_p = *prim_value_num_p;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -80,8 +80,8 @@ ecma_builtin_string_prototype_object_to_string (ecma_value_t this_arg) /**< this
                                                                        ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
 
       ecma_string_t *prim_value_str_p;
-      prim_value_str_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                                    ecma_get_internal_property_value (prim_value_prop_p));
+      prim_value_str_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_string_t,
+                                                          ecma_get_internal_property_value (prim_value_prop_p));
 
       prim_value_str_p = ecma_copy_or_ref_ecma_string (prim_value_str_p);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -126,7 +126,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *prim_value_prop_p;
       prim_value_prop_p = ecma_create_internal_property (object_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
-      ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_str_value_p);
+      ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_str_value_p);
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_STRING_BUILTIN */
@@ -140,7 +140,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *prim_value_prop_p;
       prim_value_prop_p = ecma_create_internal_property (object_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-      ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_num_value_p);
+      ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_num_value_p);
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_NUMBER_BUILTIN */
@@ -165,7 +165,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_property_t *prim_value_prop_p;
       prim_value_prop_p = ecma_create_internal_property (object_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-      ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_num_value_p);
+      ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_num_value_p);
       break;
     }
 #endif /* !CONFIG_ECMA_COMPACT_PROFILE_DISABLE_DATE_BUILTIN */

--- a/jerry-core/ecma/operations/ecma-number-object.c
+++ b/jerry-core/ecma/operations/ecma-number-object.c
@@ -66,7 +66,7 @@ ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Numb
 
   ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
-  ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_value_p);
+  ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_value_p);
 
   return ecma_make_object_value (obj_p);
 } /* ecma_op_create_number_object */

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -95,7 +95,7 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
 
   ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
-  ECMA_SET_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_str_value_p);
+  ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_str_value_p);
 
   // 15.5.5.1
   ecma_string_t *length_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
@@ -169,8 +169,9 @@ ecma_op_string_object_get_own_property (ecma_object_t *obj_p, /**< a String obje
   // 4.
   ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                    ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
-  ecma_string_t *prim_value_str_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                                               ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value);
+  ecma_string_t *prim_value_str_p;
+  prim_value_str_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_string_t,
+                                                      ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value);
 
   // 6.
   ecma_length_t length = ecma_string_get_length (prim_value_str_p);
@@ -236,8 +237,9 @@ ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p, /**< a String obj
 
   ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                    ECMA_INTERNAL_PROPERTY_PRIMITIVE_STRING_VALUE);
-  ecma_string_t *prim_value_str_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                                               ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value);
+  ecma_string_t *prim_value_str_p;
+  prim_value_str_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_string_t,
+                                                      ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value);
 
   ecma_length_t length = ecma_string_get_length (prim_value_str_p);
 


### PR DESCRIPTION
This change affects only those internal properties which have a primitive value field.

JerryScript-DCO-1.0-Signed-off-by: Robert Sipka rsipka.uszeged@partner.samsung.com