### PR TITLE
Drop jerry_port_putchar

### DIFF
--- a/jerry-core/jerry-port.h
+++ b/jerry-core/jerry-port.h
@@ -34,7 +34,6 @@ extern "C"
  */
 int jerry_port_logmsg (FILE *stream, const char *format, ...);
 int jerry_port_errormsg (const char *format, ...);
-int jerry_port_putchar (int c);
 
 /*
  * Termination Port API

--- a/jerry-libc/include/stdio.h
+++ b/jerry-libc/include/stdio.h
@@ -48,7 +48,6 @@ extern FILE *stderr;
  * I/O routines
  */
 int vfprintf (FILE *stream, const char *format, va_list ap);
-int puts (const char *s);
 FILE *fopen (const char *path, const char *mode);
 int fclose (FILE *fp);
 size_t fread (void *ptr, size_t size, size_t nmemb, FILE *stream);
@@ -58,7 +57,6 @@ long ftell (FILE *stream);
 int printf (const char *format, ...);
 void rewind (FILE *stream);
 int fprintf (FILE *stream, const char *format, ...);
-int putchar (int c);
 
 #ifdef __cplusplus
 }

--- a/jerry-libc/target/mcu-stubs/jerry-libc-target.c
+++ b/jerry-libc/target/mcu-stubs/jerry-libc-target.c
@@ -24,13 +24,6 @@
 
 #include "jerry-libc-defs.h"
 
-/** Output of character. Writes the character c, cast to an unsigned char, to stdout.  */
-int
-putchar (int c __attr_unused___)
-{
-  return 1;
-} /* putchar */
-
 /** exit - cause normal process termination  */
 void __attr_noreturn___ __attr_used___
 exit (int status __attr_unused___)

--- a/jerry-libc/target/posix/jerry-libc-target.c
+++ b/jerry-libc/target/posix/jerry-libc-target.c
@@ -46,31 +46,6 @@ extern long int syscall_1 (long int syscall_no, long int arg1);
 extern long int syscall_2 (long int syscall_no, long int arg1, long int arg2);
 extern long int syscall_3 (long int syscall_no, long int arg1, long int arg2, long int arg3);
 
-/** Output of character. Writes the character c, cast to an unsigned char, to stdout.  */
-int
-putchar (int c)
-{
-  fwrite (&c, 1, sizeof (char), stdout);
-
-  return c;
-} /* putchar */
-
-/**
- * Output specified string
- */
-int
-puts (const char *s) /**< string to print */
-{
-  while (*s)
-  {
-    putchar (*s);
-
-    s++;
-  }
-
-  return 0;
-} /* puts */
-
 /**
  * Exit - cause normal process termination with specified status code
  */

--- a/targets/default/jerry-port-default-io.c
+++ b/targets/default/jerry-port-default-io.c
@@ -45,11 +45,3 @@ int jerry_port_errormsg (const char *format, /**< format string */
   va_end (args);
   return count;
 } /* jerry_port_errormsg */
-
-/**
- * Provide output character to console implementation for the engine.
- */
-int jerry_port_putchar (int c) /**< character to put */
-{
-  return putchar ((unsigned char) c);
-} /* jerry_port_putchar */

--- a/targets/esp8266/user/jerry_port.c
+++ b/targets/esp8266/user/jerry_port.c
@@ -46,16 +46,6 @@ int jerry_port_errormsg (const char* format, ...)
   return count;
 }
 
-/**
- * Provide output character to console implementation for the engine.
- */
-int jerry_port_putchar (int c)
-{
-  printf ("%c", (char)c);
-  return c;
-}
-
-
 void exit (int status)
 {
   printf ("!!!! EXIT: %d\n", status);

--- a/targets/mbedk64f/source/jerry_port.c
+++ b/targets/mbedk64f/source/jerry_port.c
@@ -43,11 +43,3 @@ int jerry_port_errormsg (const char* format, ...)
   va_end (args);
   return count;
 }
-
-/**
- * Provide output character to console implementation for the engine.
- */
-int jerry_port_putchar (int c)
-{
-  return putchar(c);
-}

--- a/targets/nuttx-stm32f4/main-nuttx.c
+++ b/targets/nuttx-stm32f4/main-nuttx.c
@@ -276,11 +276,3 @@ int jerry_port_errormsg (const char* format, ...)
   va_end (args);
   return count;
 }
-
-/**
- * Provide output character to console implementation for the engine.
- */
-int jerry_port_putchar (int c)
-{
-  return putchar(c);
-}


### PR DESCRIPTION
Recent changes eliminate the need for `jerry_port_putchar`. As port
API discussions don't make it likely that it will ever be needed
again, this patch removes its declaration from jerry-port.h and its
implementations from the port(s).

The related code in jerry-libc is not needed either: whatever `putc`
(and `puts`) can do, `printf` can do as well.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu