### PR TITLE
Force enums in snapshots to be 32bits wide

### DIFF
--- a/jerry-core/lit/lit-literal-storage.h
+++ b/jerry-core/lit/lit-literal-storage.h
@@ -30,7 +30,8 @@ typedef enum
   LIT_RECORD_TYPE_CHARSET = 1, /**< Charset record that holds characters. */
   LIT_RECORD_TYPE_MAGIC_STR = 2, /**< Magic string record that holds a magic string id. */
   LIT_RECORD_TYPE_MAGIC_STR_EX = 3, /**< External magic string record that holds an extrernal magic string id. */
-  LIT_RECORD_TYPE_NUMBER = 4 /**< Number record that holds a numeric value. */
+  LIT_RECORD_TYPE_NUMBER = 4, /**< Number record that holds a numeric value. */
+  LIT_RECORD_TYPE__FORCE_LARGE = INT32_MAX,
 } lit_record_type_t;
 
 /**

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -33,7 +33,8 @@ typedef enum
 #include "lit-magic-strings.inc.h"
 #undef LIT_MAGIC_STRING_DEF
 
-  LIT_MAGIC_STRING__COUNT /**< number of magic strings */
+  LIT_MAGIC_STRING__COUNT, /**< number of magic strings */
+  LIT_MAGIC_STRING__FORCE_LARGE = INT32_MAX,
 } lit_magic_string_id_t;
 
 /**


### PR DESCRIPTION
Assumptions are hard-coded elsewhere that require these enums to be 32 bits in size, yet it isn't enforced and some compilers will shorten them.

JerryScript-DCO-1.0-Signed-off-by: François Baldassari <francois@pebble.com>