### PR TITLE
Add context support for memory allocator

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -105,16 +105,16 @@ project (JerryCore C ASM)
 # Include directories
  set(INCLUDE_CORE
      ${CMAKE_SOURCE_DIR}/jerry-core
-     ${CMAKE_SOURCE_DIR}/jerry-core/lit
-     ${CMAKE_SOURCE_DIR}/jerry-core/rcs
-     ${CMAKE_SOURCE_DIR}/jerry-core/jmem
-     ${CMAKE_SOURCE_DIR}/jerry-core/vm
-     ${CMAKE_SOURCE_DIR}/jerry-core/ecma/builtin-objects
      ${CMAKE_SOURCE_DIR}/jerry-core/ecma/base
+     ${CMAKE_SOURCE_DIR}/jerry-core/ecma/builtin-objects
      ${CMAKE_SOURCE_DIR}/jerry-core/ecma/operations
+     ${CMAKE_SOURCE_DIR}/jerry-core/jcontext
+     ${CMAKE_SOURCE_DIR}/jerry-core/jmem
+     ${CMAKE_SOURCE_DIR}/jerry-core/jrt
+     ${CMAKE_SOURCE_DIR}/jerry-core/lit
      ${CMAKE_SOURCE_DIR}/jerry-core/parser/js
      ${CMAKE_SOURCE_DIR}/jerry-core/parser/regexp
-     ${CMAKE_SOURCE_DIR}/jerry-core/jrt)
+     ${CMAKE_SOURCE_DIR}/jerry-core/vm)
 
  # Third-party
   # Valgrind
@@ -123,29 +123,29 @@ project (JerryCore C ASM)
 # Sources
  # Jerry core
   file(GLOB SOURCE_CORE_API                   *.c)
-  file(GLOB SOURCE_CORE_LIT                   lit/*.c)
-  file(GLOB SOURCE_CORE_RCS                   rcs/*.c)
-  file(GLOB SOURCE_CORE_MEM                   jmem/*.c)
-  file(GLOB SOURCE_CORE_VM                    vm/*.c)
-  file(GLOB SOURCE_CORE_ECMA_BUILTINS         ecma/builtin-objects/*.c)
   file(GLOB SOURCE_CORE_ECMA_BASE             ecma/base/*.c)
+  file(GLOB SOURCE_CORE_ECMA_BUILTINS         ecma/builtin-objects/*.c)
   file(GLOB SOURCE_CORE_ECMA_OPERATIONS       ecma/operations/*.c)
+  file(GLOB SOURCE_CORE_JCONTEXT              jcontext/*.c)
+  file(GLOB SOURCE_CORE_JMEM                  jmem/*.c)
+  file(GLOB SOURCE_CORE_JRT                   jrt/*.c)
+  file(GLOB SOURCE_CORE_LIT                   lit/*.c)
   file(GLOB SOURCE_CORE_PARSER_JS             parser/js/*.c)
   file(GLOB SOURCE_CORE_PARSER_REGEXP         parser/regexp/*.c)
-  file(GLOB SOURCE_CORE_JRT                   jrt/*.c)
+  file(GLOB SOURCE_CORE_VM                    vm/*.c)
 
   set(SOURCE_CORE_FILES
       ${SOURCE_CORE_API}
-      ${SOURCE_CORE_LIT}
-      ${SOURCE_CORE_RCS}
-      ${SOURCE_CORE_MEM}
-      ${SOURCE_CORE_VM}
-      ${SOURCE_CORE_ECMA_BUILTINS}
       ${SOURCE_CORE_ECMA_BASE}
+      ${SOURCE_CORE_ECMA_BUILTINS}
       ${SOURCE_CORE_ECMA_OPERATIONS}
+      ${SOURCE_CORE_JCONTEXT}
+      ${SOURCE_CORE_JMEM}
+      ${SOURCE_CORE_JRT}
+      ${SOURCE_CORE_LIT}
       ${SOURCE_CORE_PARSER_JS}
       ${SOURCE_CORE_PARSER_REGEXP}
-      ${SOURCE_CORE_JRT})
+      ${SOURCE_CORE_VM})
 
  # Jerry port
  if(NOT ("${PORT_DIR}" STREQUAL ""))

--- a/jerry-core/jcontext/jcontext.c
+++ b/jerry-core/jcontext/jcontext.c
@@ -1,0 +1,48 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jcontext.h"
+
+/** \addtogroup context Jerry context
+ * @{
+ *
+ * \addtogroup context Context
+ * @{
+ */
+
+/**
+ * Global context.
+ */
+jerry_context_t jerry_global_context;
+
+/**
+ * Jerry global heap section attribute.
+ */
+#ifndef JERRY_HEAP_SECTION_ATTR
+#define JERRY_GLOBAL_HEAP_SECTION
+#else /* JERRY_HEAP_SECTION_ATTR */
+#define JERRY_GLOBAL_HEAP_SECTION __attribute__ ((section (JERRY_HEAP_SECTION_ATTR)))
+#endif /* !JERRY_HEAP_SECTION_ATTR */
+
+/**
+ * Global heap.
+ */
+jmem_heap_t jerry_global_heap __attribute__ ((aligned (JMEM_ALIGNMENT))) JERRY_GLOBAL_HEAP_SECTION;
+
+/**
+ * @}
+ * @}
+ */

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -1,0 +1,111 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Memory context for JerryScript
+ */
+#ifndef JCONTEXT_H
+#define JCONTEXT_H
+
+#include "jrt.h"
+#include "jmem-allocator.h"
+#include "jmem-config.h"
+
+/** \addtogroup context Jerry context
+ * @{
+ *
+ * \addtogroup context Context
+ * @{
+ */
+
+/**
+ * Calculate heap area size, leaving space for a pointer to the free list
+ */
+#define JMEM_HEAP_AREA_SIZE (JMEM_HEAP_SIZE - JMEM_ALIGNMENT)
+
+/**
+ * Heap structure
+ *
+ * Memory blocks returned by the allocator must not start from the
+ * beginning of the heap area because offset 0 is reserved for
+ * JMEM_CP_NULL. This special constant is used in several places,
+ * e.g. it marks the end of the property chain list, so it cannot
+ * be eliminated from the project. Although the allocator cannot
+ * use the first 8 bytes of the heap, nothing prevents to use it
+ * for other purposes. Currently the free region start is stored
+ * there.
+ */
+typedef struct
+{
+  jmem_heap_free_t first; /**< first node in free region list */
+  uint8_t area[JMEM_HEAP_AREA_SIZE]; /**< heap area */
+} jmem_heap_t;
+
+/**
+ * JerryScript context
+ *
+ * The purpose of this header is storing
+ * all global variables for Jerry
+ */
+typedef struct
+{
+  /**
+   * Memory manager part.
+   */
+  size_t jmem_heap_allocated_size; /**< size of allocated regions */
+  size_t jmem_heap_limit; /**< current limit of heap usage, that is upon being reached,
+                           *   causes call of "try give memory back" callbacks */
+  jmem_heap_free_t *jmem_heap_list_skip_p; /**< This is used to speed up deallocation. */
+  jmem_pools_chunk_t *jmem_free_chunk_p; /**< list of free pool chunks */
+  jmem_free_unused_memory_callback_t jmem_free_unused_memory_callback; /**< Callback for freeing up memory. */
+
+#ifdef JMEM_STATS
+  jmem_heap_stats_t jmem_heap_stats; /**< heap's memory usage statistics */
+  jmem_pools_stats_t jmem_pools_stats; /**< pools' memory usage statistics */
+#endif /* MEM_STATS */
+
+#ifdef JERRY_VALGRIND_FREYA
+  bool valgrind_freya_mempool_request; /**< Tells whether a pool manager
+                                        *   allocator request is in progress */
+#endif /* JERRY_VALGRIND_FREYA */
+} jerry_context_t;
+
+/**
+ * Jerry global context.
+ */
+extern jerry_context_t jerry_global_context;
+
+/**
+ * Jerry global heap.
+ */
+extern jmem_heap_t jerry_global_heap;
+
+/**
+ * Provides a reference to a field in the current context.
+ */
+#define JERRY_CONTEXT(field) (jerry_global_context.field)
+
+/**
+ * Provides a reference to the area field of the heap.
+ */
+#define JERRY_HEAP_CONTEXT(field) (jerry_global_heap.field)
+
+/**
+ * @}
+ * @}
+ */
+
+#endif /* !JCONTEXT_H */

--- a/jerry-core/jmem/jmem-allocator.c
+++ b/jerry-core/jmem/jmem-allocator.c
@@ -18,19 +18,14 @@
  * Allocator implementation
  */
 
-#include "jrt.h"
-#include "jrt-libc-includes.h"
+#include "jcontext.h"
 #include "jmem-allocator.h"
 #include "jmem-heap.h"
 #include "jmem-poolman.h"
+#include "jrt-libc-includes.h"
 
 #define JMEM_ALLOCATOR_INTERNAL
 #include "jmem-allocator-internal.h"
-
-/**
- * The 'try to give memory back' callback
- */
-static jmem_free_unused_memory_callback_t jmem_free_unused_memory_callback = NULL;
 
 /**
  * Initialize memory allocators.
@@ -94,9 +89,9 @@ void
 jmem_register_free_unused_memory_callback (jmem_free_unused_memory_callback_t callback) /**< callback routine */
 {
   /* Currently only one callback is supported */
-  JERRY_ASSERT (jmem_free_unused_memory_callback == NULL);
+  JERRY_ASSERT (JERRY_CONTEXT (jmem_free_unused_memory_callback) == NULL);
 
-  jmem_free_unused_memory_callback = callback;
+  JERRY_CONTEXT (jmem_free_unused_memory_callback) = callback;
 } /* jmem_register_free_unused_memory_callback */
 
 /**
@@ -106,9 +101,9 @@ void
 jmem_unregister_free_unused_memory_callback (jmem_free_unused_memory_callback_t callback) /**< callback routine */
 {
   /* Currently only one callback is supported */
-  JERRY_ASSERT (jmem_free_unused_memory_callback == callback);
+  JERRY_ASSERT (JERRY_CONTEXT (jmem_free_unused_memory_callback) == callback);
 
-  jmem_free_unused_memory_callback = NULL;
+  JERRY_CONTEXT (jmem_free_unused_memory_callback) = NULL;
 } /* jmem_unregister_free_unused_memory_callback */
 
 /**
@@ -117,9 +112,9 @@ jmem_unregister_free_unused_memory_callback (jmem_free_unused_memory_callback_t 
 void
 jmem_run_free_unused_memory_callbacks (jmem_free_unused_memory_severity_t severity) /**< severity of the request */
 {
-  if (jmem_free_unused_memory_callback != NULL)
+  if (JERRY_CONTEXT (jmem_free_unused_memory_callback) != NULL)
   {
-    jmem_free_unused_memory_callback (severity);
+    JERRY_CONTEXT (jmem_free_unused_memory_callback) (severity);
   }
 
   jmem_pools_collect_empty ();

--- a/jerry-core/jmem/jmem-allocator.h
+++ b/jerry-core/jmem/jmem-allocator.h
@@ -69,7 +69,24 @@ typedef enum
 } jmem_free_unused_memory_severity_t;
 
 /**
- * A 'try give memory back' callback routine type.
+ *  Free region node
+ */
+typedef struct
+{
+  uint32_t next_offset; /* Offset of next region in list */
+  uint32_t size; /* Size of region */
+} jmem_heap_free_t;
+
+/**
+ * Node for free chunk list
+ */
+typedef struct mem_pools_chunk
+{
+  struct mem_pools_chunk *next_p; /* pointer to next pool chunk */
+} jmem_pools_chunk_t;
+
+/**
+ * A free memory callback routine type.
  */
 typedef void (*jmem_free_unused_memory_callback_t) (jmem_free_unused_memory_severity_t);
 


### PR DESCRIPTION
This is the first patch which aims to move all jerry global variables into a context. This patch contains the infrastructure part, and the memory manager is updated to use this context. The JERRY_CONTEXT macro should provide the freedom of using contexts in Jerry.

@franc0is if you have some time please check this patch.