### PR TITLE
Introduce integer ecma-value representation to reduce the double allocations

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -24,6 +24,15 @@
  * @{
  */
 
+JERRY_STATIC_ASSERT (sizeof (ecma_value_t) == sizeof (ecma_integer_value_t),
+                     size_of_ecma_value_t_must_be_equal_to_the_size_of_ecma_integer_value_t);
+
+JERRY_STATIC_ASSERT (ECMA_DIRECT_SHIFT == ECMA_VALUE_SHIFT + 1,
+                     currently_directly_encoded_values_has_one_extra_flag);
+
+JERRY_STATIC_ASSERT (((1 << (ECMA_DIRECT_SHIFT - 1)) | ECMA_TYPE_DIRECT) == ECMA_DIRECT_TYPE_SIMPLE_VALUE,
+                     currently_directly_encoded_values_start_after_direct_type_simple_value);
+
 #define ECMA_NUMBER_SIGN_POS (ECMA_NUMBER_FRACTION_WIDTH + \
                               ECMA_NUMBER_BIASED_EXP_WIDTH)
 

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1110,21 +1110,9 @@ ecma_named_data_property_assign_value (ecma_object_t *obj_p, /**< object */
   JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
   ecma_assert_object_contains_the_property (obj_p, prop_p);
 
-  if (ecma_is_value_number (value)
-      && ecma_is_value_number (ecma_get_named_data_property_value (prop_p)))
-  {
-    const ecma_number_t *num_src_p = ecma_get_number_from_value (value);
-    ecma_number_t *num_dst_p = ecma_get_number_from_value (ecma_get_named_data_property_value (prop_p));
+  ecma_property_value_t *prop_value_p = ECMA_PROPERTY_VALUE_PTR (prop_p);
 
-    *num_dst_p = *num_src_p;
-  }
-  else
-  {
-    ecma_value_t v = ecma_get_named_data_property_value (prop_p);
-    ecma_free_value_if_not_object (v);
-
-    ecma_set_named_data_property_value (prop_p, ecma_copy_value_if_not_object (value));
-  }
+  ecma_value_assign_value (&prop_value_p->value, value);
 } /* ecma_named_data_property_assign_value */
 
 /**

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -122,6 +122,8 @@ extern bool ecma_is_value_true (ecma_value_t);
 extern bool ecma_is_value_false (ecma_value_t);
 extern bool ecma_is_value_array_hole (ecma_value_t);
 
+extern bool ecma_is_value_integer_number (ecma_value_t);
+extern bool ecma_is_value_float_number (ecma_value_t);
 extern bool ecma_is_value_number (ecma_value_t);
 extern bool ecma_is_value_string (ecma_value_t);
 extern bool ecma_is_value_object (ecma_value_t);
@@ -130,17 +132,25 @@ extern bool ecma_is_value_error (ecma_value_t);
 extern void ecma_check_value_type_is_spec_defined (ecma_value_t);
 
 extern ecma_value_t ecma_make_simple_value (const ecma_simple_value_t value);
-extern ecma_value_t ecma_make_number_value (const ecma_number_t *);
+extern ecma_value_t ecma_make_integer_value (ecma_integer_value_t);
+extern ecma_value_t ecma_make_nan_value (void);
+extern ecma_value_t ecma_make_number_value (ecma_number_t);
+extern ecma_value_t ecma_make_int32_value (int32_t);
+extern ecma_value_t ecma_make_uint32_value (uint32_t);
 extern ecma_value_t ecma_make_string_value (const ecma_string_t *);
 extern ecma_value_t ecma_make_object_value (const ecma_object_t *);
 extern ecma_value_t ecma_make_error_value (ecma_value_t);
 extern ecma_value_t ecma_make_error_obj_value (const ecma_object_t *);
-extern ecma_number_t *ecma_get_number_from_value (ecma_value_t) __attr_pure___;
+extern ecma_number_t ecma_get_number_from_value (ecma_value_t) __attr_pure___;
+extern uint32_t ecma_get_uint32_from_value (ecma_value_t) __attr_pure___;
 extern ecma_string_t *ecma_get_string_from_value (ecma_value_t) __attr_pure___;
 extern ecma_object_t *ecma_get_object_from_value (ecma_value_t) __attr_pure___;
 extern ecma_value_t ecma_get_value_from_error_value (ecma_value_t) __attr_pure___;
 extern ecma_value_t ecma_copy_value (ecma_value_t);
 extern ecma_value_t ecma_copy_value_if_not_object (ecma_value_t);
+extern void ecma_value_assign_value (ecma_value_t *, ecma_value_t);
+extern void ecma_value_assign_number (ecma_value_t *, ecma_number_t);
+extern void ecma_value_assign_uint32 (ecma_value_t *, uint32_t);
 extern void ecma_free_value (ecma_value_t);
 extern void ecma_free_value_if_not_object (ecma_value_t);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -62,16 +62,16 @@ ecma_builtin_date_prototype_to_string (ecma_value_t this_arg) /**< this argument
                   ecma_date_get_primitive_value (this_arg),
                   ret_value);
 
-  ecma_number_t *prim_num_p = ecma_get_number_from_value (prim_value);
+  ecma_number_t prim_num = ecma_get_number_from_value (prim_value);
 
-  if (ecma_number_is_nan (*prim_num_p))
+  if (ecma_number_is_nan (prim_num))
   {
     ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INVALID_DATE_UL);
     ret_value = ecma_make_string_value (magic_str_p);
   }
   else
   {
-    ret_value = ecma_date_value_to_string (*prim_num_p);
+    ret_value = ecma_date_value_to_string (prim_num);
   }
 
   ECMA_FINALIZE (prim_value);
@@ -257,10 +257,7 @@ ecma_builtin_date_prototype_get_time (ecma_value_t this_arg) /**< this argument 
       prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
                                                           ecma_get_internal_property_value (prim_prop_p));
 
-      ecma_number_t *ret_num_p = ecma_alloc_number ();
-      *ret_num_p = *prim_value_num_p;
-
-      return ecma_make_number_value (ret_num_p);
+      return ecma_make_number_value (*prim_value_num_p);
     }
   }
 
@@ -293,9 +290,9 @@ ecma_builtin_date_prototype_get_ ## _routine_name (ecma_value_t this_arg) /**< t
  \
   /* 1. */ \
   ECMA_TRY_CATCH (value, ecma_builtin_date_prototype_get_time (this_arg), ret_value); \
-  ecma_number_t *this_num_p = ecma_get_number_from_value (value); \
+  ecma_number_t this_num = ecma_get_number_from_value (value); \
   /* 2. */ \
-  if (ecma_number_is_nan (*this_num_p)) \
+  if (ecma_number_is_nan (this_num)) \
   { \
     ecma_string_t *nan_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAN); \
     ret_value = ecma_make_string_value (nan_str_p); \
@@ -303,9 +300,8 @@ ecma_builtin_date_prototype_get_ ## _routine_name (ecma_value_t this_arg) /**< t
   else \
   { \
     /* 3. */ \
-    ecma_number_t *ret_num_p = ecma_alloc_number (); \
-    *ret_num_p = _getter_name (DEFINE_GETTER_ARGUMENT_ ## _timezone (*this_num_p)); \
-    ret_value = ecma_make_number_value (ret_num_p); \
+    ecma_number_t ret_num = _getter_name (DEFINE_GETTER_ARGUMENT_ ## _timezone (this_num)); \
+    ret_value = ecma_make_number_value (ret_num); \
   } \
   ECMA_FINALIZE (value); \
   \
@@ -358,8 +354,7 @@ ecma_builtin_date_prototype_set_time (ecma_value_t this_arg, /**< this argument 
   {
     /* 1. */
     ECMA_OP_TO_NUMBER_TRY_CATCH (t, time, ret_value);
-    ecma_number_t *value_p = ecma_alloc_number ();
-    *value_p = ecma_date_time_clip (t);
+    ecma_number_t value = ecma_date_time_clip (t);
 
     /* 2. */
     ecma_object_t *obj_p = ecma_get_object_from_value (this_arg);
@@ -369,10 +364,10 @@ ecma_builtin_date_prototype_set_time (ecma_value_t this_arg, /**< this argument 
 
     ecma_number_t *prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
                                                                        ecma_get_internal_property_value (prim_prop_p));
-    *prim_value_num_p = *value_p;
+    *prim_value_num_p = value;
 
     /* 3. */
-    ret_value = ecma_make_number_value (value_p);
+    ret_value = ecma_make_number_value (value);
     ECMA_OP_TO_NUMBER_FINALIZE (t);
   }
 
@@ -396,7 +391,7 @@ ecma_builtin_date_prototype_set_milliseconds (ecma_value_t this_arg, /**< this a
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = ecma_date_local_time (*ecma_get_number_from_value (this_time_value));
+  ecma_number_t t = ecma_date_local_time (ecma_get_number_from_value (this_time_value));
 
   /* 2. */
   ECMA_OP_TO_NUMBER_TRY_CATCH (milli, ms, ret_value);
@@ -433,7 +428,7 @@ ecma_builtin_date_prototype_set_utc_milliseconds (ecma_value_t this_arg, /**< th
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = *ecma_get_number_from_value (this_time_value);
+  ecma_number_t t = ecma_get_number_from_value (this_time_value);
 
   /* 2. */
   ECMA_OP_TO_NUMBER_TRY_CATCH (milli, ms, ret_value);
@@ -471,7 +466,7 @@ ecma_builtin_date_prototype_set_seconds (ecma_value_t this_arg, /**< this argume
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = ecma_date_local_time (*ecma_get_number_from_value (this_time_value));
+  ecma_number_t t = ecma_date_local_time (ecma_get_number_from_value (this_time_value));
 
   /* 2. */
   ECMA_OP_TO_NUMBER_TRY_CATCH (s, sec, ret_value);
@@ -516,7 +511,7 @@ ecma_builtin_date_prototype_set_utc_seconds (ecma_value_t this_arg, /**< this ar
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = *ecma_get_number_from_value (this_time_value);
+  ecma_number_t t = ecma_get_number_from_value (this_time_value);
 
   /* 2. */
   ECMA_OP_TO_NUMBER_TRY_CATCH (s, sec, ret_value);
@@ -561,7 +556,7 @@ ecma_builtin_date_prototype_set_minutes (ecma_value_t this_arg, /**< this argume
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = ecma_date_local_time (*ecma_get_number_from_value (this_time_value));
+  ecma_number_t t = ecma_date_local_time (ecma_get_number_from_value (this_time_value));
 
   /* 2. */
   ecma_number_t m = ecma_number_make_nan ();
@@ -622,7 +617,7 @@ ecma_builtin_date_prototype_set_utc_minutes (ecma_value_t this_arg, /**< this ar
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = *ecma_get_number_from_value (this_time_value);
+  ecma_number_t t = ecma_get_number_from_value (this_time_value);
 
   /* 2. */
   ecma_number_t m = ecma_number_make_nan ();
@@ -683,7 +678,7 @@ ecma_builtin_date_prototype_set_hours (ecma_value_t this_arg, /**< this argument
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = ecma_date_local_time (*ecma_get_number_from_value (this_time_value));
+  ecma_number_t t = ecma_date_local_time (ecma_get_number_from_value (this_time_value));
 
   /* 2. */
   ecma_number_t h = ecma_number_make_nan ();
@@ -752,7 +747,7 @@ ecma_builtin_date_prototype_set_utc_hours (ecma_value_t this_arg, /**< this argu
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = *ecma_get_number_from_value (this_time_value);
+  ecma_number_t t = ecma_get_number_from_value (this_time_value);
 
   /* 2. */
   ecma_number_t h = ecma_number_make_nan ();
@@ -820,7 +815,7 @@ ecma_builtin_date_prototype_set_date (ecma_value_t this_arg, /**< this argument 
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = ecma_date_local_time (*ecma_get_number_from_value (this_time_value));
+  ecma_number_t t = ecma_date_local_time (ecma_get_number_from_value (this_time_value));
 
   /* 2. */
   ECMA_OP_TO_NUMBER_TRY_CATCH (dt, date, ret_value);
@@ -856,7 +851,7 @@ ecma_builtin_date_prototype_set_utc_date (ecma_value_t this_arg, /**< this argum
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = *ecma_get_number_from_value (this_time_value);
+  ecma_number_t t = ecma_get_number_from_value (this_time_value);
 
   /* 2. */
   ECMA_OP_TO_NUMBER_TRY_CATCH (dt, date, ret_value);
@@ -893,7 +888,7 @@ ecma_builtin_date_prototype_set_month (ecma_value_t this_arg, /**< this argument
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = ecma_date_local_time (*ecma_get_number_from_value (this_time_value));
+  ecma_number_t t = ecma_date_local_time (ecma_get_number_from_value (this_time_value));
 
   /* 2. */
   ECMA_OP_TO_NUMBER_TRY_CATCH (m, month, ret_value);
@@ -937,7 +932,7 @@ ecma_builtin_date_prototype_set_utc_month (ecma_value_t this_arg, /**< this argu
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = *ecma_get_number_from_value (this_time_value);
+  ecma_number_t t = ecma_get_number_from_value (this_time_value);
 
   /* 2. */
   ECMA_OP_TO_NUMBER_TRY_CATCH (m, month, ret_value);
@@ -981,7 +976,7 @@ ecma_builtin_date_prototype_set_full_year (ecma_value_t this_arg, /**< this argu
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = ecma_date_local_time (*ecma_get_number_from_value (this_time_value));
+  ecma_number_t t = ecma_date_local_time (ecma_get_number_from_value (this_time_value));
   if (ecma_number_is_nan (t))
   {
     t = ECMA_NUMBER_ZERO;
@@ -1045,7 +1040,7 @@ ecma_builtin_date_prototype_set_utc_full_year (ecma_value_t this_arg, /**< this 
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = *ecma_get_number_from_value (this_time_value);
+  ecma_number_t t = ecma_get_number_from_value (this_time_value);
   if (ecma_number_is_nan (t))
   {
     t = ECMA_NUMBER_ZERO;
@@ -1109,16 +1104,16 @@ ecma_builtin_date_prototype_to_utc_string (ecma_value_t this_arg) /**< this argu
                   ecma_date_get_primitive_value (this_arg),
                   ret_value);
 
-  ecma_number_t *prim_num_p = ecma_get_number_from_value (prim_value);
+  ecma_number_t prim_num = ecma_get_number_from_value (prim_value);
 
-  if (ecma_number_is_nan (*prim_num_p))
+  if (ecma_number_is_nan (prim_num))
   {
     ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INVALID_DATE_UL);
     ret_value = ecma_make_string_value (magic_str_p);
   }
   else
   {
-    ret_value = ecma_date_value_to_utc_string (*prim_num_p);
+    ret_value = ecma_date_value_to_utc_string (prim_num);
   }
 
   ECMA_FINALIZE (prim_value);
@@ -1144,15 +1139,15 @@ ecma_builtin_date_prototype_to_iso_string (ecma_value_t this_arg) /**< this argu
                   ecma_date_get_primitive_value (this_arg),
                   ret_value);
 
-  ecma_number_t *prim_num_p = ecma_get_number_from_value (prim_value);
+  ecma_number_t prim_num = ecma_get_number_from_value (prim_value);
 
-  if (ecma_number_is_nan (*prim_num_p) || ecma_number_is_infinity (*prim_num_p))
+  if (ecma_number_is_nan (prim_num) || ecma_number_is_infinity (prim_num))
   {
     ret_value = ecma_raise_range_error (ECMA_ERR_MSG (""));
   }
   else
   {
-    ret_value = ecma_date_value_to_iso_string (*prim_num_p);
+    ret_value = ecma_date_value_to_iso_string (prim_num);
   }
 
   ECMA_FINALIZE (prim_value);
@@ -1188,9 +1183,9 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg, /**< this argument *
   /* 3. */
   if (ecma_is_value_number (tv))
   {
-    ecma_number_t num_value_p = *ecma_get_number_from_value (tv);
+    ecma_number_t num_value = ecma_get_number_from_value (tv);
 
-    if (ecma_number_is_nan (num_value_p) || ecma_number_is_infinity (num_value_p))
+    if (ecma_number_is_nan (num_value) || ecma_number_is_infinity (num_value))
     {
       ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_NULL);
     }
@@ -1247,9 +1242,9 @@ ecma_builtin_date_prototype_get_year (ecma_value_t this_arg) /**< this argument 
 
   /* 1. */
   ECMA_TRY_CATCH (value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t *this_num_p = ecma_get_number_from_value (value);
+  ecma_number_t this_num = ecma_get_number_from_value (value);
   /* 2. */
-  if (ecma_number_is_nan (*this_num_p))
+  if (ecma_number_is_nan (this_num))
   {
     ecma_string_t *nan_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAN);
     ret_value = ecma_make_string_value (nan_str_p);
@@ -1257,9 +1252,8 @@ ecma_builtin_date_prototype_get_year (ecma_value_t this_arg) /**< this argument 
   else
   {
     /* 3. */
-    ecma_number_t *ret_num_p = ecma_alloc_number ();
-    *ret_num_p = ecma_date_year_from_time (ecma_date_local_time (*this_num_p)) - 1900;
-    ret_value = ecma_make_number_value (ret_num_p);
+    ecma_number_t ret_num = ecma_date_year_from_time (ecma_date_local_time (this_num)) - 1900;
+    ret_value = ecma_make_number_value (ret_num);
   }
   ECMA_FINALIZE (value);
 
@@ -1283,7 +1277,7 @@ ecma_builtin_date_prototype_set_year (ecma_value_t this_arg, /**< this argument 
 
   /* 1. */
   ECMA_TRY_CATCH (this_time_value, ecma_builtin_date_prototype_get_time (this_arg), ret_value);
-  ecma_number_t t = ecma_date_local_time (*ecma_get_number_from_value (this_time_value));
+  ecma_number_t t = ecma_date_local_time (ecma_get_number_from_value (this_time_value));
   if (ecma_number_is_nan (t))
   {
     t = ECMA_NUMBER_ZERO;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -81,14 +81,13 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
                             ecma_length_t args_len) /**< number of arguments */
 {
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
-  ecma_number_t *prim_value_p = ecma_alloc_number ();
-  *prim_value_p = ecma_number_make_nan ();
+  ecma_number_t prim_value = ecma_number_make_nan ();
 
   ECMA_TRY_CATCH (year_value, ecma_op_to_number (args[0]), ret_value);
   ECMA_TRY_CATCH (month_value, ecma_op_to_number (args[1]), ret_value);
 
-  ecma_number_t year = *ecma_get_number_from_value (year_value);
-  ecma_number_t month = *ecma_get_number_from_value (month_value);
+  ecma_number_t year = ecma_get_number_from_value (year_value);
+  ecma_number_t month = ecma_get_number_from_value (month_value);
   ecma_number_t date = ECMA_NUMBER_ONE;
   ecma_number_t hours = ECMA_NUMBER_ZERO;
   ecma_number_t minutes = ECMA_NUMBER_ZERO;
@@ -99,7 +98,7 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
   if (args_len >= 3 && ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (date_value, ecma_op_to_number (args[2]), ret_value);
-    date = *ecma_get_number_from_value (date_value);
+    date = ecma_get_number_from_value (date_value);
     ECMA_FINALIZE (date_value);
   }
 
@@ -107,7 +106,7 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
   if (args_len >= 4 && ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (hours_value, ecma_op_to_number (args[3]), ret_value);
-    hours = *ecma_get_number_from_value (hours_value);
+    hours = ecma_get_number_from_value (hours_value);
     ECMA_FINALIZE (hours_value);
   }
 
@@ -115,7 +114,7 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
   if (args_len >= 5 && ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (minutes_value, ecma_op_to_number (args[4]), ret_value);
-    minutes = *ecma_get_number_from_value (minutes_value);
+    minutes = ecma_get_number_from_value (minutes_value);
     ECMA_FINALIZE (minutes_value);
   }
 
@@ -123,7 +122,7 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
   if (args_len >= 6 && ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (seconds_value, ecma_op_to_number (args[5]), ret_value);
-    seconds = *ecma_get_number_from_value (seconds_value);
+    seconds = ecma_get_number_from_value (seconds_value);
     ECMA_FINALIZE (seconds_value);
   }
 
@@ -131,7 +130,7 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
   if (args_len >= 7 && ecma_is_value_empty (ret_value))
   {
     ECMA_TRY_CATCH (milliseconds_value, ecma_op_to_number (args[6]), ret_value);
-    milliseconds = *ecma_get_number_from_value (milliseconds_value);
+    milliseconds = ecma_get_number_from_value (milliseconds_value);
     ECMA_FINALIZE (milliseconds_value);
   }
 
@@ -152,13 +151,13 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
       }
     }
 
-    *prim_value_p = ecma_date_make_date (ecma_date_make_day (year,
-                                                             month,
-                                                             date),
-                                         ecma_date_make_time (hours,
-                                                              minutes,
-                                                              seconds,
-                                                              milliseconds));
+    prim_value = ecma_date_make_date (ecma_date_make_day (year,
+                                                          month,
+                                                          date),
+                                      ecma_date_make_time (hours,
+                                                           minutes,
+                                                           seconds,
+                                                           milliseconds));
   }
 
   ECMA_FINALIZE (month_value);
@@ -166,11 +165,7 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
 
   if (ecma_is_value_empty (ret_value))
   {
-    ret_value = ecma_make_number_value (prim_value_p);
-  }
-  else
-  {
-    ecma_dealloc_number (prim_value_p);
+    ret_value = ecma_make_number_value (prim_value);
   }
 
   return ret_value;
@@ -191,8 +186,7 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
                          ecma_value_t arg) /**< string */
 {
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
-  ecma_number_t *date_num_p = ecma_alloc_number ();
-  *date_num_p = ecma_number_make_nan ();
+  ecma_number_t date_num = ecma_number_make_nan ();
 
   /* Date Time String fromat (ECMA-262 v5, 15.9.1.15) */
   ECMA_TRY_CATCH (date_str_value,
@@ -382,11 +376,11 @@ ecma_builtin_date_parse (ecma_value_t this_arg __attr_unused___, /**< this argum
     if (date_str_curr_p >= date_str_end_p)
     {
       ecma_number_t date = ecma_date_make_day (year, month - 1, day);
-      *date_num_p = ecma_date_make_date (date, time);
+      date_num = ecma_date_make_date (date, time);
     }
   }
 
-  ret_value = ecma_make_number_value (date_num_p);
+  ret_value = ecma_make_number_value (date_num);
 
   ECMA_FINALIZE_UTF8_STRING (date_start_p, date_start_size);
   ECMA_FINALIZE (date_str_value);
@@ -416,17 +410,13 @@ ecma_builtin_date_utc (ecma_value_t this_arg __attr_unused___, /**< this argumen
      *      When the UTC function is called with fewer than two arguments,
      *      the behaviour is implementation-dependent, so just return NaN.
      */
-    ecma_number_t *nan_p = ecma_alloc_number ();
-    *nan_p = ecma_number_make_nan ();
-    return ecma_make_number_value (nan_p);
+    return ecma_make_number_value (ecma_number_make_nan ());
   }
 
   ECMA_TRY_CATCH (time_value, ecma_date_construct_helper (args, args_number), ret_value);
 
-  ecma_number_t *time_p = ecma_get_number_from_value (time_value);
-  ecma_number_t *time_clip_p = ecma_alloc_number ();
-  *time_clip_p = ecma_date_time_clip (*time_p);
-  ret_value = ecma_make_number_value (time_clip_p);
+  ecma_number_t time = ecma_get_number_from_value (time_value);
+  ret_value = ecma_make_number_value (ecma_date_time_clip (time));
 
   ECMA_FINALIZE (time_value);
 
@@ -445,11 +435,7 @@ ecma_builtin_date_utc (ecma_value_t this_arg __attr_unused___, /**< this argumen
 static ecma_value_t
 ecma_builtin_date_now (ecma_value_t this_arg __attr_unused___) /**< this argument */
 {
-  ecma_number_t *now_num_p = ecma_alloc_number ();
-
-  *now_num_p = DOUBLE_TO_ECMA_NUMBER_T (jerry_port_get_current_time ());
-
-  return ecma_make_number_value (now_num_p);
+  return ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (jerry_port_get_current_time ()));
 } /* ecma_builtin_date_now */
 
 /**
@@ -470,7 +456,7 @@ ecma_builtin_date_dispatch_call (const ecma_value_t *arguments_list_p __attr_unu
                   ecma_builtin_date_now (ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED)),
                   ret_value);
 
-  ret_value = ecma_date_value_to_string (*ecma_get_number_from_value (now_val));
+  ret_value = ecma_date_value_to_string (ecma_get_number_from_value (now_val));
 
   ECMA_FINALIZE (now_val);
 
@@ -490,7 +476,7 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
                                       ecma_length_t arguments_list_len) /**< number of arguments */
 {
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
-  ecma_number_t *prim_value_num_p = NULL;
+  ecma_number_t prim_value_num = ECMA_NUMBER_ZERO;
 
   ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_DATE_PROTOTYPE);
   ecma_object_t *obj_p = ecma_create_object (prototype_obj_p,
@@ -504,8 +490,7 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
                     ecma_builtin_date_now (ecma_make_object_value (obj_p)),
                     ret_value);
 
-    prim_value_num_p = ecma_alloc_number ();
-    *prim_value_num_p = *ecma_get_number_from_value (parse_res_value);
+    prim_value_num = ecma_get_number_from_value (parse_res_value);
 
     ECMA_FINALIZE (parse_res_value)
   }
@@ -521,8 +506,7 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
                       ecma_builtin_date_parse (ecma_make_object_value (obj_p), prim_comp_value),
                       ret_value);
 
-      prim_value_num_p = ecma_alloc_number ();
-      *prim_value_num_p = *ecma_get_number_from_value (parse_res_value);
+      prim_value_num = ecma_get_number_from_value (parse_res_value);
 
       ECMA_FINALIZE (parse_res_value);
     }
@@ -530,8 +514,7 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
     {
       ECMA_TRY_CATCH (prim_value, ecma_op_to_number (arguments_list_p[0]), ret_value);
 
-      prim_value_num_p = ecma_alloc_number ();
-      *prim_value_num_p = ecma_date_time_clip (*ecma_get_number_from_value (prim_value));
+      prim_value_num = ecma_date_time_clip (ecma_get_number_from_value (prim_value));
 
       ECMA_FINALIZE (prim_value);
     }
@@ -544,23 +527,21 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
                     ecma_date_construct_helper (arguments_list_p, arguments_list_len),
                     ret_value);
 
-    ecma_number_t *time_p = ecma_get_number_from_value (time_value);
-    prim_value_num_p = ecma_alloc_number ();
-    *prim_value_num_p = ecma_date_time_clip (ecma_date_utc (*time_p));
+    ecma_number_t time = ecma_get_number_from_value (time_value);
+    prim_value_num = ecma_date_time_clip (ecma_date_utc (time));
 
     ECMA_FINALIZE (time_value);
   }
   else
   {
-    prim_value_num_p = ecma_alloc_number ();
-    *prim_value_num_p = ecma_number_make_nan ();
+    prim_value_num = ecma_number_make_nan ();
   }
 
   if (ecma_is_value_empty (ret_value))
   {
-    if (!ecma_number_is_nan (*prim_value_num_p) && ecma_number_is_infinity (*prim_value_num_p))
+    if (!ecma_number_is_nan (prim_value_num) && ecma_number_is_infinity (prim_value_num))
     {
-      *prim_value_num_p = ecma_number_make_nan ();
+      prim_value_num = ecma_number_make_nan ();
     }
 
     ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p,
@@ -569,6 +550,9 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
 
     ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                         ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
+
+    ecma_number_t *prim_value_num_p = ecma_alloc_number ();
+    *prim_value_num_p = prim_value_num;
     ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_value_num_p);
 
     ret_value = ecma_make_object_value (obj_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -281,7 +281,8 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
      * See also: ecma_object_get_class_name
      */
 
-    ecma_number_t *length_p = ecma_alloc_number ();
+    /* 16. */
+    ecma_number_t length = ECMA_NUMBER_ZERO;
     ecma_string_t *magic_string_length_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
 
     /* 15. */
@@ -294,25 +295,20 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
       const ecma_length_t bound_arg_count = arg_count > 1 ? arg_count - 1 : 0;
 
       /* 15.a */
-      *length_p = *ecma_get_number_from_value (get_len_value) - ((ecma_number_t) bound_arg_count);
+      length = ecma_get_number_from_value (get_len_value) - ((ecma_number_t) bound_arg_count);
       ecma_free_value (get_len_value);
 
       /* 15.b */
-      if (ecma_number_is_negative (*length_p))
+      if (ecma_number_is_negative (length))
       {
-        *length_p = ECMA_NUMBER_ZERO;
+        length = ECMA_NUMBER_ZERO;
       }
-    }
-    else
-    {
-      /* 16. */
-      *length_p = ECMA_NUMBER_ZERO;
     }
 
     /* 17. */
     ecma_value_t completion = ecma_builtin_helper_def_prop (function_p,
                                                             magic_string_length_p,
-                                                            ecma_make_number_value (length_p),
+                                                            ecma_make_number_value (length),
                                                             false, /* Writable */
                                                             false, /* Enumerable */
                                                             false, /* Configurable */
@@ -321,7 +317,6 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
     JERRY_ASSERT (ecma_is_value_boolean (completion));
 
     ecma_deref_ecma_string (magic_string_length_p);
-    ecma_dealloc_number (length_p);
 
     /* 19-21. */
     ecma_object_t *thrower_p = ecma_builtin_get (ECMA_BUILTIN_ID_TYPE_ERROR_THROWER);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -263,9 +263,7 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
         /* 8.a */
         if (rad < 2 || rad > 36)
         {
-          ecma_number_t *ret_num_p = ecma_alloc_number ();
-          *ret_num_p = ecma_number_make_nan ();
-          ret_value = ecma_make_number_value (ret_num_p);
+          ret_value = ecma_make_nan_value ();
         }
         /* 8.b */
         else if (rad != 16)
@@ -331,16 +329,13 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
         /* 12. */
         if (end_p == start_p)
         {
-          ecma_number_t *ret_num_p = ecma_alloc_number ();
-          *ret_num_p = ecma_number_make_nan ();
-          ret_value = ecma_make_number_value (ret_num_p);
+          ret_value = ecma_make_nan_value ();
         }
       }
 
       if (ecma_is_value_empty (ret_value))
       {
-        ecma_number_t *value_p = ecma_alloc_number ();
-        *value_p = 0;
+        ecma_number_t value = ECMA_NUMBER_ZERO;
         ecma_number_t multiplier = 1.0f;
 
         /* 13. and 14. */
@@ -368,34 +363,30 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg __attr_unused___, /*
             JERRY_UNREACHABLE ();
           }
 
-          *value_p += current_number * multiplier;
+          value += current_number * multiplier;
           multiplier *= (ecma_number_t) rad;
         }
 
         /* 15. */
         if (sign < 0)
         {
-          *value_p *= (ecma_number_t) sign;
+          value *= (ecma_number_t) sign;
         }
 
-        ret_value = ecma_make_number_value (value_p);
+        ret_value = ecma_make_number_value (value);
       }
 
       ECMA_OP_TO_NUMBER_FINALIZE (radix_num);
     }
     else
     {
-      ecma_number_t *ret_num_p = ecma_alloc_number ();
-      *ret_num_p = ecma_number_make_nan ();
-      ret_value = ecma_make_number_value (ret_num_p);
+      ret_value = ecma_make_nan_value ();
     }
 
   }
   else
   {
-    ecma_number_t *ret_num_p = ecma_alloc_number ();
-    *ret_num_p = ecma_number_make_nan ();
-    ret_value = ecma_make_number_value (ret_num_p);
+    ret_value = ecma_make_nan_value ();
   }
 
   ECMA_FINALIZE_UTF8_STRING (string_buff, string_buff_size);
@@ -465,8 +456,6 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
       }
     }
 
-    ecma_number_t *ret_num_p = ecma_alloc_number ();
-
     const lit_utf8_byte_t *infinity_str_p = lit_get_magic_string_utf8 (LIT_MAGIC_STRING_INFINITY_UL);
     lit_utf8_byte_t *infinity_str_curr_p = (lit_utf8_byte_t *) infinity_str_p;
     lit_utf8_byte_t *infinity_str_end_p = infinity_str_curr_p + sizeof (*infinity_str_p);
@@ -478,8 +467,7 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
       if (infinity_str_curr_p == infinity_str_end_p)
       {
         /* String matched Infinity. */
-        *ret_num_p = ecma_number_make_infinity (sign);
-        ret_value = ecma_make_number_value (ret_num_p);
+        ret_value = ecma_make_number_value (ecma_number_make_infinity (sign));
         break;
       }
     }
@@ -590,36 +578,32 @@ ecma_builtin_global_object_parse_float (ecma_value_t this_arg __attr_unused___, 
       /* String did not contain a valid number. */
       if (start_p == end_p)
       {
-        *ret_num_p = ecma_number_make_nan ();
-        ret_value = ecma_make_number_value (ret_num_p);
+        ret_value = ecma_make_nan_value ();
       }
       else
       {
         /* 5. */
-        *ret_num_p = ecma_utf8_string_to_number (start_p,
-                                                 (lit_utf8_size_t) (end_p - start_p));
+        ecma_number_t ret_num = ecma_utf8_string_to_number (start_p,
+                                                            (lit_utf8_size_t) (end_p - start_p));
 
         if (sign)
         {
-          *ret_num_p *= -1;
+          ret_num *= ECMA_NUMBER_MINUS_ONE;
         }
 
-        ret_value = ecma_make_number_value (ret_num_p);
+        ret_value = ecma_make_number_value (ret_num);
       }
     }
     /* String ended after sign character, or was empty after removing leading whitespace. */
     else if (ecma_is_value_empty (ret_value))
     {
-      *ret_num_p = ecma_number_make_nan ();
-      ret_value = ecma_make_number_value (ret_num_p);
+      ret_value = ecma_make_nan_value ();
     }
   }
   /* String length is zero. */
   else
   {
-    ecma_number_t *ret_num_p = ecma_alloc_number ();
-    *ret_num_p = ecma_number_make_nan ();
-    ret_value = ecma_make_number_value (ret_num_p);
+    ret_value = ecma_make_nan_value ();
   }
 
   ECMA_FINALIZE_UTF8_STRING (string_buff, string_buff_size);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -889,13 +889,13 @@ ecma_date_set_internal_property (ecma_value_t this_arg, /**< this argument */
 {
   JERRY_ASSERT (ecma_is_value_object (this_arg));
 
-  ecma_number_t *value_p = ecma_alloc_number ();
   ecma_number_t date = ecma_date_make_date (day, time);
   if (is_utc != ECMA_DATE_UTC)
   {
     date = ecma_date_utc (date);
   }
-  *value_p = ecma_date_time_clip (date);
+
+  ecma_number_t value = ecma_date_time_clip (date);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (this_arg);
 
@@ -905,9 +905,9 @@ ecma_date_set_internal_property (ecma_value_t this_arg, /**< this argument */
   ecma_number_t *prim_value_num_p;
   prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
                                                       ecma_get_internal_property_value (prim_value_prop_p));
-  *prim_value_num_p = *value_p;
+  *prim_value_num_p = value;
 
-  return ecma_make_number_value (value_p);
+  return ecma_make_number_value (value);
 } /* ecma_date_set_internal_property */
 
 /**
@@ -1306,10 +1306,10 @@ ecma_date_get_primitive_value (ecma_value_t this_arg) /**< this argument */
                                                                      ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
     JERRY_ASSERT (prim_value_prop_p != NULL);
 
-    ecma_number_t *prim_value_num_p = ecma_alloc_number ();
-    *prim_value_num_p = *ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
-                                                          ecma_get_internal_property_value (prim_value_prop_p));
-    ret_value = ecma_make_number_value (prim_value_num_p);
+    ecma_number_t prim_value_num;
+    prim_value_num = *ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
+                                                       ecma_get_internal_property_value (prim_value_prop_p));
+    ret_value = ecma_make_number_value (prim_value_num);
   }
 
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -520,17 +520,16 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_value_t this_arg, /**
   /* 7 (indexOf) -- 8 (lastIndexOf) */
   ecma_string_t *search_str_p = ecma_get_string_from_value (search_str_val);
 
-  ecma_number_t *ret_num_p = ecma_alloc_number ();
-  *ret_num_p = ECMA_NUMBER_MINUS_ONE;
+  ecma_number_t ret_num = ECMA_NUMBER_MINUS_ONE;
 
   /* 8 (indexOf) -- 9 (lastIndexOf) */
   ecma_length_t index_of = 0;
   if (ecma_builtin_helper_string_find_index (original_str_p, search_str_p, first_index, start, &index_of))
   {
-    *ret_num_p = ((ecma_number_t) index_of);
+    ret_num = ((ecma_number_t) index_of);
   }
 
-  ret_value = ecma_make_number_value (ret_num_p);
+  ret_value = ecma_make_number_value (ret_num);
 
   ECMA_OP_TO_NUMBER_FINALIZE (pos_num);
   ECMA_FINALIZE (search_str_val);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
@@ -251,10 +251,7 @@ TRY_TO_INSTANTIATE_PROPERTY_ROUTINE_NAME (ecma_object_t *obj_p, /**< object */
    }
 #define NUMBER_VALUE(name, number_value, prop_writable, prop_enumerable, prop_configurable) case name: \
     { \
-      ecma_number_t *num_p = ecma_alloc_number (); \
-      *num_p = number_value; \
-      \
-      value = ecma_make_number_value (num_p); \
+      value = ecma_make_number_value (number_value); \
       \
       writable = prop_writable; \
       enumerable = prop_enumerable; \

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -451,9 +451,7 @@ ecma_builtin_json_parse_value (ecma_json_token_t *token_p) /**< token argument *
   {
     case number_token:
     {
-      ecma_number_t *number_p = ecma_alloc_number ();
-      *number_p = token_p->u.number;
-      return ecma_make_number_value (number_p);
+      return ecma_make_number_value (token_p->u.number);
     }
     case string_token:
     {
@@ -1327,7 +1325,7 @@ ecma_builtin_json_str (ecma_string_t *key_p, /**< property key*/
     /* 9. */
     else if (ecma_is_value_number (my_val))
     {
-      ecma_number_t num_value_p = *ecma_get_number_from_value (my_val);
+      ecma_number_t num_value_p = ecma_get_number_from_value (my_val);
 
       /* 9.a */
       if (!ecma_number_is_nan (num_value_p) && !ecma_number_is_infinity (num_value_p))

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
@@ -66,11 +66,7 @@ ecma_builtin_math_object_abs (ecma_value_t this_arg __attr_unused___, /**< 'this
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (fabs (arg_num));
-
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (fabs (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
 
@@ -94,10 +90,7 @@ ecma_builtin_math_object_acos (ecma_value_t this_arg __attr_unused___, /**< 'thi
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (acos (arg_num));
-
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (acos (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -120,10 +113,7 @@ ecma_builtin_math_object_asin (ecma_value_t this_arg __attr_unused___, /**< 'thi
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (asin (arg_num));
-
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (asin (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -146,10 +136,7 @@ ecma_builtin_math_object_atan (ecma_value_t this_arg __attr_unused___, /**< 'thi
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (atan (arg_num));
-
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (atan (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -174,10 +161,7 @@ ecma_builtin_math_object_atan2 (ecma_value_t this_arg __attr_unused___, /**< 'th
   ECMA_OP_TO_NUMBER_TRY_CATCH (x, arg1, ret_value);
   ECMA_OP_TO_NUMBER_TRY_CATCH (y, arg2, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (atan2 (x, y));
-
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (atan2 (x, y)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (y);
   ECMA_OP_TO_NUMBER_FINALIZE (x);
@@ -201,9 +185,7 @@ ecma_builtin_math_object_ceil (ecma_value_t this_arg __attr_unused___, /**< 'thi
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (ceil (arg_num));
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (ceil (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -226,9 +208,7 @@ ecma_builtin_math_object_cos (ecma_value_t this_arg __attr_unused___, /**< 'this
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (cos (arg_num));
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (cos (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -251,11 +231,7 @@ ecma_builtin_math_object_exp (ecma_value_t this_arg __attr_unused___, /**< 'this
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (exp (arg_num));
-
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (exp (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
 
@@ -279,9 +255,7 @@ ecma_builtin_math_object_floor (ecma_value_t this_arg __attr_unused___, /**< 'th
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (floor (arg_num));
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (floor (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -304,11 +278,7 @@ ecma_builtin_math_object_log (ecma_value_t this_arg __attr_unused___, /**< 'this
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (log (arg_num));
-
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (log (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
 
@@ -389,9 +359,7 @@ ecma_builtin_math_object_max (ecma_value_t this_arg __attr_unused___, /**< 'this
 
   if (ecma_is_value_empty (ret_value))
   {
-    ecma_number_t *num_p = ecma_alloc_number ();
-    *num_p = ret_num;
-    ret_value = ecma_make_number_value (num_p);
+    ret_value = ecma_make_number_value (ret_num);
   }
 
   return ret_value;
@@ -471,9 +439,7 @@ ecma_builtin_math_object_min (ecma_value_t this_arg __attr_unused___, /**< 'this
 
   if (ecma_is_value_empty (ret_value))
   {
-    ecma_number_t *num_p = ecma_alloc_number ();
-    *num_p = ret_num;
-    ret_value = ecma_make_number_value (num_p);
+    ret_value = ecma_make_number_value (ret_num);
   }
 
   return ret_value;
@@ -498,9 +464,7 @@ ecma_builtin_math_object_pow (ecma_value_t this_arg __attr_unused___, /**< 'this
   ECMA_OP_TO_NUMBER_TRY_CATCH (x, arg1, ret_value);
   ECMA_OP_TO_NUMBER_TRY_CATCH (y, arg2, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (pow (x, y));
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (pow (x, y)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (y);
   ECMA_OP_TO_NUMBER_FINALIZE (x);
@@ -541,10 +505,7 @@ ecma_builtin_math_object_random (ecma_value_t this_arg __attr_unused___) /**< 't
   rand /= (ecma_number_t) max_uint32;
   rand *= (ecma_number_t) (max_uint32 - 1) / (ecma_number_t) max_uint32;
 
-  ecma_number_t *rand_p = ecma_alloc_number ();
-  *rand_p = rand;
-
-  return ecma_make_number_value (rand_p);
+  return ecma_make_number_value (rand);
 } /* ecma_builtin_math_object_random */
 
 /**
@@ -564,18 +525,18 @@ ecma_builtin_math_object_round (ecma_value_t this_arg __attr_unused___, /**< 'th
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
+  ecma_number_t num = ECMA_NUMBER_ZERO;
 
   if (ecma_number_is_nan (arg_num)
       || ecma_number_is_zero (arg_num)
       || ecma_number_is_infinity (arg_num))
   {
-    *num_p = arg_num;
+    num = arg_num;
   }
   else if (ecma_number_is_negative (arg_num)
            && arg_num >= -ECMA_NUMBER_HALF)
   {
-    *num_p = ecma_number_negate (ECMA_NUMBER_ZERO);
+    num = ecma_number_negate (ECMA_NUMBER_ZERO);
   }
   else
   {
@@ -586,15 +547,15 @@ ecma_builtin_math_object_round (ecma_value_t this_arg __attr_unused___, /**< 'th
 
     if (up_rounded - arg_num <= arg_num - down_rounded)
     {
-      *num_p = up_rounded;
+      num = up_rounded;
     }
     else
     {
-      *num_p = down_rounded;
+      num = down_rounded;
     }
   }
 
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (num);
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
 
@@ -618,9 +579,7 @@ ecma_builtin_math_object_sin (ecma_value_t this_arg __attr_unused___, /**< 'this
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (sin (arg_num));
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (sin (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -643,9 +602,7 @@ ecma_builtin_math_object_sqrt (ecma_value_t this_arg __attr_unused___, /**< 'thi
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (sqrt (arg_num));
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (sqrt (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;
@@ -668,10 +625,7 @@ ecma_builtin_math_object_tan (ecma_value_t this_arg __attr_unused___, /**< 'this
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
-  ecma_number_t *num_p = ecma_alloc_number ();
-  *num_p = DOUBLE_TO_ECMA_NUMBER_T (tan (arg_num));
-
-  ret_value = ecma_make_number_value (num_p);
+  ret_value = ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (tan (arg_num)));
 
   ECMA_OP_TO_NUMBER_FINALIZE (arg_num);
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -93,7 +93,7 @@ ecma_builtin_number_prototype_object_to_string (ecma_value_t this_arg, /**< this
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (this_value, ecma_builtin_number_prototype_object_value_of (this_arg), ret_value);
-  ecma_number_t this_arg_number = *ecma_get_number_from_value (this_value);
+  ecma_number_t this_arg_number = ecma_get_number_from_value (this_value);
 
   if (arguments_list_len == 0
       || ecma_number_is_nan (this_arg_number)
@@ -362,10 +362,7 @@ ecma_builtin_number_prototype_object_value_of (ecma_value_t this_arg) /**< this 
       prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
                                                           ecma_get_internal_property_value (prim_value_prop_p));
 
-      ecma_number_t *ret_num_p = ecma_alloc_number ();
-      *ret_num_p = *prim_value_num_p;
-
-      return ecma_make_number_value (ret_num_p);
+      return ecma_make_number_value (*prim_value_num_p);
     }
   }
 
@@ -388,7 +385,7 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ECMA_TRY_CATCH (this_value, ecma_builtin_number_prototype_object_value_of (this_arg), ret_value);
-  ecma_number_t this_num = *ecma_get_number_from_value (this_value);
+  ecma_number_t this_num = ecma_get_number_from_value (this_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
@@ -592,7 +589,7 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
 
   /* 1. */
   ECMA_TRY_CATCH (this_value, ecma_builtin_number_prototype_object_value_of (this_arg), ret_value);
-  ecma_number_t this_num = *ecma_get_number_from_value (this_value);
+  ecma_number_t this_num = ecma_get_number_from_value (this_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (arg_num, arg, ret_value);
 
@@ -777,7 +774,7 @@ ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< t
 
   /* 1. */
   ECMA_TRY_CATCH (this_value, ecma_builtin_number_prototype_object_value_of (this_arg), ret_value);
-  ecma_number_t this_num = *ecma_get_number_from_value (this_value);
+  ecma_number_t this_num = ecma_get_number_from_value (this_value);
 
   /* 2. */
   if (ecma_is_value_undefined (arg))

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
@@ -59,10 +59,7 @@ ecma_builtin_number_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
 
   if (arguments_list_len == 0)
   {
-    ecma_number_t *zero_num_p = ecma_alloc_number ();
-    *zero_num_p = ECMA_NUMBER_ZERO;
-
-    ret_value = ecma_make_number_value (zero_num_p);
+    ret_value = ecma_make_integer_value (0);
   }
   else
   {
@@ -85,13 +82,7 @@ ecma_builtin_number_dispatch_construct (const ecma_value_t *arguments_list_p, /*
 
   if (arguments_list_len == 0)
   {
-    ecma_number_t *zero_num_p = ecma_alloc_number ();
-    *zero_num_p = ECMA_NUMBER_ZERO;
-
-    ecma_value_t completion = ecma_op_create_number_object (ecma_make_number_value (zero_num_p));
-
-    ecma_dealloc_number (zero_num_p);
-
+    ecma_value_t completion = ecma_op_create_number_object (ecma_make_integer_value (0));
     return completion;
   }
   else

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -321,11 +321,7 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
                                                                      string_p,
                                                                      false, false, false);
 
-
-      ecma_number_t *len_p = ecma_alloc_number ();
-      *len_p = length_prop_value;
-
-      ecma_set_named_data_property_value (len_prop_p, ecma_make_number_value (len_p));
+      ecma_set_named_data_property_value (len_prop_p, ecma_make_uint32_value (length_prop_value));
 
       JERRY_ASSERT (!ecma_is_property_configurable (len_prop_p));
       return len_prop_p;

--- a/jerry-core/ecma/operations/ecma-comparison.c
+++ b/jerry-core/ecma/operations/ecma-comparison.c
@@ -73,8 +73,8 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
     }
     else if (is_x_number)
     { // c.
-      ecma_number_t x_num = *ecma_get_number_from_value (x);
-      ecma_number_t y_num = *ecma_get_number_from_value (y);
+      ecma_number_t x_num = ecma_get_number_from_value (x);
+      ecma_number_t y_num = ecma_get_number_from_value (y);
 
       bool is_x_equal_to_y = (x_num == y_num);
 
@@ -267,8 +267,8 @@ ecma_op_strict_equality_compare (ecma_value_t x, /**< first operand */
     // d. If x is +0 and y is -0, return true.
     // e. If x is -0 and y is +0, return true.
 
-    ecma_number_t x_num = *ecma_get_number_from_value (x);
-    ecma_number_t y_num = *ecma_get_number_from_value (y);
+    ecma_number_t x_num = ecma_get_number_from_value (x);
+    ecma_number_t y_num = ecma_get_number_from_value (y);
 
     bool is_x_equal_to_y = (x_num == y_num);
 

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -109,11 +109,11 @@ ecma_op_same_value (ecma_value_t x, /**< ecma value */
   }
   else if (is_x_number)
   {
-    ecma_number_t *x_num_p = ecma_get_number_from_value (x);
-    ecma_number_t *y_num_p = ecma_get_number_from_value (y);
+    ecma_number_t x_num = ecma_get_number_from_value (x);
+    ecma_number_t y_num = ecma_get_number_from_value (y);
 
-    bool is_x_nan = ecma_number_is_nan (*x_num_p);
-    bool is_y_nan = ecma_number_is_nan (*y_num_p);
+    bool is_x_nan = ecma_number_is_nan (x_num);
+    bool is_y_nan = ecma_number_is_nan (y_num);
 
     if (is_x_nan || is_y_nan)
     {
@@ -126,15 +126,15 @@ ecma_op_same_value (ecma_value_t x, /**< ecma value */
        */
       return (is_x_nan && is_y_nan);
     }
-    else if (ecma_number_is_zero (*x_num_p)
-             && ecma_number_is_zero (*y_num_p)
-             && ecma_number_is_negative (*x_num_p) != ecma_number_is_negative (*y_num_p))
+    else if (ecma_number_is_zero (x_num)
+             && ecma_number_is_zero (y_num)
+             && ecma_number_is_negative (x_num) != ecma_number_is_negative (y_num))
     {
       return false;
     }
     else
     {
-      return (*x_num_p == *y_num_p);
+      return (x_num == y_num);
     }
   }
   else if (is_x_string)
@@ -212,10 +212,10 @@ ecma_op_to_boolean (ecma_value_t value) /**< ecma value */
   }
   else if (ecma_is_value_number (value))
   {
-    ecma_number_t *num_p = ecma_get_number_from_value (value);
+    ecma_number_t num = ecma_get_number_from_value (value);
 
-    if (ecma_number_is_nan (*num_p)
-        || ecma_number_is_zero (*num_p))
+    if (ecma_number_is_nan (num)
+        || ecma_number_is_zero (num))
     {
       ret_value = ECMA_SIMPLE_VALUE_FALSE;
     }
@@ -261,18 +261,18 @@ ecma_op_to_number (ecma_value_t value) /**< ecma value */
 {
   ecma_check_value_type_is_spec_defined (value);
 
-  if (ecma_is_value_number (value))
+  if (ecma_is_value_integer_number (value))
+  {
+    return value;
+  }
+  else if (ecma_is_value_float_number (value))
   {
     return ecma_copy_value (value);
   }
   else if (ecma_is_value_string (value))
   {
     ecma_string_t *str_p = ecma_get_string_from_value (value);
-
-    ecma_number_t *num_p = ecma_alloc_number ();
-    *num_p = ecma_string_to_number (str_p);
-
-    return ecma_make_number_value (num_p);
+    return ecma_make_number_value (ecma_string_to_number (str_p));
   }
   else if (ecma_is_value_object (value))
   {
@@ -290,15 +290,15 @@ ecma_op_to_number (ecma_value_t value) /**< ecma value */
   }
   else
   {
-    ecma_number_t *num_p = ecma_alloc_number ();
+    int16_t num = 0;
 
     if (ecma_is_value_undefined (value))
     {
-      *num_p = ecma_number_make_nan ();
+      return ecma_make_nan_value ();
     }
     else if (ecma_is_value_null (value))
     {
-      *num_p = ECMA_NUMBER_ZERO;
+      num = 0;
     }
     else
     {
@@ -306,15 +306,15 @@ ecma_op_to_number (ecma_value_t value) /**< ecma value */
 
       if (ecma_is_value_true (value))
       {
-        *num_p = ECMA_NUMBER_ONE;
+        num = 1;
       }
       else
       {
-        *num_p = ECMA_NUMBER_ZERO;
+        num = 0;
       }
     }
 
-    return ecma_make_number_value (num_p);
+    return ecma_make_integer_value (num);
   }
 } /* ecma_op_to_number */
 
@@ -357,8 +357,8 @@ ecma_op_to_string (ecma_value_t value) /**< ecma value */
     }
     else if (ecma_is_value_number (value))
     {
-      ecma_number_t *num_p = ecma_get_number_from_value (value);
-      res_p = ecma_new_ecma_string_from_number (*num_p);
+      ecma_number_t num = ecma_get_number_from_value (value);
+      res_p = ecma_new_ecma_string_from_number (num);
     }
     else if (ecma_is_value_undefined (value))
     {

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -289,7 +289,7 @@ ecma_op_function_try_lazy_instantiate_property (ecma_object_t *obj_p, /**< the f
     /* ECMA-262 v5, 13.2, 14-15 */
 
     // 14
-    ecma_number_t *len_p = ecma_alloc_number ();
+    uint32_t len = 0;
 
     ecma_property_t *bytecode_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CODE_BYTECODE);
 
@@ -300,12 +300,12 @@ ecma_op_function_try_lazy_instantiate_property (ecma_object_t *obj_p, /**< the f
     if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_UINT16_ARGUMENTS)
     {
       cbc_uint16_arguments_t *args_p = (cbc_uint16_arguments_t *) bytecode_data_p;
-      *len_p = args_p->argument_end;
+      len = args_p->argument_end;
     }
     else
     {
       cbc_uint8_arguments_t *args_p = (cbc_uint8_arguments_t *) bytecode_data_p;
-      *len_p = args_p->argument_end;
+      len = args_p->argument_end;
     }
 
     // 15
@@ -315,9 +315,7 @@ ecma_op_function_try_lazy_instantiate_property (ecma_object_t *obj_p, /**< the f
                                                                       false,
                                                                       false);
 
-    ecma_named_data_property_assign_value (obj_p, length_prop_p, ecma_make_number_value (len_p));
-
-    ecma_dealloc_number (len_p);
+    ecma_named_data_property_assign_value (obj_p, length_prop_p, ecma_make_uint32_value (len));
 
     JERRY_ASSERT (!ecma_is_property_configurable (length_prop_p));
     return length_prop_p;

--- a/jerry-core/ecma/operations/ecma-number-object.c
+++ b/jerry-core/ecma/operations/ecma-number-object.c
@@ -48,7 +48,7 @@ ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Numb
     return conv_to_num_completion;
   }
 
-  ecma_number_t *prim_value_p = ecma_get_number_from_value (conv_to_num_completion);
+  ecma_number_t prim_value = ecma_get_number_from_value (conv_to_num_completion);
 
 #ifndef CONFIG_ECMA_COMPACT_PROFILE_DISABLE_NUMBER_BUILTIN
   ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_NUMBER_PROTOTYPE);
@@ -66,8 +66,11 @@ ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Numb
 
   ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_PRIMITIVE_NUMBER_VALUE);
+  ecma_number_t *prim_value_p = ecma_alloc_number ();
+  *prim_value_p = prim_value;
   ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_value_p);
 
+  ecma_free_value (conv_to_num_completion);
   return ecma_make_object_value (obj_p);
 } /* ecma_op_create_number_object */
 

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -79,8 +79,6 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
   bool is_strict = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE) != 0;
 
   // 1.
-  ecma_number_t *len_p = ecma_alloc_number ();
-  *len_p = ((ecma_number_t) arguments_number);
 
   // 4.
   ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
@@ -90,7 +88,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
   ecma_string_t *length_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
   ecma_value_t completion = ecma_builtin_helper_def_prop (obj_p,
                                                           length_magic_string_p,
-                                                          ecma_make_number_value (len_p),
+                                                          ecma_make_uint32_value (arguments_number),
                                                           true, /* Writable */
                                                           false, /* Enumerable */
                                                           true, /* Configurable */
@@ -98,8 +96,6 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
 
   JERRY_ASSERT (ecma_is_value_true (completion));
   ecma_deref_ecma_string (length_magic_string_p);
-
-  ecma_dealloc_number (len_p);
 
   ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
 

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -214,11 +214,7 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp obejct */
 
   ecma_deref_ecma_string (magic_string_p);
 
-  ecma_number_t *lastindex_num_p = ecma_alloc_number ();
-  *lastindex_num_p = ECMA_NUMBER_ZERO;
-  JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
-  ecma_named_data_property_assign_value (re_obj_p, prop_p, ecma_make_number_value (lastindex_num_p));
-  ecma_dealloc_number (lastindex_num_p);
+  ecma_named_data_property_assign_value (re_obj_p, prop_p, ecma_make_integer_value (0));
 } /* re_initialize_props */
 
 /**
@@ -1184,18 +1180,13 @@ re_set_result_array_properties (ecma_object_t *array_obj_p, /**< result array */
   /* Set index property of the result array */
   ecma_string_t *result_prop_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
   {
-    ecma_number_t *num_p = ecma_alloc_number ();
-    *num_p = (ecma_number_t) index;
-
     ecma_builtin_helper_def_prop (array_obj_p,
                                   result_prop_str_p,
-                                  ecma_make_number_value (num_p),
+                                  ecma_make_int32_value (index),
                                   true, /* Writable */
                                   true, /* Enumerable */
                                   true, /* Configurable */
                                   true); /* Failure handling */
-
-    ecma_dealloc_number (num_p);
   }
   ecma_deref_ecma_string (result_prop_str_p);
 
@@ -1215,20 +1206,15 @@ re_set_result_array_properties (ecma_object_t *array_obj_p, /**< result array */
   /* Set length property of the result array */
   result_prop_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
   {
-
     ecma_property_descriptor_t array_item_prop_desc = ecma_make_empty_property_descriptor ();
     array_item_prop_desc.is_value_defined = true;
 
-    ecma_number_t *num_p = ecma_alloc_number ();
-    *num_p = (ecma_number_t) (num_of_elements);
-    array_item_prop_desc.value = ecma_make_number_value (num_p);
+    array_item_prop_desc.value = ecma_make_uint32_value (num_of_elements);
 
     ecma_op_object_define_own_property (array_obj_p,
                                         result_prop_str_p,
                                         &array_item_prop_desc,
                                         true);
-
-    ecma_dealloc_number (num_p);
   }
   ecma_deref_ecma_string (result_prop_str_p);
 } /* re_set_result_array_properties */
@@ -1366,10 +1352,7 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
       if (re_ctx.flags & RE_FLAG_GLOBAL)
       {
         ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
-        ecma_number_t *lastindex_num_p = ecma_alloc_number ();
-        *lastindex_num_p = ECMA_NUMBER_ZERO;
-        ecma_op_object_put (regexp_object_p, magic_str_p, ecma_make_number_value (lastindex_num_p), true);
-        ecma_dealloc_number (lastindex_num_p);
+        ecma_op_object_put (regexp_object_p, magic_str_p, ecma_make_integer_value (0), true);
         ecma_deref_ecma_string (magic_str_p);
       }
 
@@ -1403,21 +1386,20 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
   if (input_curr_p && (re_ctx.flags & RE_FLAG_GLOBAL))
   {
     ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
-    ecma_number_t *lastindex_num_p = ecma_alloc_number ();
+    ecma_number_t lastindex_num;
 
     if (sub_str_p != NULL
         && input_buffer_p != NULL)
     {
-      *lastindex_num_p = lit_utf8_string_length (input_buffer_p,
-                                                 (lit_utf8_size_t) (sub_str_p - input_buffer_p));
+      lastindex_num = lit_utf8_string_length (input_buffer_p,
+                                              (lit_utf8_size_t) (sub_str_p - input_buffer_p));
     }
     else
     {
-      *lastindex_num_p = ECMA_NUMBER_ZERO;
+      lastindex_num = ECMA_NUMBER_ZERO;
     }
 
-    ecma_op_object_put (regexp_object_p, magic_str_p, ecma_make_number_value (lastindex_num_p), true);
-    ecma_dealloc_number (lastindex_num_p);
+    ecma_op_object_put (regexp_object_p, magic_str_p, ecma_make_number_value (lastindex_num), true);
     ecma_deref_ecma_string (magic_str_p);
   }
 

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -102,9 +102,8 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
   ecma_property_t *length_prop_p = ecma_create_named_data_property (obj_p,
                                                                     length_magic_string_p,
                                                                     false, false, false);
-  ecma_number_t *length_prop_value_p = ecma_alloc_number ();
-  *length_prop_value_p = length_value;
-  ecma_set_named_data_property_value (length_prop_p, ecma_make_number_value (length_prop_value_p));
+
+  ecma_set_named_data_property_value (length_prop_p, ecma_make_number_value (length_value));
   ecma_deref_ecma_string (length_magic_string_p);
 
   return ecma_make_object_value (obj_p);

--- a/jerry-core/ecma/operations/ecma-try-catch-macro.h
+++ b/jerry-core/ecma/operations/ecma-try-catch-macro.h
@@ -68,7 +68,7 @@
   ecma_number_t num_var = ecma_number_make_nan (); \
   if (ecma_is_value_number (value)) \
   { \
-    num_var = *ecma_get_number_from_value (value); \
+    num_var = ecma_get_number_from_value (value); \
   } \
   else \
   { \
@@ -76,7 +76,7 @@
                     ecma_op_to_number (value), \
                     return_value); \
     \
-    num_var = *ecma_get_number_from_value (to_number_value); \
+    num_var = ecma_get_number_from_value (to_number_value); \
     \
     ECMA_FINALIZE (to_number_value); \
   } \

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -397,14 +397,14 @@ jerry_api_convert_ecma_value_to_api_value (jerry_api_value_t *out_value_p, /**< 
   }
   else if (ecma_is_value_number (value))
   {
-    ecma_number_t *num = ecma_get_number_from_value (value);
+    ecma_number_t num = ecma_get_number_from_value (value);
 
 #if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32
     out_value_p->type = JERRY_API_DATA_TYPE_FLOAT32;
-    out_value_p->u.v_float32 = *num;
+    out_value_p->u.v_float32 = num;
 #elif CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64
     out_value_p->type = JERRY_API_DATA_TYPE_FLOAT64;
-    out_value_p->u.v_float64 = *num;
+    out_value_p->u.v_float64 = num;
 #endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32 */
   }
   else if (ecma_is_value_string (value))
@@ -461,28 +461,19 @@ jerry_api_convert_api_value_to_ecma_value (ecma_value_t *out_value_p, /**< [out]
     }
     case JERRY_API_DATA_TYPE_FLOAT32:
     {
-      ecma_number_t *num = ecma_alloc_number ();
-      *num = (ecma_number_t) (api_value_p->u.v_float32);
-
-      *out_value_p = ecma_make_number_value (num);
+      *out_value_p = ecma_make_number_value ((ecma_number_t) (api_value_p->u.v_float32));
 
       break;
     }
     case JERRY_API_DATA_TYPE_FLOAT64:
     {
-      ecma_number_t *num = ecma_alloc_number ();
-      *num = (ecma_number_t) (api_value_p->u.v_float64);
-
-      *out_value_p = ecma_make_number_value (num);
+      *out_value_p = ecma_make_number_value ((ecma_number_t) (api_value_p->u.v_float64));
 
       break;
     }
     case JERRY_API_DATA_TYPE_UINT32:
     {
-      ecma_number_t *num = ecma_alloc_number ();
-      *num = (ecma_number_t) (api_value_p->u.v_uint32);
-
-      *out_value_p = ecma_make_number_value (num);
+      *out_value_p = ecma_make_uint32_value ((uint32_t) (api_value_p->u.v_uint32));
 
       break;
     }
@@ -734,9 +725,7 @@ jerry_api_create_array_object (jerry_api_size_t size) /* size of array */
 {
   JERRY_ASSERT (size > 0);
 
-  ecma_number_t *length_num_p = ecma_alloc_number ();
-  *length_num_p = ((ecma_number_t) size);
-  ecma_value_t array_length = ecma_make_number_value (length_num_p);
+  ecma_value_t array_length = ecma_make_uint32_value (size);
 
   jerry_api_length_t argument_size = 1;
   ecma_value_t new_array_completion = ecma_op_create_array_object (&array_length, argument_size, true);

--- a/jerry-core/vm/opcodes-ecma-arithmetics.c
+++ b/jerry-core/vm/opcodes-ecma-arithmetics.c
@@ -50,38 +50,38 @@ do_number_arithmetic (number_arithmetic_op op, /**< number arithmetic operation 
   ECMA_OP_TO_NUMBER_TRY_CATCH (num_left, left_value, ret_value);
   ECMA_OP_TO_NUMBER_TRY_CATCH (num_right, right_value, ret_value);
 
-  ecma_number_t *res_p = ecma_alloc_number ();
+  ecma_number_t result = ECMA_NUMBER_ZERO;
 
   switch (op)
   {
     case NUMBER_ARITHMETIC_ADDITION:
     {
-      *res_p = ecma_number_add (num_left, num_right);
+      result = ecma_number_add (num_left, num_right);
       break;
     }
     case NUMBER_ARITHMETIC_SUBSTRACTION:
     {
-      *res_p = ecma_number_substract (num_left, num_right);
+      result = ecma_number_substract (num_left, num_right);
       break;
     }
     case NUMBER_ARITHMETIC_MULTIPLICATION:
     {
-      *res_p = ecma_number_multiply (num_left, num_right);
+      result = ecma_number_multiply (num_left, num_right);
       break;
     }
     case NUMBER_ARITHMETIC_DIVISION:
     {
-      *res_p = ecma_number_divide (num_left, num_right);
+      result = ecma_number_divide (num_left, num_right);
       break;
     }
     case NUMBER_ARITHMETIC_REMAINDER:
     {
-      *res_p = ecma_op_number_remainder (num_left, num_right);
+      result = ecma_op_number_remainder (num_left, num_right);
       break;
     }
   }
 
-  ret_value = ecma_make_number_value (res_p);
+  ret_value = ecma_make_number_value (result);
 
   ECMA_OP_TO_NUMBER_FINALIZE (num_right);
   ECMA_OP_TO_NUMBER_FINALIZE (num_left);
@@ -158,10 +158,7 @@ opfunc_unary_plus (ecma_value_t left_value) /**< left value */
                                left_value,
                                ret_value);
 
-  ecma_number_t *tmp_p = ecma_alloc_number ();
-
-  *tmp_p = num_var_value;
-  ret_value = ecma_make_number_value (tmp_p);
+  ret_value = ecma_make_number_value (num_var_value);
 
   ECMA_OP_TO_NUMBER_FINALIZE (num_var_value);
 
@@ -185,10 +182,7 @@ opfunc_unary_minus (ecma_value_t left_value) /**< left value */
                                left_value,
                                ret_value);
 
-  ecma_number_t *tmp_p = ecma_alloc_number ();
-
-  *tmp_p = ecma_number_negate (num_var_value);
-  ret_value = ecma_make_number_value (tmp_p);
+  ret_value = ecma_make_number_value (ecma_number_negate (num_var_value));
 
   ECMA_OP_TO_NUMBER_FINALIZE (num_var_value);
 

--- a/jerry-core/vm/opcodes-ecma-bitwise.c
+++ b/jerry-core/vm/opcodes-ecma-bitwise.c
@@ -48,7 +48,7 @@ do_number_bitwise_logic (number_bitwise_logic_op op, /**< number bitwise logic o
   ECMA_OP_TO_NUMBER_TRY_CATCH (num_left, left_value, ret_value);
   ECMA_OP_TO_NUMBER_TRY_CATCH (num_right, right_value, ret_value);
 
-  ecma_number_t *res_p = ecma_alloc_number ();
+  ecma_number_t result = ECMA_NUMBER_ZERO;
   uint32_t right_uint32 = ecma_number_to_uint32 (num_right);
 
   switch (op)
@@ -56,45 +56,45 @@ do_number_bitwise_logic (number_bitwise_logic_op op, /**< number bitwise logic o
     case NUMBER_BITWISE_LOGIC_AND:
     {
       uint32_t left_uint32 = ecma_number_to_uint32 (num_left);
-      *res_p = (ecma_number_t) ((int32_t) (left_uint32 & right_uint32));
+      result = (ecma_number_t) ((int32_t) (left_uint32 & right_uint32));
       break;
     }
     case NUMBER_BITWISE_LOGIC_OR:
     {
       uint32_t left_uint32 = ecma_number_to_uint32 (num_left);
-      *res_p = (ecma_number_t) ((int32_t) (left_uint32 | right_uint32));
+      result = (ecma_number_t) ((int32_t) (left_uint32 | right_uint32));
       break;
     }
     case NUMBER_BITWISE_LOGIC_XOR:
     {
       uint32_t left_uint32 = ecma_number_to_uint32 (num_left);
-      *res_p = (ecma_number_t) ((int32_t) (left_uint32 ^ right_uint32));
+      result = (ecma_number_t) ((int32_t) (left_uint32 ^ right_uint32));
       break;
     }
     case NUMBER_BITWISE_SHIFT_LEFT:
     {
-      *res_p = (ecma_number_t) (ecma_number_to_int32 (num_left) << (right_uint32 & 0x1F));
+      result = (ecma_number_t) (ecma_number_to_int32 (num_left) << (right_uint32 & 0x1F));
       break;
     }
     case NUMBER_BITWISE_SHIFT_RIGHT:
     {
-      *res_p = (ecma_number_t) (ecma_number_to_int32 (num_left) >> (right_uint32 & 0x1F));
+      result = (ecma_number_t) (ecma_number_to_int32 (num_left) >> (right_uint32 & 0x1F));
       break;
     }
     case NUMBER_BITWISE_SHIFT_URIGHT:
     {
       uint32_t left_uint32 = ecma_number_to_uint32 (num_left);
-      *res_p = (ecma_number_t) (left_uint32 >> (right_uint32 & 0x1F));
+      result = (ecma_number_t) (left_uint32 >> (right_uint32 & 0x1F));
       break;
     }
     case NUMBER_BITWISE_NOT:
     {
-      *res_p = (ecma_number_t) ((int32_t) ~right_uint32);
+      result = (ecma_number_t) ((int32_t) ~right_uint32);
       break;
     }
   }
 
-  ret_value = ecma_make_number_value (res_p);
+  ret_value = ecma_make_number_value (result);
 
   ECMA_OP_TO_NUMBER_FINALIZE (num_right);
   ECMA_OP_TO_NUMBER_FINALIZE (num_left);


### PR DESCRIPTION
The patch is an initial patch to store 28 bit integer values in ecma_values. This is a first patch in a series of patches which exploits these integer numbers to accelerate math performance, since most numbers are small integer numbers in JavaScript. The memory saving is resulted by not allocating doubles for these integer numbers. The follow-up patches will likely not affect memory.

RPi2 results
```

                      Benchmark |          RSS(+ is better) |                   Perf(+ is better)
                     3d-cube.js |   84k ->   68k : +19.048% |   2.176s ->   2.096s :  +3.676%  (+-0.720%) : [+]
         access-binary-trees.js |   72k ->   72k :  +0.000% |   1.200s ->   1.144s :  +4.667%  (+-0.940%) : [+]
             access-fannkuch.js |   32k ->   32k :  +0.000% |   6.366s ->   6.084s :  +4.430%  (+-0.515%) : [+]
                access-nbody.js |   36k ->   36k :  +0.000% |   2.414s ->   2.452s :  -1.574%  (+-1.491%) : [-]
    bitops-3bit-bits-in-byte.js |   24k ->   24k :  +0.000% |   1.378s ->   1.336s :  +3.048%  (+-1.462%) : [+]
         bitops-bits-in-byte.js |   24k ->   24k :  +0.000% |   2.058s ->   1.894s :  +7.969%  (+-0.685%) : [+]
          bitops-bitwise-and.js |   24k ->   24k :  +0.000% |   2.798s ->   2.882s :  -3.002%  (+-1.157%) : [-]
          bitops-nsieve-bits.js |  164k ->  164k :  +0.000% |   3.956s ->   4.042s :  -2.174%  (+-0.743%) : [-]
       controlflow-recursive.js |  124k ->  112k :  +9.677% |   0.808s ->   0.740s :  +8.416%  (+-1.044%) : [+]
                  crypto-aes.js |  104k ->   96k :  +7.692% |   2.898s ->   2.690s :  +7.177%  (+-0.583%) : [+]
                  crypto-md5.js |  168k ->  168k :  +0.000% |   1.194s ->   1.202s :  -0.670%  (+-1.224%) : [≈]
                 crypto-sha1.js |  116k ->  116k :  +0.000% |   1.130s ->   1.144s :  -1.239%  (+-0.998%) : [-]
           date-format-tofte.js |   56k ->   56k :  +0.000% |   1.730s ->   1.648s :  +4.740%  (+-0.962%) : [+]
           date-format-xparb.js |   52k ->   52k :  +0.000% |   0.742s ->   0.690s :  +7.008%  (+-1.154%) : [+]
                 math-cordic.js |   28k ->   24k : +14.286% |   2.456s ->   2.486s :  -1.221%  (+-1.071%) : [-]
           math-partial-sums.js |   24k ->   24k :  +0.000% |   1.346s ->   1.410s :  -4.755%  (+-0.878%) : [-]
          math-spectral-norm.js |   32k ->   32k :  +0.000% |   1.190s ->   1.188s :  +0.168%  (+-0.774%) : [≈]
               string-base64.js |  156k ->  148k :  +5.128% |   5.290s ->   5.178s :  +2.117%  (+-1.191%) : [+]
                string-fasta.js |   40k ->   40k :  +0.000% |   2.702s ->   2.688s :  +0.518%  (+-1.502%) : [≈]
                Geometric mean: |     RSS reduction: 3.108% |                   Speed up: 2.146% (+-0.244%) : [+]

Binaries
master: 173,568
branch: 173,480
```
