### PR TITLE
Fix return value of 'jerry_api_get_object_field_value'

### DIFF
--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -1225,19 +1225,23 @@ jerry_api_get_object_field_value_sz (jerry_api_object_t *object_p, /**< object *
   ecma_string_t *field_name_str_p = ecma_new_ecma_string_from_utf8 ((lit_utf8_byte_t *) field_name_p,
                                                                     (lit_utf8_size_t) field_name_size);
 
-  ecma_value_t get_completion = ecma_op_object_get (object_p,
-                                                    field_name_str_p);
+  ecma_value_t field_value = ecma_op_object_get (object_p, field_name_str_p);
 
-  if (!ecma_is_value_error (get_completion))
+  if (!ecma_is_value_error (field_value))
   {
-    jerry_api_convert_ecma_value_to_api_value (field_value_p, get_completion);
+    jerry_api_convert_ecma_value_to_api_value (field_value_p, field_value);
+
+    if (ecma_is_value_undefined (field_value))
+    {
+      is_successful = false;
+    }
   }
   else
   {
     is_successful = false;
   }
 
-  ecma_free_value (get_completion);
+  ecma_free_value (field_value);
 
   ecma_deref_ecma_string (field_name_str_p);
 

--- a/tests/unit/test-api.c
+++ b/tests/unit/test-api.c
@@ -351,6 +351,11 @@ main (void)
   JERRY_ASSERT (sz == 0);
   jerry_api_release_value (&args[0]);
 
+  // Get global.boo (non-existing field)
+  is_ok = jerry_api_get_object_field_value (global_obj_p, (jerry_api_char_t *) "boo", &val_t);
+  JERRY_ASSERT (!is_ok);
+  JERRY_ASSERT (val_t.type == JERRY_API_DATA_TYPE_UNDEFINED);
+
   // Get global.t
   is_ok = jerry_api_get_object_field_value (global_obj_p, (jerry_api_char_t *)"t", &val_t);
   JERRY_ASSERT (is_ok


### PR DESCRIPTION
Fixed the return value to return false when the field does
not exist as the documentation says.

Related issue: #1041

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com