### PR TITLE
Fix check-signed-off.sh: remove CR from git show output

### DIFF
--- a/tools/check-signed-off.sh
+++ b/tools/check-signed-off.sh
@@ -31,7 +31,7 @@ fi
 author_name=`git show -s --format=%an $commit_hash`
 author_email=`git show -s --format=%ae $commit_hash`
 required_signed_off_by_line="JerryScript-DCO-1.0-Signed-off-by: $author_name $author_email"
-actual_signed_off_by_line=`git show -s --format=%B $commit_hash | sed '/^$/d' | tail -n 1`
+actual_signed_off_by_line=`git show -s --format=%B $commit_hash | sed '/^$/d' | tr -d '\015' | tail -n 1`
 
 if [ "$actual_signed_off_by_line" != "$required_signed_off_by_line" ]
 then


### PR DESCRIPTION
When merging PRs via the GitHub web interface, CR characters can
sporadically appear in the commit message. This can also cause
signed-off-by message mismatch in check-signed-off.sh (even if
everything else is OK). To be on the safe side, this patch removes
any CR characters from the output of git show when performing the
check.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu