### PR TITLE
Use const object parameters in getter API functions

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-external-pointers.c
+++ b/jerry-core/ecma/base/ecma-helpers-external-pointers.c
@@ -104,7 +104,7 @@ ecma_create_external_pointer_property (ecma_object_t *obj_p, /**< object to crea
  *         false - otherwise (value returned through out_pointer_p is NULL).
  */
 bool
-ecma_get_external_pointer_value (ecma_object_t *obj_p, /**< object to get property value from */
+ecma_get_external_pointer_value (const ecma_object_t *obj_p, /**< object to get property value from */
                                  ecma_internal_property_id_t id, /**< identifier of internal property
                                                                   *   to get value from */
                                  ecma_external_pointer_t *out_pointer_p) /**< [out] value of the external pointer */

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -511,7 +511,7 @@ ecma_create_internal_property (ecma_object_t *object_p, /**< the object */
  *         NULL - otherwise.
  */
 ecma_property_t *
-ecma_find_internal_property (ecma_object_t *object_p, /**< object descriptor */
+ecma_find_internal_property (const ecma_object_t *object_p, /**< object descriptor */
                              ecma_internal_property_id_t property_id) /**< internal property identifier */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -557,7 +557,7 @@ ecma_find_internal_property (ecma_object_t *object_p, /**< object descriptor */
  * @return pointer to the property
  */
 ecma_property_t *
-ecma_get_internal_property (ecma_object_t *object_p, /**< object descriptor */
+ecma_get_internal_property (const ecma_object_t *object_p, /**< object descriptor */
                             ecma_internal_property_id_t property_id) /**< internal property identifier */
 {
   ecma_property_t *property_p = ecma_find_internal_property (object_p, property_id);
@@ -1096,7 +1096,7 @@ ecma_set_internal_property_value (ecma_property_t *prop_p, /**< property */
  *      value previously stored in the property is freed
  */
 void
-ecma_named_data_property_assign_value (ecma_object_t *obj_p, /**< object */
+ecma_named_data_property_assign_value (const ecma_object_t *obj_p, /**< object */
                                        ecma_property_t *prop_p, /**< property */
                                        ecma_value_t value) /**< value to assign */
 {

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -263,8 +263,8 @@ extern ecma_object_t *ecma_get_lex_env_binding_object (const ecma_object_t *) __
 extern bool ecma_get_lex_env_provide_this (const ecma_object_t *) __attr_pure___;
 
 extern ecma_property_t *ecma_create_internal_property (ecma_object_t *, ecma_internal_property_id_t);
-extern ecma_property_t *ecma_find_internal_property (ecma_object_t *, ecma_internal_property_id_t);
-extern ecma_property_t *ecma_get_internal_property (ecma_object_t *, ecma_internal_property_id_t);
+extern ecma_property_t *ecma_find_internal_property (const ecma_object_t *, ecma_internal_property_id_t);
+extern ecma_property_t *ecma_get_internal_property (const ecma_object_t *, ecma_internal_property_id_t);
 
 extern ecma_property_t *
 ecma_create_named_data_property (ecma_object_t *, ecma_string_t *, uint8_t);
@@ -283,7 +283,7 @@ extern void ecma_delete_property (ecma_object_t *, ecma_property_t *);
 
 extern ecma_value_t ecma_get_named_data_property_value (const ecma_property_t *);
 extern void ecma_set_named_data_property_value (ecma_property_t *, ecma_value_t);
-extern void ecma_named_data_property_assign_value (ecma_object_t *, ecma_property_t *, ecma_value_t);
+extern void ecma_named_data_property_assign_value (const ecma_object_t *, ecma_property_t *, ecma_value_t);
 
 extern ecma_value_t ecma_get_internal_property_value (const ecma_property_t *);
 extern void ecma_set_internal_property_value (ecma_property_t *, ecma_value_t);
@@ -315,7 +315,7 @@ extern void ecma_bytecode_deref (ecma_compiled_code_t *);
 extern bool
 ecma_create_external_pointer_property (ecma_object_t *, ecma_internal_property_id_t, ecma_external_pointer_t);
 extern bool
-ecma_get_external_pointer_value (ecma_object_t *, ecma_internal_property_id_t, ecma_external_pointer_t *);
+ecma_get_external_pointer_value (const ecma_object_t *, ecma_internal_property_id_t, ecma_external_pointer_t *);
 extern void
 ecma_free_external_pointer_in_property (ecma_property_t *);
 

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -167,7 +167,7 @@ ecma_lcache_insert (ecma_object_t *object_p, /**< object */
  *         NULL otherwise
  */
 inline ecma_property_t * __attr_always_inline___
-ecma_lcache_lookup (ecma_object_t *object_p, /**< object */
+ecma_lcache_lookup (const ecma_object_t *object_p, /**< object */
                     const ecma_string_t *prop_name_p) /**< property's name */
 {
   JERRY_ASSERT (object_p != NULL);

--- a/jerry-core/ecma/base/ecma-lcache.h
+++ b/jerry-core/ecma/base/ecma-lcache.h
@@ -25,7 +25,7 @@
 
 extern void ecma_lcache_init (void);
 extern void ecma_lcache_insert (ecma_object_t *, ecma_string_t *, ecma_property_t *);
-extern ecma_property_t *ecma_lcache_lookup (ecma_object_t *, const ecma_string_t *);
+extern ecma_property_t *ecma_lcache_lookup (const ecma_object_t *, const ecma_string_t *);
 extern void ecma_lcache_invalidate (ecma_object_t *, ecma_string_t *, ecma_property_t *);
 
 /**

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -373,7 +373,7 @@ ecma_op_function_try_lazy_instantiate_property (ecma_object_t *obj_p, /**< the f
  *         NULL (i.e. ecma-undefined) - otherwise.
  */
 ecma_property_t *
-ecma_op_function_object_get_own_property (ecma_object_t *obj_p, /**< the function object */
+ecma_op_function_object_get_own_property (const ecma_object_t *obj_p, /**< the function object */
                                           ecma_string_t *property_name_p) /**< property name */
 {
   JERRY_ASSERT (ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_FUNCTION);
@@ -386,7 +386,7 @@ ecma_op_function_object_get_own_property (ecma_object_t *obj_p, /**< the functio
   }
   else if (!ecma_get_object_is_builtin (obj_p))
   {
-    prop_p = ecma_op_function_try_lazy_instantiate_property (obj_p, property_name_p);
+    prop_p = ecma_op_function_try_lazy_instantiate_property ((ecma_object_t *) obj_p, property_name_p);
 
     /*
      * Only non-configurable properties could be instantiated lazily in the function,

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -45,7 +45,7 @@ ecma_op_function_call (ecma_object_t *, ecma_value_t,
                        const ecma_value_t *, ecma_length_t);
 
 extern ecma_property_t *
-ecma_op_function_object_get_own_property (ecma_object_t *, ecma_string_t *);
+ecma_op_function_object_get_own_property (const ecma_object_t *, ecma_string_t *);
 
 extern ecma_value_t
 ecma_op_function_construct (ecma_object_t *, const ecma_value_t *, ecma_length_t);

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -307,7 +307,7 @@ ecma_arguments_get_mapped_arg_value (ecma_object_t *map_p, /**< [[ParametersMap]
  *         Returned value must be freed with ecma_free_value
  */
 ecma_value_t
-ecma_op_arguments_object_get (ecma_object_t *obj_p, /**< the object */
+ecma_op_arguments_object_get (const ecma_object_t *obj_p, /**< the object */
                               ecma_string_t *property_name_p) /**< property name */
 {
   // 1.
@@ -344,7 +344,7 @@ ecma_op_arguments_object_get (ecma_object_t *obj_p, /**< the object */
  *         Returned value must be freed with ecma_free_value
  */
 ecma_property_t *
-ecma_op_arguments_object_get_own_property (ecma_object_t *obj_p, /**< the object */
+ecma_op_arguments_object_get_own_property (const ecma_object_t *obj_p, /**< the object */
                                            ecma_string_t *property_name_p) /**< property name */
 {
   // 1.

--- a/jerry-core/ecma/operations/ecma-objects-arguments.h
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.h
@@ -24,9 +24,9 @@ ecma_op_create_arguments_object (ecma_object_t *, ecma_object_t *, const ecma_va
                                  ecma_length_t, const ecma_compiled_code_t *);
 
 extern ecma_value_t
-ecma_op_arguments_object_get (ecma_object_t *, ecma_string_t *);
+ecma_op_arguments_object_get (const ecma_object_t *, ecma_string_t *);
 extern ecma_property_t *
-ecma_op_arguments_object_get_own_property (ecma_object_t *, ecma_string_t *);
+ecma_op_arguments_object_get_own_property (const ecma_object_t *, ecma_string_t *);
 extern ecma_value_t
 ecma_op_arguments_object_delete (ecma_object_t *, ecma_string_t *, bool);
 extern ecma_value_t

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -140,7 +140,7 @@ ecma_op_create_object_object_noarg_and_set_prototype (ecma_object_t *object_prot
  *         Returned value must be freed with ecma_free_value
  */
 ecma_value_t
-ecma_op_general_object_get (ecma_object_t *obj_p, /**< the object */
+ecma_op_general_object_get (const ecma_object_t *obj_p, /**< the object */
                             ecma_string_t *property_name_p) /**< property name */
 {
   JERRY_ASSERT (obj_p != NULL
@@ -194,14 +194,14 @@ ecma_op_general_object_get (ecma_object_t *obj_p, /**< the object */
  *         NULL (i.e. ecma-undefined) - otherwise.
  */
 ecma_property_t *
-ecma_op_general_object_get_own_property (ecma_object_t *obj_p, /**< the object */
+ecma_op_general_object_get_own_property (const ecma_object_t *obj_p, /**< the object */
                                          ecma_string_t *property_name_p) /**< property name */
 {
   JERRY_ASSERT (obj_p != NULL
                 && !ecma_is_lexical_environment (obj_p));
   JERRY_ASSERT (property_name_p != NULL);
 
-  return ecma_find_named_property (obj_p, property_name_p);
+  return ecma_find_named_property ((ecma_object_t *) obj_p, property_name_p);
 } /* ecma_op_general_object_get_own_property */
 
 /**
@@ -215,7 +215,7 @@ ecma_op_general_object_get_own_property (ecma_object_t *obj_p, /**< the object *
  *         NULL (i.e. ecma-undefined) - otherwise.
  */
 ecma_property_t *
-ecma_op_general_object_get_property (ecma_object_t *obj_p, /**< the object */
+ecma_op_general_object_get_property (const ecma_object_t *obj_p, /**< the object */
                                      ecma_string_t *property_name_p) /**< property name */
 {
   JERRY_ASSERT (obj_p != NULL

--- a/jerry-core/ecma/operations/ecma-objects-general.h
+++ b/jerry-core/ecma/operations/ecma-objects-general.h
@@ -31,9 +31,9 @@ extern ecma_object_t *ecma_op_create_object_object_noarg (void);
 extern ecma_value_t ecma_op_create_object_object_arg (ecma_value_t);
 extern ecma_object_t *ecma_op_create_object_object_noarg_and_set_prototype (ecma_object_t *);
 
-extern ecma_value_t ecma_op_general_object_get (ecma_object_t *, ecma_string_t *);
-extern ecma_property_t *ecma_op_general_object_get_own_property (ecma_object_t *, ecma_string_t *);
-extern ecma_property_t *ecma_op_general_object_get_property (ecma_object_t *, ecma_string_t *);
+extern ecma_value_t ecma_op_general_object_get (const ecma_object_t *, ecma_string_t *);
+extern ecma_property_t *ecma_op_general_object_get_own_property (const ecma_object_t *, ecma_string_t *);
+extern ecma_property_t *ecma_op_general_object_get_property (const ecma_object_t *, ecma_string_t *);
 extern ecma_value_t ecma_op_general_object_put (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
 extern ecma_value_t ecma_op_general_object_delete (ecma_object_t *, ecma_string_t *, bool);
 extern ecma_value_t ecma_op_general_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -59,7 +59,7 @@
  *         Returned value must be freed with ecma_free_value
  */
 ecma_value_t
-ecma_op_object_get (ecma_object_t *obj_p, /**< the object */
+ecma_op_object_get (const ecma_object_t *obj_p, /**< the object */
                     ecma_string_t *property_name_p) /**< property name */
 {
   JERRY_ASSERT (obj_p != NULL
@@ -101,11 +101,10 @@ ecma_op_object_get (ecma_object_t *obj_p, /**< the object */
  *         NULL (i.e. ecma-undefined) - otherwise.
  */
 static ecma_property_t * __attr_noinline___
-ecma_op_object_get_own_property_longpath (ecma_object_t *obj_p, /**< the object */
+ecma_op_object_get_own_property_longpath (const ecma_object_t *obj_p, /**< the object */
                                           ecma_string_t *property_name_p) /**< property name */
 {
   const ecma_object_type_t type = ecma_get_object_type (obj_p);
-  const bool is_builtin = ecma_get_object_is_builtin (obj_p);
 
   ecma_property_t *prop_p = NULL;
 
@@ -151,9 +150,9 @@ ecma_op_object_get_own_property_longpath (ecma_object_t *obj_p, /**< the object 
 
   if (unlikely (prop_p == NULL))
   {
-    if (is_builtin)
+    if (ecma_get_object_is_builtin (obj_p))
     {
-      prop_p = ecma_builtin_try_to_instantiate_property (obj_p, property_name_p);
+      prop_p = ecma_builtin_try_to_instantiate_property ((ecma_object_t *) obj_p, property_name_p);
     }
   }
 
@@ -170,7 +169,7 @@ ecma_op_object_get_own_property_longpath (ecma_object_t *obj_p, /**< the object 
  *         NULL (i.e. ecma-undefined) - otherwise.
  */
 ecma_property_t *
-ecma_op_object_get_own_property (ecma_object_t *obj_p, /**< the object */
+ecma_op_object_get_own_property (const ecma_object_t *obj_p, /**< the object */
                                  ecma_string_t *property_name_p) /**< property name */
 {
   JERRY_ASSERT (obj_p != NULL
@@ -199,7 +198,7 @@ ecma_op_object_get_own_property (ecma_object_t *obj_p, /**< the object */
  *         NULL (i.e. ecma-undefined) - otherwise.
  */
 ecma_property_t *
-ecma_op_object_get_property (ecma_object_t *obj_p, /**< the object */
+ecma_op_object_get_property (const ecma_object_t *obj_p, /**< the object */
                              ecma_string_t *property_name_p) /**< property name */
 {
   JERRY_ASSERT (obj_p != NULL

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -26,9 +26,9 @@
  * @{
  */
 
-extern ecma_value_t ecma_op_object_get (ecma_object_t *, ecma_string_t *);
-extern ecma_property_t *ecma_op_object_get_own_property (ecma_object_t *, ecma_string_t *);
-extern ecma_property_t *ecma_op_object_get_property (ecma_object_t *, ecma_string_t *);
+extern ecma_value_t ecma_op_object_get (const ecma_object_t *, ecma_string_t *);
+extern ecma_property_t *ecma_op_object_get_own_property (const ecma_object_t *, ecma_string_t *);
+extern ecma_property_t *ecma_op_object_get_property (const ecma_object_t *, ecma_string_t *);
 extern ecma_value_t ecma_op_object_put (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
 extern ecma_value_t ecma_op_object_delete (ecma_object_t *, ecma_string_t *, bool);
 extern ecma_value_t ecma_op_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -120,7 +120,7 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
  *         Returned value must be freed with ecma_free_value
  */
 ecma_property_t *
-ecma_op_string_object_get_own_property (ecma_object_t *obj_p, /**< a String object */
+ecma_op_string_object_get_own_property (const ecma_object_t *obj_p, /**< a String object */
                                         ecma_string_t *property_name_p) /**< property name */
 {
   JERRY_ASSERT (ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_STRING);
@@ -190,7 +190,7 @@ ecma_op_string_object_get_own_property (ecma_object_t *obj_p, /**< a String obje
     // 9.
     ecma_string_t *new_prop_str_value_p = ecma_new_ecma_string_from_code_unit (c);
 
-    new_prop_p = ecma_create_named_data_property (obj_p,
+    new_prop_p = ecma_create_named_data_property ((ecma_object_t *) obj_p,
                                                   new_prop_name_p,
                                                   ECMA_PROPERTY_FLAG_ENUMERABLE);
 

--- a/jerry-core/ecma/operations/ecma-string-object.h
+++ b/jerry-core/ecma/operations/ecma-string-object.h
@@ -29,7 +29,7 @@ extern ecma_value_t
 ecma_op_create_string_object (const ecma_value_t *, ecma_length_t);
 
 extern ecma_property_t *
-ecma_op_string_object_get_own_property (ecma_object_t *, ecma_string_t *);
+ecma_op_string_object_get_own_property (const ecma_object_t *, ecma_string_t *);
 
 extern void
 ecma_op_string_list_lazy_property_names (ecma_object_t *,

--- a/jerry-core/jerry-api.h
+++ b/jerry-core/jerry-api.h
@@ -184,7 +184,7 @@ jerry_string_t *jerry_create_string_sz (const jerry_char_t *, jerry_size_t);
  * Functions of array objects
  */
 bool jerry_set_array_index_value (jerry_object_t *, jerry_length_t, jerry_value_t);
-bool jerry_get_array_index_value (jerry_object_t *, jerry_length_t, jerry_value_t *);
+bool jerry_get_array_index_value (const jerry_object_t *, jerry_length_t, jerry_value_t *);
 
 /**
  * Functions of 'jerry_string_t'
@@ -200,12 +200,12 @@ bool jerry_is_constructor (const jerry_object_t *);
 bool jerry_is_function (const jerry_object_t *);
 bool jerry_add_object_field (jerry_object_t *, const jerry_char_t *, jerry_size_t, const jerry_value_t, bool);
 bool jerry_delete_object_field (jerry_object_t *, const jerry_char_t *, jerry_size_t);
-jerry_value_t jerry_get_object_field_value (jerry_object_t *, const jerry_char_t *);
-jerry_value_t jerry_get_object_field_value_sz (jerry_object_t *, const jerry_char_t *, jerry_size_t);
+jerry_value_t jerry_get_object_field_value (const jerry_object_t *, const jerry_char_t *);
+jerry_value_t jerry_get_object_field_value_sz (const jerry_object_t *, const jerry_char_t *, jerry_size_t);
 bool jerry_set_object_field_value (jerry_object_t *, const jerry_char_t *, const jerry_value_t);
 bool jerry_set_object_field_value_sz (jerry_object_t *, const jerry_char_t *, jerry_size_t, const jerry_value_t);
 bool jerry_foreach_object_field (jerry_object_t *, jerry_object_field_foreach_t, void *);
-bool jerry_get_object_native_handle (jerry_object_t *, uintptr_t *);
+bool jerry_get_object_native_handle (const jerry_object_t *, uintptr_t *);
 void jerry_set_object_native_handle (jerry_object_t *, uintptr_t, jerry_object_free_callback_t);
 jerry_value_t jerry_construct_object (jerry_object_t *, const jerry_value_t[], uint16_t);
 jerry_value_t jerry_call_function (jerry_object_t *, jerry_object_t *, const jerry_value_t[], uint16_t);

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -572,7 +572,7 @@ jerry_set_array_index_value (jerry_object_t *array_obj_p, /**< array object */
  *         throw exception - otherwise.
  */
 bool
-jerry_get_array_index_value (jerry_object_t *array_obj_p, /**< array object */
+jerry_get_array_index_value (const jerry_object_t *array_obj_p, /**< array object */
                              jerry_length_t index, /**< index to be written */
                              jerry_value_t *value_p) /**< [out] value at index */
 {
@@ -889,7 +889,7 @@ jerry_delete_object_field (jerry_object_t *object_p, /**< object to delete field
  *         false - otherwise.
  */
 jerry_value_t
-jerry_get_object_field_value (jerry_object_t *object_p, /**< object */
+jerry_get_object_field_value (const jerry_object_t *object_p, /**< object */
                               const jerry_char_t *field_name_p) /**< field name */
 {
   return jerry_get_object_field_value_sz (object_p,
@@ -958,7 +958,7 @@ jerry_foreach_object_field (jerry_object_t *object_p, /**< object */
  * @return jerry value of the given field
  */
 jerry_value_t
-jerry_get_object_field_value_sz (jerry_object_t *object_p, /**< object */
+jerry_get_object_field_value_sz (const jerry_object_t *object_p, /**< object */
                                  const jerry_char_t *field_name_p, /**< name of the field */
                                  jerry_size_t field_name_size) /**< size of field name in bytes */
 {
@@ -1034,7 +1034,7 @@ jerry_set_object_field_value_sz (jerry_object_t *object_p, /**< object */
  *         false - otherwise.
  */
 bool
-jerry_get_object_native_handle (jerry_object_t *object_p, /**< object to get handle from */
+jerry_get_object_native_handle (const jerry_object_t *object_p, /**< object to get handle from */
                                 uintptr_t *out_handle_p) /**< [out] handle value */
 {
   jerry_assert_api_available ();


### PR DESCRIPTION
Related issue: #668

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com