### PR TITLE
Shrink test logs by not printing full paths

### DIFF
--- a/tools/runners/run-test-suite.sh
+++ b/tools/runners/run-test-suite.sh
@@ -59,6 +59,25 @@ fi
 
 rm -f $TEST_FAILED $TEST_PASSED
 
+ROOT_DIR=""
+CURRENT_DIR=`pwd`
+PATH_STEP=2
+while true
+do
+    TMP_ROOT_DIR=`(echo "$CURRENT_DIR"; echo "$0"; echo "$ENGINE"; echo "$TESTS") | cut -f1-$PATH_STEP -d/ | uniq -d`
+    if [ -z "$TMP_ROOT_DIR" ]
+    then
+        break
+    else
+        ROOT_DIR="$TMP_ROOT_DIR"
+    fi
+    PATH_STEP=$((PATH_STEP+1))
+done
+if [ -n "$ROOT_DIR" ]
+then
+    ROOT_DIR="$ROOT_DIR/"
+fi
+
 tested=1
 failed=0
 passed=0
@@ -78,7 +97,7 @@ do
 
     full_test=$TESTS_DIR/${test#./}
 
-    echo -n "[$tested/$total] $ENGINE $ENGINE_ARGS $full_test: "
+    echo -n "[$tested/$total] ${ENGINE#$ROOT_DIR} $ENGINE_ARGS ${full_test#$ROOT_DIR}: "
 
     ( ulimit -t $TIMEOUT; $ENGINE $ENGINE_ARGS $full_test &>$ENGINE_TEMP )
     status_code=$?
@@ -111,7 +130,7 @@ rm -f $ENGINE_TEMP
 
 ratio=$(echo $passed*100/$total | bc)
 
-echo "[summary] $ENGINE $ENGINE_ARGS $TESTS: $passed PASS, $failed FAIL, $total total, $ratio% success"
+echo "[summary] ${ENGINE#$ROOT_DIR} $ENGINE_ARGS ${TESTS#$ROOT_DIR}: $passed PASS, $failed FAIL, $total total, $ratio% success"
 
 if [ $failed -ne 0 ]
 then

--- a/tools/runners/run-unittests.sh
+++ b/tools/runners/run-unittests.sh
@@ -32,6 +32,25 @@ then
     exit 1
 fi
 
+ROOT_DIR=""
+CURRENT_DIR=`pwd`
+PATH_STEP=2
+while true
+do
+    TMP_ROOT_DIR=`(echo "$CURRENT_DIR"; echo "$0"; echo "$DIR") | cut -f1-$PATH_STEP -d/ | uniq -d`
+    if [ -z "$TMP_ROOT_DIR" ]
+    then
+        break
+    else
+        ROOT_DIR="$TMP_ROOT_DIR"
+    fi
+    PATH_STEP=$((PATH_STEP+1))
+done
+if [ -n "$ROOT_DIR" ]
+then
+    ROOT_DIR="$ROOT_DIR/"
+fi
+
 tested=1
 failed=0
 passed=0
@@ -40,10 +59,10 @@ UNITTEST_TEMP=`mktemp unittest-out.XXXXXXXXXX`
 
 for unit_test in $UNITTESTS
 do
-  echo -n "[$tested/$total] $unit_test: "
+    echo -n "[$tested/$total] ${unit_test#$ROOT_DIR}: "
 
-  $unit_test &>$UNITTEST_TEMP
-  status_code=$?
+    $unit_test &>$UNITTEST_TEMP
+    status_code=$?
 
     if [ $status_code -ne 0 ]
     then
@@ -73,7 +92,7 @@ rm -f $UNITTEST_TEMP
 
 ratio=$(echo $passed*100/$total | bc)
 
-echo "[summary] $DIR/unit-*: $passed PASS, $failed FAIL, $total total, $ratio% success"
+echo "[summary] ${DIR#$ROOT_DIR}/unit-*: $passed PASS, $failed FAIL, $total total, $ratio% success"
 
 if [ $failed -ne 0 ]
 then


### PR DESCRIPTION
Both JS test suite and unit test logs can grow large as Makefile
invokes run-test-suite.sh and run-unittests.sh with absolute paths
to engines and test directories, which get then printed quite
often. This patch adds code to the runner scripts to determine the
longest directory path common to the current working directory, the
invoked script, the test directory, and the engine (in case of JS
tests). Then, when a path is to be printed, this common path
component is skipped.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu