### PR TITLE
Unify the condition form within the asserts

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -37,10 +37,10 @@
  */
 #define ECMA_NUMBER_CONVERSION_128BIT_INTEGER_CHECK_PARTS_ARE_32BIT(name) \
 { \
-  JERRY_ASSERT (name[0] == (uint32_t) name[0]); \
-  JERRY_ASSERT (name[1] == (uint32_t) name[1]); \
-  JERRY_ASSERT (name[2] == (uint32_t) name[2]); \
-  JERRY_ASSERT (name[3] == (uint32_t) name[3]); \
+  JERRY_ASSERT (name[0] <= UINT32_MAX); \
+  JERRY_ASSERT (name[1] <= UINT32_MAX); \
+  JERRY_ASSERT (name[2] <= UINT32_MAX); \
+  JERRY_ASSERT (name[3] <= UINT32_MAX); \
 }
 
 /**

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -42,8 +42,7 @@
 /**
  * The length should be representable with int32_t.
  */
-JERRY_STATIC_ASSERT ((int32_t) ECMA_STRING_MAX_CONCATENATION_LENGTH ==
-                     ECMA_STRING_MAX_CONCATENATION_LENGTH,
+JERRY_STATIC_ASSERT (ECMA_STRING_MAX_CONCATENATION_LENGTH <= INT32_MAX,
                      ECMA_STRING_MAX_CONCATENATION_LENGTH_should_be_representable_with_int32_t);
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -488,7 +488,7 @@ ecma_builtin_make_function_object_for_routine (ecma_builtin_id_t builtin_id, /**
   ecma_property_t *routine_desc_prop_p = ecma_create_internal_property (func_obj_p,
                                                                         ECMA_INTERNAL_PROPERTY_BUILT_IN_ROUTINE_DESC);
 
-  JERRY_ASSERT ((uint32_t) packed_value == packed_value);
+  JERRY_ASSERT (packed_value <= UINT32_MAX);
   ecma_set_internal_property_value (routine_desc_prop_p, (uint32_t) packed_value);
 
   return func_obj_p;
@@ -523,7 +523,7 @@ ecma_builtin_dispatch_call (ecma_object_t *obj_p, /**< built-in object */
     uint64_t routine_id_field = JRT_EXTRACT_BIT_FIELD (uint64_t, builtin_routine_desc,
                                                        ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_ROUTINE_ID_POS,
                                                        ECMA_BUILTIN_ROUTINE_ID_BUILT_IN_ROUTINE_ID_WIDTH);
-    JERRY_ASSERT ((uint16_t) routine_id_field == routine_id_field);
+    JERRY_ASSERT (routine_id_field <= UINT16_MAX);
 
     ecma_builtin_id_t built_in_id = (ecma_builtin_id_t) built_in_id_field;
     uint16_t routine_id = (uint16_t) routine_id_field;


### PR DESCRIPTION
This modificiation affects those conditions which check that
a value can be representable with a smaller type.

JerryScript-DCO-1.0-Signed-off-by: Robert Sipka rsipka.uszeged@partner.samsung.com