### PR TITLE
Don't concatenate multiple JS scripts in jerry

### DIFF
--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -1698,6 +1698,8 @@ jerry_parse (const jerry_api_char_t *source_p, /**< script source */
 {
   jerry_assert_api_available ();
 
+  vm_finalize ();
+
   int is_show_instructions = ((jerry_flags & JERRY_FLAG_SHOW_OPCODES) != 0);
 
   parser_set_show_instrs (is_show_instructions);

--- a/jerry-libc/include/stdio.h
+++ b/jerry-libc/include/stdio.h
@@ -38,13 +38,6 @@ extern FILE *stdout;
 extern FILE *stderr;
 
 /**
- * fseek's 'whence' argument values
- */
-#define SEEK_SET 0
-#define SEEK_CUR 1
-#define SEEK_END 2
-
-/**
  * I/O routines
  */
 int vfprintf (FILE *stream, const char *format, va_list ap);
@@ -52,10 +45,7 @@ FILE *fopen (const char *path, const char *mode);
 int fclose (FILE *fp);
 size_t fread (void *ptr, size_t size, size_t nmemb, FILE *stream);
 size_t fwrite (const void *ptr, size_t size, size_t nmemb, FILE *stream);
-int fseek (FILE *stream, long offset, int whence);
-long ftell (FILE *stream);
 int printf (const char *format, ...);
-void rewind (FILE *stream);
 int fprintf (FILE *stream, const char *format, ...);
 
 #ifdef __cplusplus

--- a/jerry-libc/target/posix/jerry-libc-target.c
+++ b/jerry-libc/target/posix/jerry-libc-target.c
@@ -182,16 +182,6 @@ fopen (const char *path, /**< file path */
 } /* fopen */
 
 /**
- * The rewind () function sets the file position indicator
- * for the stream pointed to by STREAM to the beginning of the file.
- */
-void
-rewind (FILE *stream) /**< stream pointer */
-{
-  syscall_3 (SYSCALL_NO (lseek), (long int) stream, 0, SEEK_SET);
-} /* rewind */
-
-/**
  * fclose
  *
  * @return 0 - upon successful completion,
@@ -204,31 +194,6 @@ fclose (FILE *fp) /**< stream pointer */
 
   return 0;
 } /* fclose */
-
-/**
- * fseek
- */
-int
-fseek (FILE * fp, /**< stream pointer */
-       long offset, /**< offset */
-       int whence) /**< specifies position type
-                    *   to add offset to */
-{
-  syscall_3 (SYSCALL_NO (lseek), (long int) fp, offset, whence);
-
-  return 0;
-} /* fseek */
-
-/**
- * ftell
- */
-long
-ftell (FILE * fp) /**< stream pointer */
-{
-  long int ret = syscall_3 (SYSCALL_NO (lseek), (long int) fp, 0, SEEK_CUR);
-
-  return ret;
-} /* ftell */
 
 /**
  * fread


### PR DESCRIPTION
Jerry (the command line tool) has been supporting the execution of
multiple script files for long. However, until now, it simply
concatenated all sources into a single source buffer and
parsed/executed them as one unit. Other JS execution tools (e.g.,
jsc, v8) load and execute separate files as separate units -- but
still in the same execution environment. The most significant
effect of this approach is that the `"use strict;"` directive (or
the absence of it) at the beginning of each JS script file takes
effect as expected (i.e., as if the script was executed alone).
Contrarily, the concatenation-based approach forces the strictness
of the first script on all the rest (i.e., if the first script
starts with `"use strict";` the rest is also executed in a strict
environment even if they did not contain the directive, and vice
versa).

This patch makes the jerry command line tool to load/parse/run one
unit at a time.

Side effects:
- As there is no need for separate file read routines that load one
  file (a snapshot) or concat multiple (JS sources) anymore, those
  routines got merged.
- Both previous read routines used multiple stdio functions
  (`fseek`, `ftell`, and `rewind`). This has been simplified to
  rely on `fread` only to find out the length of the input.
- This simplification made the above mentioned functions
  superfluous in jerry-libc.
- As some error messages had to be touched in this patch, several
  more have been beautified to make them more consistent.
- One small change was needed in `jerry_parse` in jerry-core to
  allow subsequent parsing of multiple sources (without that, an
  assertion was triggered).

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu