### PR TITLE
Micro optimizations of the virtual machine

### DIFF
--- a/jerry-core/parser/js/byte-code.h
+++ b/jerry-core/parser/js/byte-code.h
@@ -173,19 +173,19 @@
 
 #define CBC_FORWARD_BRANCH(name, stack, vm_oc) \
   CBC_OPCODE (name, CBC_HAS_BRANCH_ARG | CBC_FORWARD_BRANCH_ARG, stack, \
-              (vm_oc)) \
+              (vm_oc) | VM_OC_HAS_BRANCH_ARG) \
   CBC_OPCODE (name ## _2, CBC_HAS_BRANCH_ARG | CBC_FORWARD_BRANCH_ARG, stack, \
-              (vm_oc)) \
+              (vm_oc) | VM_OC_HAS_BRANCH_ARG) \
   CBC_OPCODE (name ## _3, CBC_HAS_BRANCH_ARG | CBC_FORWARD_BRANCH_ARG, stack, \
-              (vm_oc))
+              (vm_oc) | VM_OC_HAS_BRANCH_ARG)
 
 #define CBC_BACKWARD_BRANCH(name, stack, vm_oc) \
   CBC_OPCODE (name, CBC_HAS_BRANCH_ARG, stack, \
-              (vm_oc)) \
+              (vm_oc) | VM_OC_HAS_BRANCH_ARG | VM_OC_BACKWARD_BRANCH) \
   CBC_OPCODE (name ## _2, CBC_HAS_BRANCH_ARG, stack, \
-              (vm_oc)) \
+              (vm_oc) | VM_OC_HAS_BRANCH_ARG | VM_OC_BACKWARD_BRANCH) \
   CBC_OPCODE (name ## _3, CBC_HAS_BRANCH_ARG, stack, \
-              (vm_oc))
+              (vm_oc) | VM_OC_HAS_BRANCH_ARG | VM_OC_BACKWARD_BRANCH)
 
 #define CBC_BRANCH_OFFSET_LENGTH(opcode) \
   ((opcode) & 0x3)
@@ -243,7 +243,7 @@
   CBC_FORWARD_BRANCH (CBC_BRANCH_IF_LOGICAL_TRUE, -1, \
                       VM_OC_BRANCH_IF_LOGICAL_TRUE | VM_OC_GET_STACK) \
   CBC_OPCODE (CBC_ARRAY_APPEND, CBC_HAS_POP_STACK_BYTE_ARG, 0, \
-              VM_OC_APPEND_ARRAY | VM_OC_GET_BYTE) \
+              VM_OC_APPEND_ARRAY) \
   CBC_FORWARD_BRANCH (CBC_BRANCH_IF_LOGICAL_FALSE, -1, \
                       VM_OC_BRANCH_IF_LOGICAL_FALSE | VM_OC_GET_STACK) \
   CBC_OPCODE (CBC_PUSH_ELISION, CBC_NO_FLAG, 1, \
@@ -293,7 +293,7 @@
   CBC_OPCODE (CBC_PUSH_PROP_THIS_LITERAL_REFERENCE, CBC_HAS_LITERAL_ARG, 3, \
               VM_OC_PROP_REFERENCE | VM_OC_GET_THIS_LITERAL | VM_OC_PUT_STACK) \
   CBC_OPCODE (CBC_NEW, CBC_HAS_POP_STACK_BYTE_ARG, 0, \
-              VM_OC_NEW | VM_OC_GET_BYTE | VM_OC_PUT_STACK) \
+              VM_OC_NEW | VM_OC_PUT_STACK) \
   CBC_OPCODE (CBC_NEW0, CBC_NO_FLAG, 0, \
               VM_OC_NEW | VM_OC_PUT_STACK) \
   CBC_OPCODE (CBC_NEW1, CBC_NO_FLAG, -1, \
@@ -399,17 +399,17 @@
   \
   /* Call opcodes. */ \
   CBC_OPCODE (CBC_CALL, CBC_HAS_POP_STACK_BYTE_ARG, -1, \
-              VM_OC_CALL | VM_OC_GET_BYTE) \
+              VM_OC_CALL) \
   CBC_OPCODE (CBC_CALL_PUSH_RESULT, CBC_HAS_POP_STACK_BYTE_ARG, 0, \
-              VM_OC_CALL | VM_OC_GET_BYTE | VM_OC_PUT_STACK) \
+              VM_OC_CALL | VM_OC_PUT_STACK) \
   CBC_OPCODE (CBC_CALL_BLOCK, CBC_HAS_POP_STACK_BYTE_ARG, -1, \
-              VM_OC_CALL | VM_OC_GET_BYTE | VM_OC_PUT_BLOCK) \
+              VM_OC_CALL | VM_OC_PUT_BLOCK) \
   CBC_OPCODE (CBC_CALL_PROP, CBC_HAS_POP_STACK_BYTE_ARG, -3, \
-              VM_OC_CALL | VM_OC_GET_BYTE) \
+              VM_OC_CALL) \
   CBC_OPCODE (CBC_CALL_PROP_PUSH_RESULT, CBC_HAS_POP_STACK_BYTE_ARG, -2, \
-              VM_OC_CALL | VM_OC_GET_BYTE | VM_OC_PUT_STACK) \
+              VM_OC_CALL | VM_OC_PUT_STACK) \
   CBC_OPCODE (CBC_CALL_PROP_BLOCK, CBC_HAS_POP_STACK_BYTE_ARG, -3, \
-              VM_OC_CALL | VM_OC_GET_BYTE | VM_OC_PUT_BLOCK) \
+              VM_OC_CALL | VM_OC_PUT_BLOCK) \
   CBC_OPCODE (CBC_CALL0, CBC_NO_FLAG, -1, \
               VM_OC_CALL) \
   CBC_OPCODE (CBC_CALL0_PUSH_RESULT, CBC_NO_FLAG, 0, \

--- a/jerry-core/vm/vm.h
+++ b/jerry-core/vm/vm.h
@@ -43,6 +43,16 @@
  */
 
 /**
+ * Opcode has branch argument
+ */
+#define VM_OC_HAS_BRANCH_ARG 0x8000
+
+/**
+ * Branch argument is a backward branch
+ */
+#define VM_OC_BACKWARD_BRANCH 0x4000
+
+/**
  * Position of "get arguments" opcode.
  */
 #define VM_OC_GET_ARGS_SHIFT 7
@@ -50,7 +60,7 @@
 /**
  * Mask of "get arguments" opcode.
  */
-#define VM_OC_GET_ARGS_MASK 0x1f
+#define VM_OC_GET_ARGS_MASK 0x7
 
 /**
  * Generate the binary representation of a "get arguments" opcode.
@@ -60,7 +70,7 @@
 /**
  * Extract the "get arguments" opcode.
  */
-#define VM_OC_GET_ARGS_GET_INDEX(O) (((O) >> VM_OC_GET_ARGS_SHIFT) & VM_OC_GET_ARGS_MASK)
+#define VM_OC_GET_ARGS_INDEX(O) ((O) & (VM_OC_GET_ARGS_MASK << VM_OC_GET_ARGS_SHIFT))
 
 /**
  * Checks whether the result is stored somewhere.
@@ -73,16 +83,14 @@
 typedef enum
 {
   VM_OC_GET_NONE = VM_OC_GET_ARGS_CREATE_INDEX (0),             /**< do nothing */
-  VM_OC_GET_STACK = VM_OC_GET_ARGS_CREATE_INDEX (1),            /**< pop one elemnet from the stack */
-  VM_OC_GET_STACK_STACK = VM_OC_GET_ARGS_CREATE_INDEX (2),      /**< pop two elemnets from the stack */
-  VM_OC_GET_BYTE = VM_OC_GET_ARGS_CREATE_INDEX (3),             /**< read a byte */
+  VM_OC_GET_STACK = VM_OC_GET_ARGS_CREATE_INDEX (1),            /**< pop one element from the stack */
+  VM_OC_GET_STACK_STACK = VM_OC_GET_ARGS_CREATE_INDEX (2),      /**< pop two elements from the stack */
 
-  VM_OC_GET_LITERAL = VM_OC_GET_ARGS_CREATE_INDEX (4),          /**< resolve literal */
-  VM_OC_GET_STACK_LITERAL = VM_OC_GET_ARGS_CREATE_INDEX (5),    /**< pop one elemnet from the stack
+  VM_OC_GET_LITERAL = VM_OC_GET_ARGS_CREATE_INDEX (3),          /**< resolve literal */
+  VM_OC_GET_LITERAL_LITERAL = VM_OC_GET_ARGS_CREATE_INDEX (4),  /**< resolve two literals */
+  VM_OC_GET_STACK_LITERAL = VM_OC_GET_ARGS_CREATE_INDEX (5),    /**< pop one element from the stack
                                                                  *   and resolve a literal */
-  VM_OC_GET_LITERAL_BYTE = VM_OC_GET_ARGS_CREATE_INDEX (6),     /**< pop one elemnet from stack and read a byte */
-  VM_OC_GET_LITERAL_LITERAL = VM_OC_GET_ARGS_CREATE_INDEX (7),  /**< resolve two literals */
-  VM_OC_GET_THIS_LITERAL = VM_OC_GET_ARGS_CREATE_INDEX (8),     /**< get this and resolve a literal */
+  VM_OC_GET_THIS_LITERAL = VM_OC_GET_ARGS_CREATE_INDEX (6),     /**< get this and resolve a literal */
 } vm_oc_get_types;
 
 /**
@@ -229,7 +237,7 @@ typedef enum
 /**
  * Position of "put result" opcode.
  */
-#define VM_OC_PUT_RESULT_SHIFT 12
+#define VM_OC_PUT_RESULT_SHIFT 10
 
 /**
  * Mask of "put result" opcode.


### PR DESCRIPTION
  - Branch argument information is encoded in the vm byte
    code data, so CBC flags are not loaded anymore
  - The free_flags variable is removed from the vm_loop
  - Fast code paths are added for free_value and copy_value
  - Two cases are removed from "get arguments", argument
    processing is simplified
  - A dead code is removed: collections are not used anymore
    for passing arguments. This code path accidentally remanined
    when the support was removed.