### PR TITLE
Print each output line with one command in test runners

### DIFF
--- a/tools/runners/run-test-suite.sh
+++ b/tools/runners/run-test-suite.sh
@@ -112,35 +112,31 @@ do
     if [ "$IS_SNAPSHOT" == true ]
     then
         # Testing snapshot
-
         SNAPSHOT_TEMP=`mktemp snapshot-out.XXXXXXXXXX`
 
-        echo -n "[$tested/$total] ${ENGINE#$ROOT_DIR} $ENGINE_ARGS "
-        echo -n "--save-snapshot-for-global $SNAPSHOT_TEMP ${full_test#$ROOT_DIR}: "
-
+        cmd_line="${ENGINE#$ROOT_DIR} $ENGINE_ARGS --save-snapshot-for-global $SNAPSHOT_TEMP ${full_test#$ROOT_DIR}"
         ( ulimit -t $TIMEOUT; $ENGINE $ENGINE_ARGS --save-snapshot-for-global $SNAPSHOT_TEMP $full_test &> $ENGINE_TEMP )
         status_code=$?
 
         if [ $status_code -eq 0 ]
         then
-            echo "$PASS"
-            echo -n "[$tested/$total] ${ENGINE#$ROOT_DIR} $ENGINE_ARGS --exec-snapshot $SNAPSHOT_TEMP: "
+            echo "[$tested/$total] $cmd_line: PASS"
 
+            cmd_line="${ENGINE#$ROOT_DIR} $ENGINE_ARGS --exec-snapshot $SNAPSHOT_TEMP"
             ( ulimit -t $TIMEOUT; $ENGINE $ENGINE_ARGS --exec-snapshot $SNAPSHOT_TEMP &> $ENGINE_TEMP )
             status_code=$?
         fi
 
         rm -f $SNAPSHOT_TEMP
     else
-        echo -n "[$tested/$total] ${ENGINE#$ROOT_DIR} $ENGINE_ARGS ${full_test#$ROOT_DIR}: "
-
+        cmd_line="${ENGINE#$ROOT_DIR} $ENGINE_ARGS ${full_test#$ROOT_DIR}"
         ( ulimit -t $TIMEOUT; $ENGINE $ENGINE_ARGS $full_test &> $ENGINE_TEMP )
         status_code=$?
     fi
 
     if [ $status_code -ne $error_code ]
     then
-        echo "FAIL ($status_code)"
+        echo "[$tested/$total] $cmd_line: FAIL ($status_code)"
         cat $ENGINE_TEMP
 
         echo "$status_code: $test" >> $TEST_FAILED
@@ -152,7 +148,7 @@ do
 
         failed=$((failed+1))
     else
-        echo "$PASS"
+        echo "[$tested/$total] $cmd_line: $PASS"
 
         echo "$test" >> $TEST_PASSED
 

--- a/tools/runners/run-unittests.sh
+++ b/tools/runners/run-unittests.sh
@@ -59,14 +59,13 @@ UNITTEST_TEMP=`mktemp unittest-out.XXXXXXXXXX`
 
 for unit_test in $UNITTESTS
 do
-    echo -n "[$tested/$total] ${unit_test#$ROOT_DIR}: "
-
+    cmd_line="${unit_test#$ROOT_DIR}"
     $unit_test &>$UNITTEST_TEMP
     status_code=$?
 
     if [ $status_code -ne 0 ]
     then
-        echo "FAIL ($status_code)"
+        echo "[$tested/$total] $cmd_line: FAIL ($status_code)"
         cat $UNITTEST_TEMP
 
         echo "$status_code: $unit_test" >> $UNITTEST_ERROR
@@ -78,7 +77,7 @@ do
 
         failed=$((failed+1))
     else
-        echo "PASS"
+        echo "[$tested/$total] $cmd_line: PASS"
 
         echo "$unit_test" >> $UNITTEST_OK
 


### PR DESCRIPTION
When running multiple test suites in parallel -- e.g., as it
happens on the CI --, the names of the executed commands and the
results of the executions can/do get printed far from each other,
interrupted by other prints. This can make the reading of the
output hard. This patch prints each line with one echo command,
which makes the interruption of the line less likely.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu