### PR TITLE
Fix value passing in JerryScript

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -660,6 +660,11 @@ ecma_value_assign_value (ecma_value_t *value_p, /**< [in, out] ecma value */
   JERRY_STATIC_ASSERT (ECMA_TYPE_DIRECT == 0,
                        ecma_type_direct_must_be_zero_for_the_next_check);
 
+  if (*value_p == ecma_value)
+  {
+    return;
+  }
+
   if (ecma_get_value_type_field (ecma_value || *value_p) == ECMA_TYPE_DIRECT)
   {
     *value_p = ecma_value;

--- a/tests/jerry/regression-test-issue-1072.js
+++ b/tests/jerry/regression-test-issue-1072.js
@@ -1,0 +1,19 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright 2016 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try { new (this.$)(new (this.RegExp)().ignoreCase).$ ()  } catch($){}
+try { new (this.String)() .constructor.prototype.match()  } catch($){}
+try { this.RegExp().compile() } catch($){}
+try { this.$(this.RegExp.prototype .compile (this.RegExp.prototype))  } catch($){}


### PR DESCRIPTION
When the same value is assigned to a property, and its reference
counter is one, dereferencing the value frees its allocated memory.
In this case we return early.

Fixes #1072 and several others.
