### PR TITLE
Optimize conditional jumps.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -73,12 +73,12 @@ typedef enum
    *   - immutable binding values
    *   - special register or stack values for vm
    */
-  ECMA_SIMPLE_VALUE_EMPTY,
-  ECMA_SIMPLE_VALUE_UNDEFINED, /**< undefined value */
-  ECMA_SIMPLE_VALUE_NULL, /**< null value */
+  ECMA_SIMPLE_VALUE_EMPTY, /**< uninitialized value */
+  ECMA_SIMPLE_VALUE_ARRAY_HOLE, /**< array hole, used for initialization of an array literal */
   ECMA_SIMPLE_VALUE_FALSE, /**< boolean false */
   ECMA_SIMPLE_VALUE_TRUE, /**< boolean true */
-  ECMA_SIMPLE_VALUE_ARRAY_HOLE, /**< array hole, used for initialization of an array literal */
+  ECMA_SIMPLE_VALUE_UNDEFINED, /**< undefined value */
+  ECMA_SIMPLE_VALUE_NULL, /**< null value */
   ECMA_SIMPLE_VALUE_REGISTER_REF, /**< register reference, a special "base" value for vm */
   ECMA_SIMPLE_VALUE__COUNT /** count of simple ecma values */
 } ecma_simple_value_t;

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -114,26 +114,27 @@
   }
 
 /* ecma-helpers-value.c */
-extern bool ecma_is_value_empty (ecma_value_t);
-extern bool ecma_is_value_undefined (ecma_value_t);
-extern bool ecma_is_value_null (ecma_value_t);
-extern bool ecma_is_value_boolean (ecma_value_t);
-extern bool ecma_is_value_true (ecma_value_t);
-extern bool ecma_is_value_false (ecma_value_t);
-extern bool ecma_is_value_array_hole (ecma_value_t);
+extern bool ecma_is_value_simple (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_empty (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_undefined (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_null (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_boolean (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_true (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_false (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_array_hole (ecma_value_t) __attr_pure___;
 
-extern bool ecma_is_value_integer_number (ecma_value_t);
-extern bool ecma_are_values_integer_numbers (ecma_value_t, ecma_value_t);
-extern bool ecma_is_value_float_number (ecma_value_t);
-extern bool ecma_is_value_number (ecma_value_t);
-extern bool ecma_is_value_string (ecma_value_t);
-extern bool ecma_is_value_object (ecma_value_t);
-extern bool ecma_is_value_error (ecma_value_t);
+extern bool ecma_is_value_integer_number (ecma_value_t) __attr_pure___;
+extern bool ecma_are_values_integer_numbers (ecma_value_t, ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_float_number (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_number (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_string (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_object (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_error (ecma_value_t) __attr_pure___;
 
 extern void ecma_check_value_type_is_spec_defined (ecma_value_t);
 
-extern ecma_value_t ecma_make_simple_value (const ecma_simple_value_t value);
-extern ecma_value_t ecma_make_integer_value (ecma_integer_value_t);
+extern ecma_value_t ecma_make_simple_value (const ecma_simple_value_t value) __attr_const___;
+extern ecma_value_t ecma_make_integer_value (ecma_integer_value_t) __attr_const___;
 extern ecma_value_t ecma_make_nan_value (void);
 extern ecma_value_t ecma_make_number_value (ecma_number_t);
 extern ecma_value_t ecma_make_int32_value (int32_t);
@@ -142,12 +143,14 @@ extern ecma_value_t ecma_make_string_value (const ecma_string_t *);
 extern ecma_value_t ecma_make_object_value (const ecma_object_t *);
 extern ecma_value_t ecma_make_error_value (ecma_value_t);
 extern ecma_value_t ecma_make_error_obj_value (const ecma_object_t *);
-extern ecma_integer_value_t ecma_get_integer_from_value (ecma_value_t);
+extern ecma_integer_value_t ecma_get_integer_from_value (ecma_value_t) __attr_pure___;
+extern ecma_number_t ecma_get_float_from_value (ecma_value_t value) __attr_pure___;
 extern ecma_number_t ecma_get_number_from_value (ecma_value_t) __attr_pure___;
 extern uint32_t ecma_get_uint32_from_value (ecma_value_t) __attr_pure___;
 extern ecma_string_t *ecma_get_string_from_value (ecma_value_t) __attr_pure___;
 extern ecma_object_t *ecma_get_object_from_value (ecma_value_t) __attr_pure___;
 extern ecma_value_t ecma_get_value_from_error_value (ecma_value_t) __attr_pure___;
+extern ecma_value_t ecma_invert_boolean_value (ecma_value_t) __attr_pure___;
 extern ecma_value_t ecma_copy_value (ecma_value_t);
 extern ecma_value_t ecma_fast_copy_value (ecma_value_t);
 extern ecma_value_t ecma_copy_value_if_not_object (ecma_value_t);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -2027,8 +2027,8 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
         /* 7.c.ii */
         ECMA_TRY_CATCH (call_value, ecma_op_function_call (func_object_p, arg2, call_args, 3), ret_value);
 
-        /* 7.c.iii, ecma_op_to_boolean always returns a simple value, so no need to free. */
-        if (ecma_is_value_false (ecma_op_to_boolean (call_value)))
+        /* 7.c.iii */
+        if (!ecma_op_to_boolean (call_value))
         {
           ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
         }
@@ -2125,8 +2125,8 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
         /* 7.c.ii */
         ECMA_TRY_CATCH (call_value, ecma_op_function_call (func_object_p, arg2, call_args, 3), ret_value);
 
-        /* 7.c.iii, ecma_op_to_boolean always returns a simple value, so no need to free. */
-        if (ecma_is_value_true (ecma_op_to_boolean (call_value)))
+        /* 7.c.iii */
+        if (ecma_op_to_boolean (call_value))
         {
           ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
         }
@@ -2430,8 +2430,8 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
         /* 9.c.ii */
         ECMA_TRY_CATCH (call_value, ecma_op_function_call (func_object_p, arg2, call_args, 3), ret_value);
 
-        /* 9.c.iii, ecma_op_to_boolean always returns a simple value, so no need to free. */
-        if (ecma_is_value_true (ecma_op_to_boolean (call_value)))
+        /* 9.c.iii */
+        if (ecma_op_to_boolean (call_value))
         {
           ecma_string_t *to_index_string_p = ecma_new_ecma_string_from_uint32 (new_array_index);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.c
@@ -66,7 +66,8 @@ ecma_builtin_boolean_dispatch_call (const ecma_value_t *arguments_list_p, /**< a
     arg_value = arguments_list_p[0];
   }
 
-  return ecma_op_to_boolean (arg_value);
+  return ecma_make_simple_value (ecma_op_to_boolean (arg_value) ? ECMA_SIMPLE_VALUE_TRUE
+                                                                : ECMA_SIMPLE_VALUE_FALSE);
 } /* ecma_builtin_boolean_dispatch_call */
 
 /**

--- a/jerry-core/ecma/operations/ecma-boolean-object.c
+++ b/jerry-core/ecma/operations/ecma-boolean-object.c
@@ -41,12 +41,7 @@
 ecma_value_t
 ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boolean constructor */
 {
-  ecma_value_t conv_to_boolean_completion = ecma_op_to_boolean (arg);
-
-  if (ecma_is_value_error (conv_to_boolean_completion))
-  {
-    return conv_to_boolean_completion;
-  }
+  bool boolean_value = ecma_op_to_boolean (arg);
 
 #ifndef CONFIG_ECMA_COMPACT_PROFILE_DISABLE_BOOLEAN_BUILTIN
   ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_BOOLEAN_PROTOTYPE);
@@ -64,7 +59,11 @@ ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boo
 
   ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
-  ecma_set_internal_property_value (prim_value_prop_p, conv_to_boolean_completion);
+
+  ecma_value_t prim_value = ecma_make_simple_value (boolean_value ? ECMA_SIMPLE_VALUE_TRUE
+                                                                  : ECMA_SIMPLE_VALUE_FALSE);
+
+  ecma_set_internal_property_value (prim_value_prop_p, prim_value);
 
   return ecma_make_object_value (obj_p);
 } /* ecma_op_create_boolean_object */

--- a/jerry-core/ecma/operations/ecma-comparison.c
+++ b/jerry-core/ecma/operations/ecma-comparison.c
@@ -334,15 +334,12 @@ ecma_op_abstract_relational_compare (ecma_value_t x, /**< first operand */
 {
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
-  ecma_value_t first_converted_value = left_first ? x : y;
-  ecma_value_t second_converted_value = left_first ? y : x;
-
   // 1., 2.
   ECMA_TRY_CATCH (prim_first_converted_value,
-                  ecma_op_to_primitive (first_converted_value, ECMA_PREFERRED_TYPE_NUMBER),
+                  ecma_op_to_primitive (x, ECMA_PREFERRED_TYPE_NUMBER),
                   ret_value);
   ECMA_TRY_CATCH (prim_second_converted_value,
-                  ecma_op_to_primitive (second_converted_value, ECMA_PREFERRED_TYPE_NUMBER),
+                  ecma_op_to_primitive (y, ECMA_PREFERRED_TYPE_NUMBER),
                   ret_value);
 
   const ecma_value_t px = left_first ? prim_first_converted_value : prim_second_converted_value;

--- a/jerry-core/ecma/operations/ecma-conversion.h
+++ b/jerry-core/ecma/operations/ecma-conversion.h
@@ -40,7 +40,7 @@ typedef enum
 extern ecma_value_t ecma_op_check_object_coercible (ecma_value_t);
 extern bool ecma_op_same_value (ecma_value_t, ecma_value_t);
 extern ecma_value_t ecma_op_to_primitive (ecma_value_t, ecma_preferred_type_hint_t);
-extern ecma_value_t ecma_op_to_boolean (ecma_value_t);
+extern bool ecma_op_to_boolean (ecma_value_t);
 extern ecma_value_t ecma_op_to_number (ecma_value_t);
 extern ecma_value_t ecma_op_to_string (ecma_value_t);
 extern ecma_value_t ecma_op_to_object (ecma_value_t);

--- a/jerry-core/vm/opcodes-ecma-relational.c
+++ b/jerry-core/vm/opcodes-ecma-relational.c
@@ -53,24 +53,21 @@ opfunc_less_than (ecma_value_t left_value, /**< left value */
     return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
 
-  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
+  ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, true);
 
-  ECMA_TRY_CATCH (compare_result,
-                  ecma_op_abstract_relational_compare (left_value, right_value, true),
-                  ret_value);
+  if (ecma_is_value_error (ret_value))
+  {
+    return ret_value;
+  }
 
-  if (ecma_is_value_undefined (compare_result))
+  if (ecma_is_value_undefined (ret_value))
   {
     ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
   else
   {
-    JERRY_ASSERT (ecma_is_value_boolean (compare_result));
-
-    ret_value = compare_result;
+    JERRY_ASSERT (ecma_is_value_boolean (ret_value));
   }
-
-  ECMA_FINALIZE (compare_result);
 
   return ret_value;
 } /* opfunc_less_than */
@@ -99,24 +96,21 @@ opfunc_greater_than (ecma_value_t left_value, /**< left value */
     return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
 
-  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
+  ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, false);
 
-  ECMA_TRY_CATCH (compare_result,
-                  ecma_op_abstract_relational_compare (right_value, left_value, false),
-                  ret_value);
+  if (ecma_is_value_error (ret_value))
+  {
+    return ret_value;
+  }
 
-  if (ecma_is_value_undefined (compare_result))
+  if (ecma_is_value_undefined (ret_value))
   {
     ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
   else
   {
-    JERRY_ASSERT (ecma_is_value_boolean (compare_result));
-
-    ret_value = compare_result;
+    JERRY_ASSERT (ecma_is_value_boolean (ret_value));
   }
-
-  ECMA_FINALIZE (compare_result);
 
   return ret_value;
 } /* opfunc_greater_than */
@@ -145,31 +139,23 @@ opfunc_less_or_equal_than (ecma_value_t left_value, /**< left value */
     return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
 
-  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
+  ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, false);
 
-  ECMA_TRY_CATCH (compare_result,
-                  ecma_op_abstract_relational_compare (right_value, left_value, false),
-                  ret_value);
+  if (ecma_is_value_error (ret_value))
+  {
+    return ret_value;
+  }
 
-  if (ecma_is_value_undefined (compare_result))
+  if (ecma_is_value_undefined (ret_value))
   {
     ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
   else
   {
-    JERRY_ASSERT (ecma_is_value_boolean (compare_result));
+    JERRY_ASSERT (ecma_is_value_boolean (ret_value));
 
-    if (ecma_is_value_true (compare_result))
-    {
-      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
-    }
-    else
-    {
-      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
-    }
+    ret_value = ecma_invert_boolean_value (ret_value);
   }
-
-  ECMA_FINALIZE (compare_result);
 
   return ret_value;
 } /* opfunc_less_or_equal_than */
@@ -198,31 +184,23 @@ opfunc_greater_or_equal_than (ecma_value_t left_value, /**< left value */
     return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
 
-  ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
+  ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, true);
 
-  ECMA_TRY_CATCH (compare_result,
-                  ecma_op_abstract_relational_compare (left_value, right_value, true),
-                  ret_value);
+  if (ecma_is_value_error (ret_value))
+  {
+    return ret_value;
+  }
 
-  if (ecma_is_value_undefined (compare_result))
+  if (ecma_is_value_undefined (ret_value))
   {
     ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
   else
   {
-    JERRY_ASSERT (ecma_is_value_boolean (compare_result));
+    JERRY_ASSERT (ecma_is_value_boolean (ret_value));
 
-    if (ecma_is_value_true (compare_result))
-    {
-      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
-    }
-    else
-    {
-      ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
-    }
+    ret_value = ecma_invert_boolean_value (ret_value);
   }
-
-  ECMA_FINALIZE (compare_result);
 
   return ret_value;
 } /* opfunc_greater_or_equal_than */

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -80,9 +80,8 @@ ecma_value_t
 opfunc_logical_not (ecma_value_t left_value) /**< left value */
 {
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
-  ecma_value_t to_bool_value = ecma_op_to_boolean (left_value);
 
-  if (ecma_is_value_true (to_bool_value))
+  if (ecma_op_to_boolean (left_value))
   {
     ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1498,26 +1498,26 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           uint32_t opcode_flags = VM_OC_GROUP_GET_INDEX (opcode_data) - VM_OC_BRANCH_IF_TRUE;
 
-          last_completion_value = ecma_op_to_boolean (left_value);
+          bool boolean_value = ecma_op_to_boolean (left_value);
 
-          if (ecma_is_value_error (last_completion_value))
+          if (opcode_flags & VM_OC_BRANCH_IF_FALSE_FLAG)
           {
-            goto error;
+            boolean_value = !boolean_value;
           }
 
-          bool branch_if_false = (opcode_flags & VM_OC_BRANCH_IF_FALSE_FLAG);
-
-          if (last_completion_value == ecma_make_simple_value (branch_if_false ? ECMA_SIMPLE_VALUE_FALSE
-                                                                               : ECMA_SIMPLE_VALUE_TRUE))
+          if (boolean_value)
           {
             byte_code_p = byte_code_start_p + branch_offset;
             if (opcode_flags & VM_OC_LOGICAL_BRANCH_FLAG)
             {
-              left_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+              /* "Push" the left_value back to the stack. */
               ++stack_top_p;
+              continue;
             }
           }
-          break;
+
+          ecma_fast_free_value (left_value);
+          continue;
         }
         case VM_OC_PLUS:
         {


### PR DESCRIPTION
The ecma_op_to_boolean return value is changed to bool for faster
evaluation, and no need to swap operandos of relational compare.