### PR TITLE
Optimize uint32 hash computation.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -734,7 +734,7 @@ typedef double ecma_number_t;
 /**
  * Maximum number of characters in string representation of ecma-uint32
  */
-#define ECMA_MAX_CHARS_IN_STRINGIFIED_UINT32 32
+#define ECMA_MAX_CHARS_IN_STRINGIFIED_UINT32 10
 
 /**
  * Maximum value of valid array index

--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -783,29 +783,25 @@ ecma_uint32_to_utf8_string (uint32_t value, /**< value to convert */
                             lit_utf8_byte_t *out_buffer_p, /**< buffer for string */
                             lit_utf8_size_t buffer_size) /**< size of buffer */
 {
-  const lit_utf8_byte_t digits[10] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
-
-  lit_utf8_byte_t *p = out_buffer_p + buffer_size - 1;
-  lit_utf8_size_t bytes_copied = 0;
+  lit_utf8_byte_t *buf_p = out_buffer_p + buffer_size;
 
   do
   {
-    JERRY_ASSERT (p >= out_buffer_p);
+    JERRY_ASSERT (buf_p >= out_buffer_p);
 
-    *p-- = digits[value % 10];
+    buf_p--;
+    *buf_p = (lit_utf8_byte_t) ((value % 10) + LIT_CHAR_0);
     value /= 10;
-
-    bytes_copied++;
   }
   while (value != 0);
 
-  p++;
+  JERRY_ASSERT (buf_p >= out_buffer_p);
 
-  JERRY_ASSERT (p >= out_buffer_p);
+  lit_utf8_size_t bytes_copied = (lit_utf8_size_t) (out_buffer_p + buffer_size - buf_p);
 
-  if (likely (p != out_buffer_p))
+  if (likely (buf_p != out_buffer_p))
   {
-    memmove (out_buffer_p, p, bytes_copied);
+    memmove (out_buffer_p, buf_p, bytes_copied);
   }
 
   return bytes_copied;


### PR DESCRIPTION
Small optimization, only positive improvements:

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 1.801 -> 1.761 : +2.195% | 
3d-raytrace.js | 1.998 -> 1.962 : +1.810% | 
access-binary-trees.js | 0.865 -> 0.867 : -0.307% | 
access-fannkuch.js | 3.888 -> 3.765 : +3.159% | 
access-nbody.js | 2.082 -> 2.078 : +0.182% | 
bitops-3bit-bits-in-byte.js | 0.834 -> 0.832 : +0.154% | 
bitops-bits-in-byte.js | 1.100 -> 1.100 : -0.022% | 
bitops-bitwise-and.js | 1.874 -> 1.873 : +0.028% | 
bitops-nsieve-bits.js | 2.845 -> 2.732 : +3.955% | 
controlflow-recursive.js | 0.562 -> 0.561 : +0.086% | 
crypto-aes.js | 1.981 -> 1.917 : +3.197% | 
crypto-md5.js | 0.996 -> 0.988 : +0.760% | 
crypto-sha1.js | 0.930 -> 0.918 : +1.312% | 
date-format-tofte.js | 1.472 -> 1.437 : +2.355% | 
date-format-xparb.js | 0.652 -> 0.653 : -0.100% | 
math-cordic.js | 2.086 -> 2.071 : +0.732% | 
math-partial-sums.js | 1.110 -> 1.110 : -0.025% | 
math-spectral-norm.js | 0.975 -> 0.955 : +2.112% | 
string-base64.js | 4.931 -> 4.914 : +0.345% | 
string-fasta.js | 2.440 -> 2.363 : +3.163% | 
Geometric mean: | +1.264% | 

Binary sizes (bytes)
old:167976
new:167960