### PR TITLE
Improve the output of test runner

### DIFF
--- a/tools/runners/run-test-suite.sh
+++ b/tools/runners/run-test-suite.sh
@@ -112,7 +112,7 @@ do
     if [ "$IS_SNAPSHOT" == true ]
     then
         # Testing snapshot
-        SNAPSHOT_TEMP=`mktemp snapshot-out.XXXXXXXXXX`
+        SNAPSHOT_TEMP=`mktemp $(basename -s .js $test).XXXXXXXXXX.snapshot`
 
         cmd_line="${ENGINE#$ROOT_DIR} $ENGINE_ARGS --save-snapshot-for-global $SNAPSHOT_TEMP ${full_test#$ROOT_DIR}"
         ( ulimit -t $TIMEOUT; $ENGINE $ENGINE_ARGS --save-snapshot-for-global $SNAPSHOT_TEMP $full_test &> $ENGINE_TEMP )
@@ -161,6 +161,11 @@ done
 rm -f $ENGINE_TEMP
 
 ratio=$(echo $passed*100/$total | bc)
+
+if [ "$IS_SNAPSHOT" == true ]
+then
+    ENGINE_ARGS="--snapshot $ENGINE_ARGS"
+fi
 
 echo "[summary] ${ENGINE#$ROOT_DIR} $ENGINE_ARGS ${TESTS#$ROOT_DIR}: $passed PASS, $failed FAIL, $total total, $ratio% success"
 


### PR DESCRIPTION
* Improve the name of the temporary snapshot files in test runner:
  Until now, test runner used a completely random filename for the
  temporary snapshot file when testing (saving to and executing from)
  snapshots. This patch makes the temp file contain part of the name
  of the original test file in order to make reading the logs (and
  thus, identifying failing tests) easier.

* Add `--snapshot` to summary info of test runner if testing snapshot
  support:
  This helps reading the logs, especially when multiple tests run in
  parallel and get their output mixed. E.g., on the CI, all tests
  write the console at the same time and messages get interleaved.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu