### PR TITLE
Optimize put result phase in the vm.

### DIFF
--- a/jerry-core/vm/opcodes-ecma-equality.c
+++ b/jerry-core/vm/opcodes-ecma-equality.c
@@ -119,10 +119,10 @@ opfunc_not_equal_value (ecma_value_t left_value, /**< left value */
  *
  * See also: ECMA-262 v5, 11.9.4
  *
- * @return ecma value
- *         Returned value must be freed with ecma_free_value
+ * @return true if values are strictly equal
+ *         false otherwise
  */
-ecma_value_t
+bool
 opfunc_equal_value_type (ecma_value_t left_value, /**< left value */
                          ecma_value_t right_value) /**< right value */
 {
@@ -131,48 +131,11 @@ opfunc_equal_value_type (ecma_value_t left_value, /**< left value */
 
   if (ecma_are_values_integer_numbers (left_value, right_value))
   {
-    if (left_value == right_value)
-    {
-      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
-    }
-    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
+    return left_value == right_value;
   }
 
-  bool is_equal = ecma_op_strict_equality_compare (left_value, right_value);
-
-  return ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE
-                                          : ECMA_SIMPLE_VALUE_FALSE);
+  return ecma_op_strict_equality_compare (left_value, right_value);
 } /* opfunc_equal_value_type */
-
-/**
- * 'Strict Does-not-equals' opcode handler.
- *
- * See also: ECMA-262 v5, 11.9.5
- *
- * @return ecma value
- *         Returned value must be freed with ecma_free_value
- */
-ecma_value_t
-opfunc_not_equal_value_type (ecma_value_t left_value, /**< left value */
-                             ecma_value_t right_value) /**< right value */
-{
-  JERRY_ASSERT (!ecma_is_value_error (left_value)
-                && !ecma_is_value_error (right_value));
-
-  if (ecma_are_values_integer_numbers (left_value, right_value))
-  {
-    if (left_value == right_value)
-    {
-      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
-    }
-    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
-  }
-
-  bool is_equal = ecma_op_strict_equality_compare (left_value, right_value);
-
-  return ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_FALSE
-                                          : ECMA_SIMPLE_VALUE_TRUE);
-} /* opfunc_not_equal_value_type */
 
 /**
  * @}

--- a/jerry-core/vm/opcodes.h
+++ b/jerry-core/vm/opcodes.h
@@ -62,11 +62,8 @@ opfunc_equal_value (ecma_value_t, ecma_value_t);
 ecma_value_t
 opfunc_not_equal_value (ecma_value_t, ecma_value_t);
 
-ecma_value_t
+bool
 opfunc_equal_value_type (ecma_value_t, ecma_value_t);
-
-ecma_value_t
-opfunc_not_equal_value_type (ecma_value_t, ecma_value_t);
 
 ecma_value_t
 do_number_arithmetic (number_arithmetic_op, ecma_value_t, ecma_value_t);


### PR DESCRIPTION
Many opcodes has no results, or their results are always pushed onto the stack,
and checking their result type is wasting CPU cycles. Furthermore the
last_completion_value is removed which simplify this third phase.