### PR TITLE
Optimize LCache operation.

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -583,8 +583,6 @@ ecma_try_to_give_back_some_memory (jmem_try_give_memory_back_severity_t severity
     JERRY_ASSERT (severity == JMEM_TRY_GIVE_MEMORY_BACK_SEVERITY_HIGH);
 
     /* Freeing as much memory as we currently can */
-    ecma_lcache_invalidate_all ();
-
     ecma_gc_run ();
   }
 } /* ecma_try_to_give_back_some_memory */

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -527,7 +527,6 @@ ecma_copy_or_ref_ecma_string (ecma_string_t *string_p) /**< string descriptor */
   if (unlikely (string_p->refs_and_container >= ECMA_STRING_MAX_REF))
   {
     /* First trying to free unreachable objects that maybe refer to the string */
-    ecma_lcache_invalidate_all ();
     ecma_gc_run ();
 
     if (string_p->refs_and_container >= ECMA_STRING_MAX_REF)

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -51,7 +51,6 @@ ecma_finalize (void)
   jmem_unregister_a_try_give_memory_back_callback (ecma_try_to_give_back_some_memory);
 
   ecma_finalize_environment ();
-  ecma_lcache_invalidate_all ();
   ecma_finalize_builtins ();
   ecma_gc_run ();
 } /* ecma_finalize */

--- a/jerry-core/ecma/base/ecma-lcache.h
+++ b/jerry-core/ecma/base/ecma-lcache.h
@@ -24,9 +24,8 @@
  */
 
 extern void ecma_lcache_init (void);
-extern void ecma_lcache_invalidate_all (void);
 extern void ecma_lcache_insert (ecma_object_t *, ecma_string_t *, ecma_property_t *);
-extern bool ecma_lcache_lookup (ecma_object_t *, const ecma_string_t *, ecma_property_t **);
+extern ecma_property_t *ecma_lcache_lookup (ecma_object_t *, const ecma_string_t *);
 extern void ecma_lcache_invalidate (ecma_object_t *, ecma_string_t *, ecma_property_t *);
 
 /**

--- a/jerry-core/ecma/base/ecma-property-hashmap.c
+++ b/jerry-core/ecma/base/ecma-property-hashmap.c
@@ -402,7 +402,8 @@ ecma_property_hashmap_delete (ecma_object_t *object_p, /**< object */
  */
 ecma_property_t *
 ecma_property_hashmap_find (ecma_property_hashmap_t *hashmap_p, /**< hashmap */
-                            ecma_string_t *name_p) /**< property name */
+                            ecma_string_t *name_p, /**< property name */
+                            ecma_string_t **property_real_name_p) /**< [out] property real name */
 {
 #ifndef JERRY_NDEBUG
   /* A sanity check in debug mode: a named property must be present
@@ -481,6 +482,7 @@ ecma_property_hashmap_find (ecma_property_hashmap_t *hashmap_p, /**< hashmap */
 #ifndef JERRY_NDEBUG
         JERRY_ASSERT (property_found);
 #endif /* !JERRY_NDEBUG */
+        *property_real_name_p = property_name_p;
         return property_pair_p->header.types + offset;
       }
     }

--- a/jerry-core/ecma/base/ecma-property-hashmap.h
+++ b/jerry-core/ecma/base/ecma-property-hashmap.h
@@ -59,7 +59,7 @@ extern void ecma_property_hashmap_insert (ecma_object_t *, ecma_string_t *, ecma
 extern void ecma_property_hashmap_delete (ecma_object_t *, ecma_string_t *, ecma_property_t *);
 
 #ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
-extern ecma_property_t *ecma_property_hashmap_find (ecma_property_hashmap_t *, ecma_string_t *);
+extern ecma_property_t *ecma_property_hashmap_find (ecma_property_hashmap_t *, ecma_string_t *, ecma_string_t **);
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 
 /**

--- a/jerry-core/ecma/operations/ecma-lex-env.h
+++ b/jerry-core/ecma/operations/ecma-lex-env.h
@@ -40,7 +40,7 @@ extern ecma_object_t *ecma_get_global_environment (void);
 
 /* ECMA-262 v5, 8.7.1 and 8.7.2 */
 extern ecma_value_t ecma_op_get_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_value_t ecma_op_get_value_object_base (ecma_reference_t);
+extern ecma_value_t ecma_op_get_value_object_base (ecma_value_t, ecma_string_t *);
 extern ecma_value_t ecma_op_put_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool, ecma_value_t);
 
 /* ECMA-262 v5, Table 17. Abstract methods of Environment Records */

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -177,9 +177,9 @@ ecma_op_object_get_own_property (ecma_object_t *obj_p, /**< the object */
                 && !ecma_is_lexical_environment (obj_p));
   JERRY_ASSERT (property_name_p != NULL);
 
-  ecma_property_t *prop_p = NULL;
+  ecma_property_t *prop_p = ecma_lcache_lookup (obj_p, property_name_p);
 
-  if (likely (ecma_lcache_lookup (obj_p, property_name_p, &prop_p)))
+  if (likely (prop_p != NULL))
   {
     return prop_p;
   }


### PR DESCRIPTION
The cache stores only real properties now, because storing NULLs has
little benefit according to tests. Since only real properties are
stored now, there is no need to create real references to objects
and property names, which reduces the keeping of dead objects after
garbage collection.