### PR TITLE
Optimize number-to-string conversion

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -962,7 +962,7 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
   if (ecma_number_is_zero (num))
   {
     // 2.
-    *buffer_p = (lit_utf8_byte_t) LIT_CHAR_0;
+    *buffer_p = LIT_CHAR_0;
     JERRY_ASSERT (1 <= buffer_size);
     return 1;
   }
@@ -972,7 +972,7 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
   if (ecma_number_is_negative (num))
   {
     // 3.
-    *dst_p++ = (lit_utf8_byte_t) LIT_CHAR_MINUS;
+    *dst_p++ = LIT_CHAR_MINUS;
     num = ecma_number_negate (num);
   }
 
@@ -1009,7 +1009,7 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
     // 6.
     dst_p += k;
 
-    memset (dst_p, (lit_utf8_byte_t) LIT_CHAR_0, (size_t) (n - k));
+    memset (dst_p, LIT_CHAR_0, (size_t) (n - k));
     dst_p += n - k;
 
     JERRY_ASSERT (dst_p <= buffer_p + buffer_size);
@@ -1020,7 +1020,7 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
   {
     // 7.
     memmove (dst_p + n + 1, dst_p + n, (size_t) (k - n));
-    *(dst_p + n) = (lit_utf8_byte_t) LIT_CHAR_DOT;
+    *(dst_p + n) = LIT_CHAR_DOT;
     dst_p += k + 1;
 
     JERRY_ASSERT (dst_p <= buffer_p + buffer_size);
@@ -1031,9 +1031,9 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
   {
     // 8.
     memmove (dst_p + 2 - n, dst_p, (size_t) k);
-    memset (dst_p + 2, (lit_utf8_byte_t) LIT_CHAR_0, (size_t) -n);
-    *dst_p = (lit_utf8_byte_t) LIT_CHAR_0;
-    *(dst_p + 1) = (lit_utf8_byte_t) LIT_CHAR_DOT;
+    memset (dst_p + 2, LIT_CHAR_0, (size_t) -n);
+    *dst_p = LIT_CHAR_0;
+    *(dst_p + 1) = LIT_CHAR_DOT;
     dst_p += k - n + 2;
 
     JERRY_ASSERT (dst_p <= buffer_p + buffer_size);
@@ -1049,13 +1049,13 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
   {
     // 10.
     memmove (dst_p + 2, dst_p + 1, (size_t) (k - 1));
-    *(dst_p + 1) = (lit_utf8_byte_t) LIT_CHAR_DOT;
+    *(dst_p + 1) = LIT_CHAR_DOT;
     dst_p += k + 1;
   }
 
   // 9., 10.
-  *dst_p++ = (lit_utf8_byte_t) LIT_CHAR_LOWERCASE_E;
-  *dst_p++ = (n >= 1) ? (lit_utf8_byte_t) LIT_CHAR_PLUS : (lit_utf8_byte_t) LIT_CHAR_MINUS;
+  *dst_p++ = LIT_CHAR_LOWERCASE_E;
+  *dst_p++ = (n >= 1) ? LIT_CHAR_PLUS : LIT_CHAR_MINUS;
   uint32_t t = (uint32_t) (n >= 1 ? (n - 1) : -(n - 1));
 
   dst_p += ecma_uint32_to_utf8_string (t, dst_p, (lit_utf8_size_t) (buffer_p + buffer_size - dst_p));

--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -962,7 +962,7 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
   if (ecma_number_is_zero (num))
   {
     // 2.
-    *buffer_p = '0';
+    *buffer_p = (lit_utf8_byte_t) LIT_CHAR_0;
     JERRY_ASSERT (1 <= buffer_size);
     return 1;
   }
@@ -972,7 +972,7 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
   if (ecma_number_is_negative (num))
   {
     // 3.
-    *dst_p++ = '-';
+    *dst_p++ = (lit_utf8_byte_t) LIT_CHAR_MINUS;
     num = ecma_number_negate (num);
   }
 
@@ -1009,7 +1009,7 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
     // 6.
     dst_p += k;
 
-    memset (dst_p, '0', (size_t) (n - k));
+    memset (dst_p, (lit_utf8_byte_t) LIT_CHAR_0, (size_t) (n - k));
     dst_p += n - k;
 
     JERRY_ASSERT (dst_p <= buffer_p + buffer_size);
@@ -1020,7 +1020,7 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
   {
     // 7.
     memmove (dst_p + n + 1, dst_p + n, (size_t) (k - n));
-    *(dst_p + n) = '.';
+    *(dst_p + n) = (lit_utf8_byte_t) LIT_CHAR_DOT;
     dst_p += k + 1;
 
     JERRY_ASSERT (dst_p <= buffer_p + buffer_size);
@@ -1031,9 +1031,9 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
   {
     // 8.
     memmove (dst_p + 2 - n, dst_p, (size_t) k);
-    memset (dst_p + 2, '0', (size_t) -n);
-    *dst_p = '0';
-    *(dst_p + 1) = '.';
+    memset (dst_p + 2, (lit_utf8_byte_t) LIT_CHAR_0, (size_t) -n);
+    *dst_p = (lit_utf8_byte_t) LIT_CHAR_0;
+    *(dst_p + 1) = (lit_utf8_byte_t) LIT_CHAR_DOT;
     dst_p += k - n + 2;
 
     JERRY_ASSERT (dst_p <= buffer_p + buffer_size);
@@ -1049,13 +1049,13 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
   {
     // 10.
     memmove (dst_p + 2, dst_p + 1, (size_t) (k - 1));
-    *(dst_p + 1) = '.';
+    *(dst_p + 1) = (lit_utf8_byte_t) LIT_CHAR_DOT;
     dst_p += k + 1;
   }
 
   // 9., 10.
-  *dst_p++ = 'e';
-  *dst_p++ = (n >= 1) ? '+' : '-';
+  *dst_p++ = (lit_utf8_byte_t) LIT_CHAR_LOWERCASE_E;
+  *dst_p++ = (n >= 1) ? (lit_utf8_byte_t) LIT_CHAR_PLUS : (lit_utf8_byte_t) LIT_CHAR_MINUS;
   uint32_t t = (uint32_t) (n >= 1 ? (n - 1) : -(n - 1));
 
   dst_p += ecma_uint32_to_utf8_string (t, dst_p, (lit_utf8_size_t) (buffer_p + buffer_size - dst_p));

--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -925,7 +925,7 @@ ecma_number_to_int32 (ecma_number_t num) /**< ecma-number */
   */
 lit_utf8_size_t
 ecma_number_to_decimal (ecma_number_t num, /**< ecma-number */
-                        lit_utf8_byte_t *out_digits_p, /**< buffer to fill with digits */
+                        lit_utf8_byte_t *out_digits_p, /**< [out] buffer to fill with digits */
                         int32_t *out_decimal_exp_p) /**< [out] decimal exponent */
 {
   JERRY_ASSERT (!ecma_number_is_nan (num));

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -217,7 +217,7 @@ extern ecma_number_t ecma_number_add (ecma_number_t, ecma_number_t);
 extern ecma_number_t ecma_number_substract (ecma_number_t, ecma_number_t);
 extern ecma_number_t ecma_number_multiply (ecma_number_t, ecma_number_t);
 extern ecma_number_t ecma_number_divide (ecma_number_t, ecma_number_t);
-extern void ecma_number_to_decimal (ecma_number_t, uint64_t *, int32_t *, int32_t *);
+extern lit_utf8_size_t ecma_number_to_decimal (ecma_number_t, lit_utf8_byte_t *, int32_t *);
 
 /* ecma-helpers-values-collection.c */
 extern ecma_collection_header_t *ecma_new_values_collection (const ecma_value_t[], ecma_length_t, bool);
@@ -327,9 +327,7 @@ extern int32_t ecma_number_to_int32 (ecma_number_t);
 extern lit_utf8_size_t ecma_number_to_utf8_string (ecma_number_t, lit_utf8_byte_t *, lit_utf8_size_t);
 
 /* ecma-helpers-errol.c */
-#if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64
-extern uint64_t ecma_errol0_dtoa (ecma_number_t, int32_t *, int32_t *);
-#endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64 */
+extern lit_utf8_size_t ecma_errol0_dtoa (double, lit_utf8_byte_t *, int32_t *);
 
 /**
  * @}

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -54,13 +54,13 @@
  * @return the length of the generated string representation
  */
 static lit_utf8_size_t
-ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits, /**< number as string in decimal form */
+ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits_p, /**< number as string in decimal form */
                                                 lit_utf8_size_t num_digits, /**< length of the string representation */
                                                 int32_t exponent, /**< decimal exponent */
-                                                lit_utf8_byte_t *to_digits, /**< [out] buffer to write */
+                                                lit_utf8_byte_t *to_digits_p, /**< [out] buffer to write */
                                                 lit_utf8_size_t to_num_digits) /**< requested number of digits */
 {
-  lit_utf8_byte_t *p = to_digits;
+  lit_utf8_byte_t *p = to_digits_p;
 
   if (exponent <= 0)
   {
@@ -85,10 +85,10 @@ ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits, /**< nu
     /* Add significant digits of the integer part. */
     lit_utf8_size_t to_copy = JERRY_MIN (num_digits, to_num_digits);
     to_copy = JERRY_MIN (to_copy, (lit_utf8_size_t) exponent);
-    memmove (p, digits, (size_t) to_copy);
+    memmove (p, digits_p, (size_t) to_copy);
     p += to_copy;
     to_num_digits -= to_copy;
-    digits += to_copy;
+    digits_p += to_copy;
     num_digits -= to_copy;
     exponent -= (int32_t) to_copy;
 
@@ -111,7 +111,7 @@ ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits, /**< nu
   {
     /* Add significant digits of the fraction part. */
     lit_utf8_size_t to_copy = JERRY_MIN (num_digits, to_num_digits);
-    memmove (p, digits, (size_t) to_copy);
+    memmove (p, digits_p, (size_t) to_copy);
     p += to_copy;
     to_num_digits -= to_copy;
 
@@ -123,7 +123,7 @@ ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits, /**< nu
     }
   }
 
-  return (lit_utf8_size_t) (p - to_digits);
+  return (lit_utf8_size_t) (p - to_digits_p);
 } /* ecma_builtin_number_prototype_helper_to_string */
 
 /**
@@ -132,7 +132,8 @@ ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits, /**< nu
  * @return rounded number
  */
 static inline lit_utf8_size_t __attr_always_inline___
-ecma_builtin_number_prototype_helper_round (lit_utf8_byte_t *digits, /**< number as a string in decimal form */
+ecma_builtin_number_prototype_helper_round (lit_utf8_byte_t *digits_p, /**< [in,out] number as a string in decimal
+                                                                        *   form */
                                             lit_utf8_size_t num_digits, /**< length of the string representation */
                                             int32_t round_num) /**< number of digits to keep */
 {
@@ -146,9 +147,9 @@ ecma_builtin_number_prototype_helper_round (lit_utf8_byte_t *digits, /**< number
     return num_digits;
   }
 
-  if (digits[round_num] >= '5')
+  if (digits_p[round_num] >= '5')
   {
-    digits[round_num - 1]++;
+    digits_p[round_num - 1]++;
   }
   return (lit_utf8_size_t) round_num;
 } /* ecma_builtin_number_prototype_helper_round */
@@ -554,13 +555,13 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
             *p++ = '-';
           }
 
+          lit_utf8_size_t to_num_digits = ((exponent > 0) ? (lit_utf8_size_t) (exponent + frac_digits)
+                                                          : (lit_utf8_size_t) (frac_digits + 1));
           p += ecma_builtin_number_prototype_helper_to_string (digits,
                                                                num_digits,
                                                                exponent,
                                                                p,
-                                                               (exponent > 0)
-                                                               ? (lit_utf8_size_t) (exponent + frac_digits)
-                                                               : (lit_utf8_size_t) (frac_digits + 1));
+                                                               to_num_digits);
 
           JERRY_ASSERT (p - buff < buffer_size);
           /* String terminator. */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -48,8 +48,6 @@
  * @{
  */
 
-#define min(X,Y) ((X) < (Y) ? (X) : (Y))
-
 /**
  * Helper for stringifying numbers
  *
@@ -59,7 +57,7 @@ static lit_utf8_size_t
 ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits, /**< number as string in decimal form */
                                                 lit_utf8_size_t num_digits, /**< length of the string representation */
                                                 int32_t exponent, /**< decimal exponent */
-                                                lit_utf8_byte_t *to_digits, /**< buffer to write */
+                                                lit_utf8_byte_t *to_digits, /**< [out] buffer to write */
                                                 lit_utf8_size_t to_num_digits) /**< requested number of digits */
 {
   lit_utf8_byte_t *p = to_digits;
@@ -85,8 +83,8 @@ ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits, /**< nu
   else
   {
     /* Add significant digits of the integer part. */
-    lit_utf8_size_t to_copy = min (num_digits, to_num_digits);
-    to_copy = min (to_copy, (lit_utf8_size_t) exponent);
+    lit_utf8_size_t to_copy = JERRY_MIN (num_digits, to_num_digits);
+    to_copy = JERRY_MIN (to_copy, (lit_utf8_size_t) exponent);
     memmove (p, digits, (size_t) to_copy);
     p += to_copy;
     to_num_digits -= to_copy;
@@ -112,7 +110,7 @@ ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits, /**< nu
   if (to_num_digits > 0)
   {
     /* Add significant digits of the fraction part. */
-    lit_utf8_size_t to_copy = min (num_digits, to_num_digits);
+    lit_utf8_size_t to_copy = JERRY_MIN (num_digits, to_num_digits);
     memmove (p, digits, (size_t) to_copy);
     p += to_copy;
     to_num_digits -= to_copy;
@@ -127,8 +125,6 @@ ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits, /**< nu
 
   return (lit_utf8_size_t) (p - to_digits);
 } /* ecma_builtin_number_prototype_helper_to_string */
-
-#undef min
 
 /**
  * Helper for rounding numbers
@@ -558,7 +554,10 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
             *p++ = '-';
           }
 
-          p += ecma_builtin_number_prototype_helper_to_string (digits, num_digits, exponent, p,
+          p += ecma_builtin_number_prototype_helper_to_string (digits,
+                                                               num_digits,
+                                                               exponent,
+                                                               p,
                                                                (exponent > 0)
                                                                ? (lit_utf8_size_t) (exponent + frac_digits)
                                                                : (lit_utf8_size_t) (frac_digits + 1));
@@ -690,7 +689,10 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
           *actual_char_p++ = '-';
         }
 
-        actual_char_p += ecma_builtin_number_prototype_helper_to_string (digits, num_digits, 1, actual_char_p,
+        actual_char_p += ecma_builtin_number_prototype_helper_to_string (digits,
+                                                                         num_digits,
+                                                                         1,
+                                                                         actual_char_p,
                                                                          (lit_utf8_size_t) (frac_digits + 1));
 
         *actual_char_p++ = 'e';
@@ -846,7 +848,10 @@ ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< t
         /* 10.c, Exponential notation.*/
         if (exponent < -5 || exponent > precision)
         {
-          actual_char_p  += ecma_builtin_number_prototype_helper_to_string (digits, num_digits, 1, actual_char_p,
+          actual_char_p  += ecma_builtin_number_prototype_helper_to_string (digits,
+                                                                            num_digits,
+                                                                            1,
+                                                                            actual_char_p,
                                                                             (lit_utf8_size_t) precision);
 
           *actual_char_p++ = 'e';
@@ -870,7 +875,10 @@ ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< t
         {
           lit_utf8_size_t to_num_digits = ((exponent <= 0) ? (lit_utf8_size_t) (1 - exponent + precision)
                                                            : (lit_utf8_size_t) precision);
-          actual_char_p += ecma_builtin_number_prototype_helper_to_string (digits, num_digits, exponent, actual_char_p,
+          actual_char_p += ecma_builtin_number_prototype_helper_to_string (digits,
+                                                                           num_digits,
+                                                                           exponent,
+                                                                           actual_char_p,
                                                                            to_num_digits);
 
         }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -48,32 +48,117 @@
  * @{
  */
 
+#define min(X,Y) ((X) < (Y) ? (X) : (Y))
+
+/**
+ * Helper for stringifying numbers
+ *
+ * @return the length of the generated string representation
+ */
+static lit_utf8_size_t
+ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits, /**< number as string in decimal form */
+                                                lit_utf8_size_t num_digits, /**< length of the string representation */
+                                                int32_t exponent, /**< decimal exponent */
+                                                lit_utf8_byte_t *to_digits, /**< buffer to write */
+                                                lit_utf8_size_t to_num_digits) /**< requested number of digits */
+{
+  lit_utf8_byte_t *start = to_digits;
+  lit_utf8_byte_t *p = to_digits;
+
+  if (exponent <= 0)
+  {
+    /* Add zero to the integer part. */
+    *p++ = '0';
+    to_num_digits--;
+
+    if (to_num_digits > 0)
+    {
+      *p++ = '.';
+
+      /* Add leading zeros to the fraction part. */
+      for (int i = 0; i < -exponent && to_num_digits > 0; i++)
+      {
+        *p++ = '0';
+        to_num_digits--;
+      }
+    }
+  }
+  else
+  {
+    /* Add significant digits of the integer part. */
+    lit_utf8_size_t to_copy = min (num_digits, to_num_digits);
+    to_copy = min (to_copy, (lit_utf8_size_t) exponent);
+    memmove (p, digits, (size_t) to_copy);
+    p += to_copy;
+    to_num_digits -= to_copy;
+    digits += to_copy;
+    num_digits -= to_copy;
+    exponent -= (int32_t) to_copy;
+
+    if (to_num_digits > 0)
+    {
+      /* Add zeros before decimal point. */
+      while (exponent > 0 && to_num_digits > 0)
+      {
+        JERRY_ASSERT (num_digits == 0);
+        *p++ = '0';
+        to_num_digits--;
+        exponent--;
+      }
+
+      if (to_num_digits > 0)
+      {
+        *p++ = '.';
+      }
+    }
+  }
+
+  if (to_num_digits > 0)
+  {
+    /* Add significant digits of the fraction part. */
+    lit_utf8_size_t to_copy = min (num_digits, to_num_digits);
+    memmove (p, digits, (size_t) to_copy);
+    p += to_copy;
+    to_num_digits -= to_copy;
+
+    /* Add trailing zeros. */
+    while (to_num_digits > 0)
+    {
+      *p++ = '0';
+      to_num_digits--;
+    }
+  }
+
+  return (lit_utf8_size_t) (p - start);
+} /* ecma_builtin_number_prototype_helper_to_string */
+
+#undef min
+
 /**
  * Helper for rounding numbers
  *
  * @return rounded number
  */
-static uint64_t
-ecma_builtin_number_prototype_helper_round (uint64_t digits, /**< actual number **/
-                                            int32_t round_num) /**< number of digits to round off **/
+static inline lit_utf8_size_t __attr_always_inline___
+ecma_builtin_number_prototype_helper_round (lit_utf8_byte_t *digits, /**< number as a string in decimal form */
+                                            lit_utf8_size_t num_digits, /**< length of the string representation */
+                                            int32_t round_num) /**< number of digits to keep */
 {
-  int8_t digit = 0;
-
-  /* Remove unneeded precision digits. */
-  while (round_num > 0)
+  if (round_num < 1)
   {
-    digit = (int8_t) (digits % 10);
-    digits /= 10;
-    round_num--;
+    return 0;
   }
 
-  /* Round the last digit up if neccessary */
-  if (digit >= 5)
+  if ((lit_utf8_size_t) round_num >= num_digits)
   {
-    digits++;
+    return num_digits;
   }
 
-  return digits;
+  if (digits[round_num] >= '5')
+  {
+    digits[round_num - 1]++;
+  }
+  return (lit_utf8_size_t) round_num;
 } /* ecma_builtin_number_prototype_helper_round */
 
 /**
@@ -107,7 +192,7 @@ ecma_builtin_number_prototype_object_to_string (ecma_value_t this_arg, /**< this
   }
   else
   {
-    const lit_utf8_byte_t digit_chars[36] =
+    static const lit_utf8_byte_t digit_chars[36] =
     {
       '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
       'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
@@ -131,8 +216,8 @@ ecma_builtin_number_prototype_object_to_string (ecma_value_t this_arg, /**< this
     }
     else
     {
-      uint64_t digits;
-      int32_t num_digits;
+      lit_utf8_byte_t digits[ECMA_MAX_CHARS_IN_STRINGIFIED_NUMBER];
+      lit_utf8_size_t num_digits;
       int32_t exponent;
       bool is_negative = false;
       bool should_round = false;
@@ -143,9 +228,9 @@ ecma_builtin_number_prototype_object_to_string (ecma_value_t this_arg, /**< this
         is_negative = true;
       }
 
-      ecma_number_to_decimal (this_arg_number, &digits, &num_digits, &exponent);
+      num_digits = ecma_number_to_decimal (this_arg_number, digits, &exponent);
 
-      exponent = exponent - num_digits;
+      exponent = exponent - (int32_t) num_digits;
       bool is_scale_negative = false;
 
       /* Calculate the scale of the number in the specified radix. */
@@ -431,9 +516,9 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
       }
       else
       {
-        uint64_t digits = 0;
-        int32_t num_digits = 0;
-        int32_t exponent = 1;
+        lit_utf8_byte_t digits[ECMA_MAX_CHARS_IN_STRINGIFIED_NUMBER];
+        lit_utf8_size_t num_digits;
+        int32_t exponent;
 
         /* 1. */
         int32_t frac_digits = ecma_number_to_int32 (arg_num);
@@ -441,10 +526,14 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
         /* Get the parameters of the number if non-zero. */
         if (!ecma_number_is_zero (this_num))
         {
-          ecma_number_to_decimal (this_num, &digits, &num_digits, &exponent);
+          num_digits = ecma_number_to_decimal (this_num, digits, &exponent);
         }
-
-        digits = ecma_builtin_number_prototype_helper_round (digits, num_digits - exponent - frac_digits);
+        else
+        {
+          digits[0] = '0';
+          num_digits = 1;
+          exponent = 1;
+        }
 
         /* 7. */
         if (exponent > 21)
@@ -454,6 +543,8 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
         /* 8. */
         else
         {
+          num_digits = ecma_builtin_number_prototype_helper_round (digits, num_digits, exponent + frac_digits);
+
           /* Buffer that is used to construct the string. */
           int buffer_size = (exponent > 0) ? exponent + frac_digits + 2 : frac_digits + 3;
 
@@ -472,86 +563,10 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
             *p++ = '-';
           }
 
-          int8_t digit = 0;
-          uint64_t s = 1;
-
-          /* Calculate the magnitude of the number. This is used to get the digits from left to right. */
-          while (s <= digits)
-          {
-            s *= 10;
-          }
-
-          if (exponent <= 0)
-          {
-            /* Add leading zeros. */
-            *p++ = '0';
-
-            if (frac_digits != 0)
-            {
-              *p++ = '.';
-            }
-
-            for (int i = 0; i < -exponent && i < frac_digits; i++)
-            {
-              *p++ = '0';
-            }
-
-            /* Add significant digits. */
-            for (int i = -exponent; i < frac_digits; i++)
-            {
-              digit = 0;
-              s /= 10;
-
-              while (digits >= s && s > 0)
-              {
-                digits -= s;
-                digit++;
-              }
-
-              *p = (lit_utf8_byte_t) ((lit_utf8_byte_t) digit + '0');
-              p++;
-            }
-          }
-          else
-          {
-            /* Add significant digits. */
-            for (int i = 0; i < exponent; i++)
-            {
-              digit = 0;
-              s /= 10;
-
-              while (digits >= s && s > 0)
-              {
-                digits -= s;
-                digit++;
-              }
-
-              *p = (lit_utf8_byte_t) ((lit_utf8_byte_t) digit + '0');
-              p++;
-            }
-
-            /* Add the decimal point after whole part. */
-            if (frac_digits != 0)
-            {
-              *p++ = '.';
-            }
-
-            /* Add neccessary fracion digits. */
-            for (int i = 0; i < frac_digits; i++)
-            {
-              digit = 0;
-              s /= 10;
-
-              while (digits >= s && s > 0)
-              {
-                digits -= s;
-                digit++;
-              }
-
-              *p = (lit_utf8_byte_t) ((lit_utf8_byte_t) digit + '0');
-              p++;
-            }
-          }
+          p += ecma_builtin_number_prototype_helper_to_string (digits, num_digits, exponent, p,
+                                                               (exponent > 0)
+                                                               ? (lit_utf8_size_t) (exponent + frac_digits)
+                                                               : (lit_utf8_size_t) (frac_digits + 1));
 
           JERRY_ASSERT (p - buff < buffer_size);
           /* String terminator. */
@@ -635,27 +650,33 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
       }
       else
       {
-        uint64_t digits = 0;
-        int32_t num_digits = 0;
-        int32_t exponent = 1;
+        lit_utf8_byte_t digits[ECMA_MAX_CHARS_IN_STRINGIFIED_NUMBER];
+        lit_utf8_size_t num_digits;
+        int32_t exponent;
 
         if (!ecma_number_is_zero (this_num))
         {
           /* Get the parameters of the number if non zero. */
-          ecma_number_to_decimal (this_num, &digits, &num_digits, &exponent);
+          num_digits = ecma_number_to_decimal (this_num, digits, &exponent);
+        }
+        else
+        {
+          digits[0] = '0';
+          num_digits = 1;
+          exponent = 1;
         }
 
         int32_t frac_digits;
         if (ecma_is_value_undefined (arg))
         {
-          frac_digits = num_digits - 1;
+          frac_digits = (int32_t) num_digits - 1;
         }
         else
         {
           frac_digits = ecma_number_to_int32 (arg_num);
         }
 
-        digits = ecma_builtin_number_prototype_helper_round (digits, num_digits - frac_digits - 1);
+        num_digits = ecma_builtin_number_prototype_helper_round (digits, num_digits, frac_digits + 1);
 
         /* frac_digits + 2 characters for number, 5 characters for exponent, 1 for \0. */
         int buffer_size = frac_digits + 2 + 5 + 1;
@@ -668,15 +689,6 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
 
         JMEM_DEFINE_LOCAL_ARRAY (buff, buffer_size, lit_utf8_byte_t);
 
-        int digit = 0;
-        uint64_t scale = 1;
-
-        /* Calculate the magnitude of the number. This is used to get the digits from left to right. */
-        while (scale <= digits)
-        {
-          scale *= 10;
-        }
-
         lit_utf8_byte_t *actual_char_p = buff;
 
         if (is_negative)
@@ -684,25 +696,8 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
           *actual_char_p++ = '-';
         }
 
-        /* Add significant digits. */
-        for (int i = 0; i <= frac_digits; i++)
-        {
-          digit = 0;
-          scale /= 10;
-          while (digits >= scale && scale > 0)
-          {
-            digits -= scale;
-            digit++;
-          }
-
-          *actual_char_p = (lit_utf8_byte_t) (digit + '0');
-          actual_char_p++;
-
-          if (i == 0 && frac_digits != 0)
-          {
-            *actual_char_p++ = '.';
-          }
-        }
+        actual_char_p += ecma_builtin_number_prototype_helper_to_string (digits, num_digits, 1, actual_char_p,
+                                                                         (lit_utf8_size_t) (frac_digits + 1));
 
         *actual_char_p++ = 'e';
 
@@ -717,29 +712,8 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
           *actual_char_p++ = '+';
         }
 
-        /* Get magnitude of exponent. */
-        int32_t scale_expt = 1;
-        while (scale_expt <= exponent)
-        {
-          scale_expt *= 10;
-        }
-        scale_expt /= 10;
-
         /* Add exponent digits. */
-        if (exponent == 0)
-        {
-          *actual_char_p++ = '0';
-        }
-        else
-        {
-          while (scale_expt > 0)
-          {
-            digit = exponent / scale_expt;
-            exponent %= scale_expt;
-            *actual_char_p++ = (lit_utf8_byte_t) (digit + '0');
-            scale_expt /= 10;
-          }
-        }
+        actual_char_p += ecma_uint32_to_utf8_string ((uint32_t) exponent, actual_char_p, 3);
 
         JERRY_ASSERT (actual_char_p - buff < buffer_size);
         *actual_char_p = '\0';
@@ -826,19 +800,25 @@ ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< t
       }
       else
       {
-        uint64_t digits = 0;
-        int32_t num_digits = 0;
-        int32_t exponent = 1;
+        lit_utf8_byte_t digits[ECMA_MAX_CHARS_IN_STRINGIFIED_NUMBER];
+        lit_utf8_size_t num_digits;
+        int32_t exponent;
 
         int32_t precision = ecma_number_to_int32 (arg_num);
 
         /* Get the parameters of the number if non-zero. */
         if (!ecma_number_is_zero (this_num))
         {
-          ecma_number_to_decimal (this_num, &digits, &num_digits, &exponent);
+          num_digits = ecma_number_to_decimal (this_num, digits, &exponent);
+        }
+        else
+        {
+          digits[0] = '0';
+          num_digits = 1;
+          exponent = 1;
         }
 
-        digits = ecma_builtin_number_prototype_helper_round (digits, num_digits - precision);
+        num_digits = ecma_builtin_number_prototype_helper_round (digits, num_digits, precision);
 
         int buffer_size;
         if (exponent  < -5 || exponent > precision)
@@ -865,42 +845,16 @@ ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< t
         JMEM_DEFINE_LOCAL_ARRAY (buff, buffer_size, lit_utf8_byte_t);
         lit_utf8_byte_t *actual_char_p = buff;
 
-        uint64_t scale = 1;
-
-        /* Calculate the magnitude of the number. This is used to get the digits from left to right. */
-        while (scale <= digits)
-        {
-          scale *= 10;
-        }
-
         if (is_negative)
         {
           *actual_char_p++ = '-';
         }
 
-        int digit = 0;
-
         /* 10.c, Exponential notation.*/
         if (exponent < -5 || exponent > precision)
         {
-          /* Add significant digits. */
-          for (int i = 1; i <= precision; i++)
-          {
-            digit = 0;
-            scale /= 10;
-            while (digits >= scale && scale > 0)
-            {
-              digits -= scale;
-              digit++;
-            }
-
-            *actual_char_p++ = (lit_utf8_byte_t) (digit + '0');
-
-            if (i == 1 && i != precision)
-            {
-              *actual_char_p++ = '.';
-            }
-          }
+          actual_char_p  += ecma_builtin_number_prototype_helper_to_string (digits, num_digits, 1, actual_char_p,
+                                                                            (lit_utf8_size_t) precision);
 
           *actual_char_p++ = 'e';
 
@@ -915,62 +869,17 @@ ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< t
             *actual_char_p++ = '+';
           }
 
-          /* Get magnitude of exponent. */
-          int32_t scale_expt = 1;
-          while (scale_expt <= exponent)
-          {
-            scale_expt *= 10;
-          }
-          scale_expt /= 10;
-
           /* Add exponent digits. */
-          if (exponent == 0)
-          {
-            *actual_char_p++ = '0';
-          }
-          else
-          {
-            while (scale_expt > 0)
-            {
-              digit = exponent / scale_expt;
-              exponent %= scale_expt;
-              *actual_char_p++ = (lit_utf8_byte_t) (digit + '0');
-              scale_expt /= 10;
-            }
-          }
+          actual_char_p += ecma_uint32_to_utf8_string ((uint32_t) exponent, actual_char_p, 3);
         }
         /* Fixed notation. */
         else
         {
-          /* Add leading zeros if neccessary. */
-          if (exponent <= 0)
-          {
-            *actual_char_p++ = '0';
-            *actual_char_p++ = '.';
-            for (int i = exponent; i < 0; i++)
-            {
-              *actual_char_p++ = '0';
-            }
-          }
+          lit_utf8_size_t to_num_digits = ((exponent <= 0) ? (lit_utf8_size_t) (1 - exponent + precision)
+                                                           : (lit_utf8_size_t) precision);
+          actual_char_p += ecma_builtin_number_prototype_helper_to_string (digits, num_digits, exponent, actual_char_p,
+                                                                           to_num_digits);
 
-          /* Add significant digits. */
-          for (int i = 1; i <= precision; i++)
-          {
-            digit = 0;
-            scale /= 10;
-            while (digits >= scale && scale > 0)
-            {
-              digits -= scale;
-              digit++;
-            }
-
-            *actual_char_p++ = (lit_utf8_byte_t) (digit + '0');
-
-            if (i == exponent && i != precision)
-            {
-              *actual_char_p++ = '.';
-            }
-          }
         }
 
         JERRY_ASSERT (actual_char_p - buff < buffer_size);


### PR DESCRIPTION
* Changed ERROL0 dtoa implementation to use the `double` type
  instead of `ecma_number_t`. Thus, even is `ecma_number_t` is 32
  bit wide, the algorithm works the same.
* Changed `ecma_number_to_decimal` to use the ERROL0 dtoa algorithm
  for 32-bit floats as well.
* Changed `ecma_number_to_decimal` to generate the decimal string
  representation of the mantissa instead of an `uint64_t` number.

* Make `ecma_number_to_utf8_string` use early returns, and rewrite
  its self-recursion in case of negative numbers.
* Make the stringification of decimal exponent in
  `ecma_number_to_utf8_string` use `ecma_uint32_to_utf8_string`.
* Changed `ecma_number_to_utf8_string` to make use of the already
  available string representation of the mantissa, generated now by
  `ecma_number_to_decimal`.
* Changed `ecma_number_to_utf8_string` not to use arrays and
  variables for digit, "e", etc. generation.

* Changed all `Number.prototype.toXXX` implementations and the
  `ecma_builtin_number_prototype_helper_round` helper to make use
  of the already available string representation of the mantissa,
  generated now by `ecma_number_to_decimal`.
* Factored out the common stringification parts of all
  `Number.prototype.toXXX` implementations into a new helper
  `ecma_builtin_number_prototype_helper_to_string`.

Please note that our current "official" benchmarks don't contain any `Number.prototype.toXXX` calls, so specially crafted micro-benchmarks are needed to test the effect of the patch.
