### PR TITLE
Modify the usage of ecma_string_to_utf8_string()

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -66,8 +66,7 @@
   if (utf8_ptr == NULL) \
   { \
     utf8_ptr = (const lit_utf8_byte_t *) jmem_heap_alloc_block (utf8_str_size); \
-    lit_utf8_size_t sz = ecma_string_to_utf8_string (ecma_str_ptr, (lit_utf8_byte_t *) utf8_ptr, utf8_str_size); \
-    JERRY_ASSERT (sz == utf8_str_size); \
+    ecma_string_to_utf8_bytes (ecma_str_ptr, (lit_utf8_byte_t *) utf8_ptr, utf8_str_size); \
     utf8_ptr ## must_be_freed = true; \
   }
 
@@ -177,7 +176,8 @@ extern ecma_number_t ecma_string_to_number (const ecma_string_t *);
 extern bool ecma_string_get_array_index (const ecma_string_t *, uint32_t *);
 
 extern lit_utf8_size_t __attr_return_value_should_be_checked___
-ecma_string_to_utf8_string (const ecma_string_t *, lit_utf8_byte_t *, lit_utf8_size_t);
+ecma_string_copy_to_utf8_buffer (const ecma_string_t *, lit_utf8_byte_t *, lit_utf8_size_t);
+extern void ecma_string_to_utf8_bytes (const ecma_string_t *, lit_utf8_byte_t *, lit_utf8_size_t);
 extern const lit_utf8_byte_t *ecma_string_raw_chars (const ecma_string_t *, lit_utf8_size_t *, bool *);
 
 extern bool ecma_compare_ecma_strings_equal_hashes (const ecma_string_t *, const ecma_string_t *);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
@@ -142,7 +142,7 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
           JMEM_DEFINE_LOCAL_ARRAY (ret_str_buffer, size, lit_utf8_byte_t);
           lit_utf8_byte_t *ret_str_buffer_p = ret_str_buffer;
 
-          lit_utf8_size_t bytes = ecma_string_to_utf8_string (name_string_p, ret_str_buffer_p, name_size);
+          lit_utf8_size_t bytes = ecma_string_copy_to_utf8_buffer (name_string_p, ret_str_buffer_p, name_size);
           JERRY_ASSERT (bytes == name_size);
           ret_str_buffer_p = ret_str_buffer_p + bytes;
           JERRY_ASSERT (ret_str_buffer_p <= ret_str_buffer + size);
@@ -157,7 +157,7 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
                                                               space_size);
           JERRY_ASSERT (ret_str_buffer_p <= ret_str_buffer + size);
 
-          bytes = ecma_string_to_utf8_string (msg_string_p, ret_str_buffer_p, msg_size);
+          bytes = ecma_string_copy_to_utf8_buffer (msg_string_p, ret_str_buffer_p, msg_size);
           JERRY_ASSERT (bytes == msg_size);
           ret_str_buffer_p = ret_str_buffer_p + bytes;
           JERRY_ASSERT (ret_str_buffer_p == ret_str_buffer + size);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -85,8 +85,7 @@ ecma_builtin_global_object_print (ecma_value_t this_arg __attr_unused___, /**< t
                              utf8_str_size,
                              lit_utf8_byte_t);
 
-    lit_utf8_size_t actual_sz = ecma_string_to_utf8_string (str_p, utf8_str_p, utf8_str_size);
-    JERRY_ASSERT (actual_sz == utf8_str_size);
+    ecma_string_to_utf8_bytes (str_p, utf8_str_p, utf8_str_size);
 
     const lit_utf8_byte_t *utf8_str_curr_p = utf8_str_p;
     const lit_utf8_byte_t *utf8_str_end_p = utf8_str_p + utf8_str_size;
@@ -739,10 +738,7 @@ ecma_builtin_global_object_decode_uri_helper (ecma_value_t uri __attr_unused___,
                            input_size + 1,
                            lit_utf8_byte_t);
 
-  lit_utf8_size_t sz = ecma_string_to_utf8_string (input_string_p,
-                                                   input_start_p,
-                                                   input_size);
-  JERRY_ASSERT (sz == input_size);
+  ecma_string_to_utf8_bytes (input_string_p, input_start_p, input_size);
 
   input_start_p[input_size] = LIT_BYTE_NULL;
 
@@ -1017,10 +1013,7 @@ ecma_builtin_global_object_encode_uri_helper (ecma_value_t uri, /**< uri argumen
                            input_size,
                            lit_utf8_byte_t);
 
-  lit_utf8_size_t sz = ecma_string_to_utf8_string (input_string_p,
-                                                   input_start_p,
-                                                   input_size);
-  JERRY_ASSERT (sz == input_size);
+  ecma_string_to_utf8_bytes (input_string_p, input_start_p, input_size);
 
   /*
    * The URI encoding has two major phases: first we validate the input,
@@ -1238,10 +1231,7 @@ ecma_builtin_global_object_escape (ecma_value_t this_arg __attr_unused___, /**< 
                            input_size,
                            lit_utf8_byte_t);
 
-  lit_utf8_size_t sz = ecma_string_to_utf8_string (input_string_p,
-                                                   input_start_p,
-                                                   input_size);
-  JERRY_ASSERT (sz == input_size);
+  ecma_string_to_utf8_bytes (input_string_p, input_start_p, input_size);
 
   /*
    * The escape routine has two major phases: first we compute
@@ -1358,8 +1348,7 @@ ecma_builtin_global_object_unescape (ecma_value_t this_arg __attr_unused___, /**
 
   /* 3. */
   JMEM_DEFINE_LOCAL_ARRAY (input_start_p, input_size, lit_utf8_byte_t);
-  lit_utf8_size_t sz = ecma_string_to_utf8_string (input_string_p, input_start_p, input_size);
-  JERRY_ASSERT (sz == input_size);
+  ecma_string_to_utf8_bytes (input_string_p, input_start_p, input_size);
 
   const lit_utf8_byte_t *input_curr_p = input_start_p;
   const lit_utf8_byte_t *input_end_p = input_start_p + input_size;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -712,7 +712,7 @@ ecma_builtin_json_parse (ecma_value_t this_arg __attr_unused___, /**< 'this' arg
 
   JMEM_DEFINE_LOCAL_ARRAY (str_start_p, buffer_size, lit_utf8_byte_t);
 
-  const lit_utf8_size_t sz = ecma_string_to_utf8_string (string_p, str_start_p, buffer_size);
+  const lit_utf8_size_t sz = ecma_string_copy_to_utf8_buffer (string_p, str_start_p, buffer_size);
   JERRY_ASSERT (sz == string_size);
 
   str_start_p[string_size] = LIT_BYTE_NULL;

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -540,7 +540,7 @@ jerry_string_to_char_buffer (const jerry_string_t *string_p, /**< string descrip
 {
   jerry_assert_api_available ();
 
-  return ecma_string_to_utf8_string (string_p, (lit_utf8_byte_t *) buffer_p, buffer_size);
+  return ecma_string_copy_to_utf8_buffer (string_p, (lit_utf8_byte_t *) buffer_p, buffer_size);
 } /* jerry_string_to_char_buffer */
 
 /**


### PR DESCRIPTION
Parts:
 * The functions return value mostly used in assertion, but this value
    is already checked by the function itself, therefore we can remove some
    local variables, which serves this purpose.
 * Remove the 'should use return value' requirement for this function
   and remove the attribute itself, because it became unused in the project.

JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com