### PR TITLE
Reduce the default LCache size by half. From 4Kbyte to 2Kbyte.

### DIFF
--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -46,12 +46,18 @@ typedef struct
 /**
  * Number of rows in LCache's hash table
  */
-#define ECMA_LCACHE_HASH_ROWS_COUNT 256
+#define ECMA_LCACHE_HASH_ROWS_COUNT 128
 
 /**
  * Number of entries in a row of LCache's hash table
  */
 #define ECMA_LCACHE_HASH_ROW_LENGTH 2
+
+
+/**
+ * Mask for hash bits
+ */
+#define ECMA_LCACHE_HASH_MASK (ECMA_LCACHE_HASH_ROWS_COUNT - 1)
 
 /**
  * LCache's hash table
@@ -97,7 +103,7 @@ ecma_lcache_row_idx (jmem_cpointer_t object_cp, /**< compressed pointer to objec
 {
   /* Randomize the hash of the property name with the object pointer using a xor operation,
    * so properties of different objects with the same name can be cached effectively. */
-  return (size_t) ((ecma_string_hash (prop_name_p) ^ object_cp) & (ECMA_LCACHE_HASH_ROWS_COUNT - 1));
+  return (size_t) ((ecma_string_hash (prop_name_p) ^ object_cp) & ECMA_LCACHE_HASH_MASK);
 } /* ecma_lcache_row_idx */
 #endif /* !CONFIG_ECMA_LCACHE_DISABLE */
 
@@ -181,7 +187,7 @@ ecma_lcache_lookup (ecma_object_t *object_p, /**< object */
       ecma_string_t *entry_prop_name_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
                                                                     entry_p->prop_name_cp);
 
-      JERRY_ASSERT (prop_name_p->hash == entry_prop_name_p->hash);
+      JERRY_ASSERT ((prop_name_p->hash & ECMA_LCACHE_HASH_MASK) == (entry_prop_name_p->hash & ECMA_LCACHE_HASH_MASK));
 
       if (ECMA_STRING_GET_CONTAINER (prop_name_p) == ECMA_STRING_GET_CONTAINER (entry_prop_name_p)
           && prop_name_p->u.common_field == entry_prop_name_p->u.common_field)


### PR DESCRIPTION
Benchmark | RSS (bytes) | Perf (sec) |
----: | ----: | ----: | 
3d-cube.js | 73728 -> 69632 : +5.556% | 1.490 -> 1.491 : -0.102% | 
3d-raytrace.js | 212992 -> 217088 : -1.923% | 1.539 -> 1.588 : -3.154% | 
access-binary-trees.js | 77824 -> 69632 : +10.526% | 0.763 -> 0.761 : +0.219% | 
access-fannkuch.js | 32768 -> 24576 : +25.000% | 3.253 -> 3.230 : +0.698% | 
access-nbody.js | 32768 -> 28672 : +12.500% | 1.589 -> 1.594 : -0.291% | 
bitops-3bit-bits-in-byte.js | 20480 -> 16384 : +20.000% | 0.793 -> 0.792 : +0.023% | 
bitops-bits-in-byte.js | 20480 -> 16384 : +20.000% | 1.043 -> 1.044 : -0.099% | 
bitops-bitwise-and.js | 24576 -> 16384 : +33.333% | 1.945 -> 1.931 : +0.719% | 
bitops-nsieve-bits.js | 159744 -> 155648 : +2.564% | 2.559 -> 2.553 : +0.270% | 
controlflow-recursive.js | 110592 -> 106496 : +3.704% | 0.548 -> 0.549 : -0.013% | 
crypto-aes.js | 98304 -> 94208 : +4.167% | 1.480 -> 1.478 : +0.144% | 
crypto-md5.js | 176128 -> 167936 : +4.651% | 0.929 -> 0.925 : +0.409% | 
crypto-sha1.js | 118784 -> 110592 : +6.897% | 0.872 -> 0.866 : +0.714% | 
date-format-tofte.js | 53248 -> 45056 : +15.385% | 1.173 -> 1.174 : -0.097% | 
date-format-xparb.js | 53248 -> 49152 : +7.692% | 0.612 -> 0.609 : +0.480% | 
math-cordic.js | 28672 -> 20480 : +28.571% | 2.000 -> 2.000 : -0.020% | 
math-partial-sums.js | 24576 -> 16384 : +33.333% | 1.124 -> 1.116 : +0.719% | 
math-spectral-norm.js | 28672 -> 24576 : +14.286% | 0.888 -> 0.890 : -0.129% | 
string-base64.js | 143360 -> 135168 : +5.714% | 4.736 -> 4.733 : +0.059% | 
string-fasta.js | 40960 -> 32768 : +20.000% | 2.267 -> 2.270 : -0.140% | 
Geometric mean: | +14.242% | +0.024% | 

The performance is roughly the same, but provides 14% memory reduction.