### PR TITLE
Optimize add operation.

### DIFF
--- a/jerry-core/vm/opcodes.h
+++ b/jerry-core/vm/opcodes.h
@@ -32,7 +32,6 @@
  */
 typedef enum
 {
-  NUMBER_ARITHMETIC_ADDITION, /**< addition */
   NUMBER_ARITHMETIC_SUBSTRACTION, /**< substraction */
   NUMBER_ARITHMETIC_MULTIPLICATION, /**< multiplication */
   NUMBER_ARITHMETIC_DIVISION, /**< division */


### PR DESCRIPTION
Improves 3d-cube.js and math-spectral-norm.js

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 1.482 -> 1.308 : +11.718% | 
3d-raytrace.js | 1.584 -> 1.539 : +2.815% | 
access-binary-trees.js | 0.749 -> 0.744 : +0.615% | 
access-fannkuch.js | 3.100 -> 3.124 : -0.752% | 
access-nbody.js | 1.558 -> 1.525 : +2.089% | 
bitops-3bit-bits-in-byte.js | 0.792 -> 0.751 : +5.165% | 
bitops-bits-in-byte.js | 1.041 -> 1.048 : -0.725% | 
bitops-bitwise-and.js | 1.875 -> 1.973 : -5.222% | 
bitops-nsieve-bits.js | 2.523 -> 2.475 : +1.901% | 
controlflow-recursive.js | 0.549 -> 0.542 : +1.173% | 
crypto-aes.js | 1.445 -> 1.449 : -0.280% | 
crypto-md5.js | 0.934 -> 0.899 : +3.746% | 
crypto-sha1.js | 0.880 -> 0.849 : +3.485% | 
date-format-tofte.js | 1.140 -> 1.145 : -0.405% | 
date-format-xparb.js | 0.591 -> 0.578 : +2.265% | 
math-cordic.js | 2.002 -> 1.887 : +5.747% | 
math-partial-sums.js | 1.096 -> 1.058 : +3.468% | 
math-spectral-norm.js | 0.892 -> 0.789 : +11.580% | 
string-base64.js | 4.692 -> 4.647 : +0.960% | 
string-fasta.js | 2.241 -> 2.188 : +2.363% | 
Geometric mean: | +2.663% | 