### PR TITLE
Added target to compile RIOT-OS against jerryscript

### DIFF
--- a/targets/riot-stm32f4/Makefile
+++ b/targets/riot-stm32f4/Makefile
@@ -1,0 +1,50 @@
+# Copyright 2016 Samsung Electronics Co., Ltd.
+# Copyright 2016 University of Szeged
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# application name
+APPLICATION = riot_jerry
+
+# default BOARD enviroment
+BOARD ?= stm32f4discovery
+
+# path to the RIOT base directory
+RIOTBASE ?= $(CURDIR)/../RIOT
+# path to the JERRYSCRIPT directory
+JERRYDIR ?= $(CURDIR)
+
+# path to the application directory
+APPDIR ?= $(JERRYDIR)/targets/riot-stm32f4/source
+
+# path to the binary directory
+BINDIR ?= $(JERRYDIR)/targets/riot-stm32f4/bin/
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+INCLUDES += -I$(JERRYDIR)/jerry-core/
+
+# Add the shell and some shell commands
+USEMODULE += shell
+USEMODULE += shell_commands
+
+# Add the jerry lib
+USEMODULE += libjerrycore
+
+include $(RIOTBASE)/Makefile.include

--- a/targets/riot-stm32f4/Makefile.riot
+++ b/targets/riot-stm32f4/Makefile.riot
@@ -1,0 +1,61 @@
+# Copyright 2016 Samsung Electronics Co., Ltd.
+# Copyright 2016 University of Szeged
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TYPE       ?= release
+INTERM     ?= build/obj-riot-stm32f4
+OUTPUT     ?= build/bin/$(TYPE).riotstm32f4
+COPYTARGET ?= targets/riot-stm32f4/bin/
+
+JERRYHEAP  ?= 16
+
+EXT_CFLAGS := -D__TARGET_RIOT_STM32F4
+EXT_CFLAGS += -mlittle-endian -mthumb -mcpu=cortex-m4
+EXT_CFLAGS += -Wno-error=format=
+
+.PHONY: libjerry riot-jerry flash clean
+
+all: libjerry riot-jerry
+
+libjerry:
+	mkdir -p $(INTERM)
+	mkdir -p $(OUTPUT)
+	mkdir -p $(COPYTARGET)
+	cmake -B$(INTERM) -H./ \
+	 -DEXTERNAL_PORT_DIR=UNDEFINED \
+	 -DENABLE_LTO=OFF \
+	 -DENABLE_VALGRIND=OFF \
+	 -DCMAKE_TOOLCHAIN_FILE=build/configs/toolchain_external.cmake \
+	 -DCOMPILER_DEFAULT_LIBC=ON \
+	 -DEXTERNAL_CMAKE_SYSTEM_PROCESSOR=armv7l-hf \
+	 -DEXTERNAL_CMAKE_C_COMPILER=arm-none-eabi-gcc \
+	 -DEXTERNAL_CMAKE_C_COMPILER_ID=GNU \
+	 -DEXTERNAL_COMPILE_FLAGS="$(EXT_CFLAGS)" \
+	 -DEXTERNAL_MEM_HEAP_SIZE_KB=$(JERRYHEAP)
+
+	make -C $(INTERM) $(TYPE).external
+	cp `cat $(INTERM)/$(TYPE).external/list` $(OUTPUT)/.
+	cp $(OUTPUT)/lib$(TYPE).jerry-core.a $(COPYTARGET)/libjerrycore.a
+
+riot-jerry: libjerry
+	make -f ./targets/riot-stm32f4/Makefile
+
+flash: libjerry
+	make -f ./targets/riot-stm32f4/Makefile flash
+
+clean:
+	rm -rf $(INTERM)
+	rm -rf $(OUTPUT)
+	rm -rf $(COPYTARGET)
+	make -f ./targets/riot-stm32f4/Makefile clean

--- a/targets/riot-stm32f4/README.md
+++ b/targets/riot-stm32f4/README.md
@@ -1,0 +1,96 @@
+### About
+
+This folder contains files to run JerryScript on RIOT-OS with STM32F4-Discovery board.
+
+### How to build
+
+#### 1. Preface
+
+1, Directory structure
+
+Assume `harmony` as the path to the projects to build.
+The folder tree related would look like this.
+
+```
+harmony
+  + jerryscript
+  |  + targets
+  |      + riot-stm32f4
+  + RIOT
+```
+
+2, Target board
+
+Assume [STM32F4-Discovery with BB](http://www.st.com/web/en/catalog/tools/FM116/SC959/SS1532/LN1199/PF255417)
+as the target board.
+
+#### 2. Prepare RIOT-OS
+
+Follow [this](https://www.riot-os.org/#download) page to get the RIOT-OS source.
+
+Follow the [Inroduction](https://github.com/RIOT-OS/RIOT/wiki/Introduction) wiki site and also check that you can flash the stm32f4-board.
+
+
+#### 3. Build JerryScript for RIOT-OS
+
+```
+# assume you are in harmony folder
+cd jerryscript
+make -f ./targets/riot-stm32f4/Makefile.riot
+```
+
+This will generate the following libraries:
+```
+/build/bin/release.riotstm32f4/librelease.jerry-core.a
+/build/bin/release.riotstm32f4/librelease.jerry-libm.lib.a
+```
+
+This will copy one library files to `targets/riot-stm32f4/bin` folder:
+```
+libjerrycore.a
+```
+
+This will create a hex file in the `targets/riot-stm32f4/bin` folder:
+```
+riot_jerry.elf
+```
+
+#### 4. Flashing
+
+```
+make -f ./targets/riot-stm32f4/Makefile.riot flash
+```
+
+For how to flash the image with other alternative way can be found here:
+[Alternative way to flash](https://github.com/RIOT-OS/RIOT/wiki/Board:-STM32F4discovery#alternative-way-to-flash)
+
+#### 5. Cleaning
+
+To clean the build result:
+```
+make -f ./targets/riot-stm32f4/Makefile.riot clean
+```
+
+
+### 5. Running JerryScript Hello World! example
+
+You may have to press `RESET` on the board after the flash.
+
+You can use `minicom` for terminal program, and if the prompt shows like this:
+```
+main(): This is RIOT! (Version: ****)
+                                     You are running RIOT on a(n) stm32f4discovery board.
+                                                                                         This board features a(n) stm32f4 MCU.
+```
+please set `Add Carriage Ret` option by `CTRL-A` > `Z` > `U` at the console, if you're using `minicom`.
+
+
+Help will provide a list of commands:
+```
+> help
+```
+
+The `test` command will run the test example, which contains the following script code:
+```
+print ('Hello, World!');
+```

--- a/targets/riot-stm32f4/source/main-riotos.c
+++ b/targets/riot-stm32f4/source/main-riotos.c
@@ -1,0 +1,55 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ * Copyright 2016 University of Szeged.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+#include "shell.h"
+#include "jerry.h"
+
+/**
+ * Jerryscript simple test
+ */
+int test_jerry (int argc, char **argv)
+{
+  /* Suppress compiler errors */
+  (void) argc;
+  (void) argv;
+  const jerry_api_char_t script[] = "print ('Hello, World!');";
+  printf ("This test run the following script code: [%s]\n\n", script);
+
+  size_t script_size = strlen ((const char *) script);
+  jerry_completion_code_t return_code = jerry_run_simple (script,
+                                                          script_size,
+                                                          JERRY_FLAG_EMPTY);
+
+  return return_code;
+} /* test_jerry */
+
+const shell_command_t shell_commands[] = {
+  { "test", "Jerryscript Hello World test", test_jerry },
+  { NULL, NULL, NULL }
+};
+
+int main (void)
+{
+  printf ("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
+  printf ("This board features a(n) %s MCU.\n", RIOT_MCU);
+
+  /* start the shell */
+  char line_buf[SHELL_DEFAULT_BUFSIZE];
+  shell_run (shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+  return 0;
+}


### PR DESCRIPTION
This patch contains an example in which you can run a small js on RIOT-OS with STM32F4-Discovery.
Check the README.md for a more detailed explanation of how to compile and run it.

JerryScript-DCO-1.0-Signed-off-by: Robert Sipka rsipka.uszeged@partner.samsung.com