### PR TITLE
Improve get-value

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -222,12 +222,11 @@ ecma_new_ecma_string_from_code_unit (ecma_char_t code_unit) /**< code unit */
 } /* ecma_new_ecma_string_from_code_unit */
 
 /**
- * Allocate new ecma-string and fill it with ecma-number
- *
- * @return pointer to ecma-string descriptor
+ * Initialize an ecma-string with an ecma-number
  */
-ecma_string_t *
-ecma_new_ecma_string_from_uint32 (uint32_t uint32_number) /**< UInt32-represented ecma-number */
+inline void __attr_always_inline___
+ecma_init_ecma_string_from_uint32 (ecma_string_t *string_desc_p, /**< ecma-string */
+                                   uint32_t uint32_number) /**< uint32 value of the string */
 {
   lit_utf8_byte_t byte_buf[ECMA_MAX_CHARS_IN_STRINGIFIED_UINT32];
   lit_utf8_byte_t *buf_p = byte_buf + ECMA_MAX_CHARS_IN_STRINGIFIED_UINT32;
@@ -245,13 +244,24 @@ ecma_new_ecma_string_from_uint32 (uint32_t uint32_number) /**< UInt32-represente
 
   lit_utf8_size_t size = (lit_utf8_size_t) (byte_buf + ECMA_MAX_CHARS_IN_STRINGIFIED_UINT32 - buf_p);
 
-  ecma_string_t *string_desc_p = ecma_alloc_string ();
   string_desc_p->refs_and_container = ECMA_STRING_CONTAINER_UINT32_IN_DESC | ECMA_STRING_REF_ONE;
   string_desc_p->hash = lit_utf8_string_calc_hash (buf_p, size);
 
   string_desc_p->u.common_field = 0;
   string_desc_p->u.uint32_number = uint32_number;
+} /* ecma_init_ecma_string_from_uint32 */
 
+/**
+ * Allocate new ecma-string and fill it with ecma-number
+ *
+ * @return pointer to ecma-string descriptor
+ */
+ecma_string_t *
+ecma_new_ecma_string_from_uint32 (uint32_t uint32_number) /**< uint32 value of the string */
+{
+  ecma_string_t *string_desc_p = ecma_alloc_string ();
+
+  ecma_init_ecma_string_from_uint32 (string_desc_p, uint32_number);
   return string_desc_p;
 } /* ecma_new_ecma_string_from_uint32 */
 

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -179,6 +179,7 @@ extern lit_utf8_size_t __attr_return_value_should_be_checked___
 ecma_string_copy_to_utf8_buffer (const ecma_string_t *, lit_utf8_byte_t *, lit_utf8_size_t);
 extern void ecma_string_to_utf8_bytes (const ecma_string_t *, lit_utf8_byte_t *, lit_utf8_size_t);
 extern const lit_utf8_byte_t *ecma_string_raw_chars (const ecma_string_t *, lit_utf8_size_t *, bool *);
+extern void ecma_init_ecma_string_from_uint32 (ecma_string_t *, uint32_t);
 
 extern bool ecma_compare_ecma_strings_equal_hashes (const ecma_string_t *, const ecma_string_t *);
 extern bool ecma_compare_ecma_strings (const ecma_string_t *, const ecma_string_t *);


### PR DESCRIPTION
Slight perf improvement. But 4% on access-fannkuch.js

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 1.210 -> 1.178 : +2.620% | 
3d-raytrace.js | 1.468 -> 1.415 : +3.627% | 
access-binary-trees.js | 0.727 -> 0.730 : -0.408% | 
access-fannkuch.js | 2.980 -> 2.837 : +4.802% | 
access-nbody.js | 1.481 -> 1.408 : +4.900% | 
bitops-3bit-bits-in-byte.js | 0.645 -> 0.651 : -0.937% | 
bitops-bits-in-byte.js | 0.944 -> 0.942 : +0.160% | 
bitops-bitwise-and.js | 1.971 -> 1.999 : -1.376% | 
bitops-nsieve-bits.js | 2.284 -> 2.275 : +0.397% | 
controlflow-recursive.js | 0.495 -> 0.497 : -0.348% | 
crypto-aes.js | 1.360 -> 1.303 : +4.137% | 
crypto-md5.js | 0.865 -> 0.872 : -0.803% | 
crypto-sha1.js | 0.810 -> 0.812 : -0.270% | 
date-format-tofte.js | 1.098 -> 1.088 : +0.924% | 
date-format-xparb.js | 0.569 -> 0.578 : -1.470% | 
math-cordic.js | 1.726 -> 1.715 : +0.659% | 
math-partial-sums.js | 1.009 -> 1.008 : +0.123% | 
math-spectral-norm.js | 0.737 -> 0.714 : +3.046% | 
string-base64.js | 4.611 -> 4.629 : -0.388% | 
string-fasta.js | 2.190 -> 2.178 : +0.565% | 
Geometric mean: | +1.019% | 

Binary size unchanged.