### PR TITLE
Add travis script to build and run jerryscript with zephyr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,19 @@ os: linux
 dist: trusty
 sudo: required
 
+addons:
+  apt:
+    packages:
+      - gcc
+      - gcc-multilib
+      - g++
+      - libc6-dev-i386
+      - g++-multilib
+      - python3-ply
+      - linux-libc-dev
+      - gcc-multilib
+      - build-essential
+
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tools/apt-get-install-deps.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tools/apt-get-install-qemu-arm.sh; fi
@@ -26,5 +39,8 @@ matrix:
       env: TARGET="build.darwin test-js"
     - os: osx
       env: TARGET=test-unit
+    - os: linux
+      env: TARGET=build_zephyr
   allow_failures:
     - os: osx
+    - env: TARGET=build_zephyr

--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,10 @@ clean:
 check-signed-off:
 	$(Q) ./tools/check-signed-off.sh
 
+.PHONY: check-signed-off
+build_zephyr:
+	$(Q) ./tools/build_zephyr.sh
+
 .PHONY: check-vera
 check-vera:
 	$(Q) $(call SHLOG,./tools/check-vera.sh,$(OUT_DIR)/vera.log,Vera++)

--- a/targets/arduino_101/src/main-zephyr.c
+++ b/targets/arduino_101/src/main-zephyr.c
@@ -122,23 +122,23 @@ static int shell_cmd_handler (int argc, char *argv[])
 
   * (d - 1) = '\0';
 
-  if (flags & VERBOSE)
-  {
-    printf ("[%s] %lu\n", source_buffer, strlen (source_buffer));
-  }
-
   jerry_completion_code_t ret_code;
 
   ret_code = jerry_run_simple ((jerry_char_t *) source_buffer,
     strlen (source_buffer),
     JERRY_FLAG_EMPTY);
 
-  free (source_buffer);
-
   if (ret_code != JERRY_COMPLETION_CODE_OK)
   {
     printf ("Failed to run JS\n");
   }
+
+  if (flags & VERBOSE || ret_code != JERRY_COMPLETION_CODE_OK)
+  {
+    printf ("[%s] %lu\n", source_buffer, strlen (source_buffer));
+  }
+
+  free (source_buffer);
 
   return 0;
 } /* shell_cmd_handler */

--- a/tools/build_zephyr.sh
+++ b/tools/build_zephyr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+# Copyright 2016 University of Szeged
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+git clone https://gerrit.zephyrproject.org/r/zephyr
+cd zephyr
+wget https://nexus.zephyrproject.org/content/repositories/releases/org/zephyrproject/zephyr-sdk/0.8-i686/zephyr-sdk-0.8-i686-setup.run
+chmod +x zephyr-sdk-0.8-i686-setup.run
+mkdir zephyr_uncompressed && cd zephyr_uncompressed
+../zephyr-sdk-0.8-i686-setup.run --target $(pwd) --noexec
+mkdir ../zephyr_sdk && cd ../zephyr_sdk
+export ZEPHYR_SDK_INSTALL_DIR=$(pwd)
+cd ../zephyr_uncompressed
+./setup.sh -d $ZEPHYR_SDK_INSTALL_DIR
+source ../zephyr-env.sh
+export ZEPHYR_GCC_VARIANT=zephyr
+cd ../..
+sudo ln -s /usr/include/asm-generic /usr/include/asm
+make -f ./targets/arduino_101/Makefile.arduino_101 BOARD=qemu_x86
+mkfifo path.in path.out
+./zephyr/zephyr_sdk/sysroots/i686-pokysdk-linux/usr/bin/qemu-system-i386 -m 32 -cpu qemu32 -no-reboot -nographic -vga none -display none -net none -clock dynticks -no-acpi -balloon none -L ./zephyr/zephyr_sdk/sysroots/i686-pokysdk-linux/usr/share/qemu -bios bios.bin -machine type=pc-0.14 -pidfile qemu.pid -serial pipe:path -kernel ./build/qemu_x86/zephyr/zephyr.elf & sleep 5
+cat path.out > log.txt & sleep 5
+printf "test\r\n" > path.in
+sleep 5
+kill %1
+cat log.txt
+if grep "Hi JS World!" log.txt > /dev/null; then echo -e "\n\nQapla'!    (it means \"Success\" in Klingon)"; else echo -e "\n\nScript has failed"; fi
+grep "Hi JS World!" log.txt > /dev/null


### PR DESCRIPTION
Travis will build jerryscript against zephyr and run the "test" command in the virtual console, using named pipe. The output is directed to log.txt which is then checked to see if the command was successful.


JerryScript-DCO-1.0-Signed-off-by: Adrian Moldovan adrian.moldovan@intel.com