### PR TITLE
Rename ecma_is_value_error to ECMA_IS_VALUE_ERROR.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -173,6 +173,12 @@ typedef int32_t ecma_integer_value_t;
 #endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32 */
 
 /**
+ * Checks whether the error flag is set.
+ */
+#define ECMA_IS_VALUE_ERROR(value) \
+  (unlikely ((value & ECMA_VALUE_ERROR_FLAG) != 0))
+
+/**
  * Internal properties' identifiers.
  */
 typedef enum

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -312,18 +312,6 @@ ecma_is_value_object (ecma_value_t value) /**< ecma value */
 } /* ecma_is_value_object */
 
 /**
- * Check if the value is an error value.
- *
- * @return true - if the value contains an error value,
- *         false - otherwise.
- */
-inline bool __attr_pure___ __attr_always_inline___
-ecma_is_value_error (ecma_value_t value) /**< ecma value */
-{
-  return (value & ECMA_VALUE_ERROR_FLAG) != 0;
-} /* ecma_is_value_error */
-
-/**
  * Debug assertion that specified value's type is one of ECMA-defined
  * script-visible types, i.e.: undefined, null, boolean, number, string, object.
  */
@@ -501,7 +489,7 @@ ecma_value_t __attr_const___
 ecma_make_error_value (ecma_value_t value) /**< original ecma value */
 {
   /* Error values cannot be converted. */
-  JERRY_ASSERT (!ecma_is_value_error (value));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (value));
 
   return value | ECMA_VALUE_ERROR_FLAG;
 } /* ecma_make_error_value */
@@ -618,11 +606,11 @@ ecma_invert_boolean_value (ecma_value_t value) /**< ecma value */
 ecma_value_t __attr_pure___
 ecma_get_value_from_error_value (ecma_value_t value) /**< ecma value */
 {
-  JERRY_ASSERT (ecma_is_value_error (value));
+  JERRY_ASSERT (ECMA_IS_VALUE_ERROR (value));
 
   value = (ecma_value_t) (value & ~ECMA_VALUE_ERROR_FLAG);
 
-  JERRY_ASSERT (!ecma_is_value_error (value));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (value));
 
   return value;
 } /* ecma_get_value_from_error_value */

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -129,7 +129,6 @@ extern bool ecma_is_value_float_number (ecma_value_t) __attr_pure___;
 extern bool ecma_is_value_number (ecma_value_t) __attr_pure___;
 extern bool ecma_is_value_string (ecma_value_t) __attr_pure___;
 extern bool ecma_is_value_object (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_error (ecma_value_t) __attr_pure___;
 
 extern void ecma_check_value_type_is_spec_defined (ecma_value_t);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -2005,7 +2005,7 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
 
     /* We already checked that arg1 is callable, so it will always coerce to an object. */
     ecma_value_t to_object_comp = ecma_op_to_object (arg1);
-    JERRY_ASSERT (!ecma_is_value_error (to_object_comp));
+    JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (to_object_comp));
 
     func_object_p = ecma_get_object_from_value (to_object_comp);
 
@@ -2103,7 +2103,7 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
 
     /* We already checked that arg1 is callable, so it will always coerce to an object. */
     ecma_value_t to_object_comp = ecma_op_to_object (arg1);
-    JERRY_ASSERT (!ecma_is_value_error (to_object_comp));
+    JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (to_object_comp));
 
     func_object_p = ecma_get_object_from_value (to_object_comp);
 
@@ -2200,7 +2200,7 @@ ecma_builtin_array_prototype_object_for_each (ecma_value_t this_arg, /**< this a
 
     /* We already checked that arg1 is callable, so it will always coerce to an object. */
     ecma_value_t to_object_comp = ecma_op_to_object (arg1);
-    JERRY_ASSERT (!ecma_is_value_error (to_object_comp));
+    JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (to_object_comp));
 
     func_object_p = ecma_get_object_from_value (to_object_comp);
 
@@ -2295,7 +2295,7 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
 
     /* 6. */
     ecma_value_t new_array = ecma_op_create_array_object (NULL, 0, false);
-    JERRY_ASSERT (!ecma_is_value_error (new_array));
+    JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (new_array));
     ecma_object_t *new_array_p = ecma_get_object_from_value (new_array);
 
     /* 7-8. */
@@ -2402,7 +2402,7 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
 
     /* 6. */
     ecma_value_t new_array = ecma_op_create_array_object (NULL, 0, false);
-    JERRY_ASSERT (!ecma_is_value_error (new_array));
+    JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (new_array));
     ecma_object_t *new_array_p = ecma_get_object_from_value (new_array);
 
     /* We already checked that arg1 is callable, so it will always be an object. */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -564,7 +564,7 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
   }
   else
   {
-    JERRY_ASSERT (ecma_is_value_error (ret_value));
+    JERRY_ASSERT (ECMA_IS_VALUE_ERROR (ret_value));
     ecma_deref_object (obj_p);
   }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
@@ -87,7 +87,7 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
       name_to_str_completion = ecma_op_to_string (name_get_ret_value);
     }
 
-    if (unlikely (ecma_is_value_error (name_to_str_completion)))
+    if (unlikely (ECMA_IS_VALUE_ERROR (name_to_str_completion)))
     {
       ret_value = ecma_copy_value (name_to_str_completion);
     }
@@ -112,7 +112,7 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
         msg_to_str_completion = ecma_op_to_string (msg_get_ret_value);
       }
 
-      if (unlikely (ecma_is_value_error (msg_to_str_completion)))
+      if (unlikely (ECMA_IS_VALUE_ERROR (msg_to_str_completion)))
       {
         ret_value = ecma_copy_value (msg_to_str_completion);
       }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -289,7 +289,7 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
     if (ecma_object_get_class_name (this_arg_obj_p) == LIT_MAGIC_STRING_FUNCTION_UL)
     {
       ecma_value_t get_len_value = ecma_op_object_get (this_arg_obj_p, magic_string_length_p);
-      JERRY_ASSERT (!ecma_is_value_error (get_len_value));
+      JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (get_len_value));
       JERRY_ASSERT (ecma_is_value_number (get_len_value));
 
       const ecma_length_t bound_arg_count = arg_count > 1 ? arg_count - 1 : 0;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -65,7 +65,7 @@ ecma_builtin_helper_object_to_string (const ecma_value_t this_arg) /**< this arg
   {
     ecma_value_t obj_this = ecma_op_to_object (this_arg);
 
-    if (ecma_is_value_error (obj_this))
+    if (ECMA_IS_VALUE_ERROR (obj_this))
     {
       return obj_this;
     }
@@ -200,7 +200,7 @@ ecma_builtin_helper_object_get_properties (ecma_object_t *obj_p, /**< object */
   JERRY_ASSERT (obj_p != NULL);
 
   ecma_value_t new_array = ecma_op_create_array_object (NULL, 0, false);
-  JERRY_ASSERT (!ecma_is_value_error (new_array));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (new_array));
   ecma_object_t *new_array_p = ecma_get_object_from_value (new_array);
 
   uint32_t index = 0;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -533,7 +533,7 @@ ecma_builtin_json_parse_value (ecma_json_token_t *token_p) /**< token argument *
       uint32_t length = 0;
 
       ecma_value_t array_construction = ecma_op_create_array_object (NULL, 0, false);
-      JERRY_ASSERT (!ecma_is_value_error (array_construction));
+      JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (array_construction));
 
       ecma_object_t *array_p = ecma_get_object_from_value (array_construction);
 
@@ -678,7 +678,7 @@ ecma_builtin_json_walk (ecma_object_t *reviver_p, /**< reviver function */
   }
   else
   {
-    JERRY_ASSERT (ecma_is_value_error (ret_value));
+    JERRY_ASSERT (ECMA_IS_VALUE_ERROR (ret_value));
   }
 
   ECMA_FINALIZE (value_get);
@@ -1323,7 +1323,7 @@ ecma_builtin_json_str (ecma_string_t *key_p, /**< property key*/
     if (ecma_is_value_null (my_val) || ecma_is_value_boolean (my_val))
     {
       ret_value = ecma_op_to_string (my_val);
-      JERRY_ASSERT (!ecma_is_value_error (ret_value));
+      JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (ret_value));
     }
     /* 8. */
     else if (ecma_is_value_string (my_val))
@@ -1340,7 +1340,7 @@ ecma_builtin_json_str (ecma_string_t *key_p, /**< property key*/
       if (!ecma_number_is_nan (num_value_p) && !ecma_number_is_infinity (num_value_p))
       {
         ret_value = ecma_op_to_string (my_val);
-        JERRY_ASSERT (!ecma_is_value_error (ret_value));
+        JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (ret_value));
       }
       else
       {
@@ -1482,7 +1482,7 @@ ecma_builtin_json_object (ecma_object_t *obj_p, /**< the object*/
 
       /* 8.b.i */
       ecma_value_t str_comp_val = ecma_builtin_json_quote (key_p);
-      JERRY_ASSERT (!ecma_is_value_error (str_comp_val));
+      JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (str_comp_val));
 
       ecma_string_t *member_str_p = ecma_get_string_from_value (str_comp_val);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1763,7 +1763,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
               ecma_string_t *zero_str_p = ecma_new_ecma_string_from_number (ECMA_NUMBER_ZERO);
               ecma_value_t match_comp_value = ecma_op_object_get (match_array_obj_p, zero_str_p);
 
-              JERRY_ASSERT (!ecma_is_value_error (match_comp_value));
+              JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (match_comp_value));
 
               ecma_string_t *match_str_p = ecma_get_string_from_value (match_comp_value);
               ecma_length_t match_str_length = ecma_string_get_length (match_str_p);
@@ -1842,7 +1842,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
 
                 ecma_value_t match_comp_value = ecma_op_object_get (match_array_obj_p, idx_str_p);
 
-                JERRY_ASSERT (!ecma_is_value_error (match_comp_value));
+                JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (match_comp_value));
 
                 /* 13.c.iii.7.b */
                 ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -179,12 +179,12 @@ ecma_op_array_object_define_own_property (ecma_object_t *obj_p, /**< the array o
 
     // c.
     ecma_value_t completion = ecma_op_to_number (property_desc_p->value);
-    if (ecma_is_value_error (completion))
+    if (ECMA_IS_VALUE_ERROR (completion))
     {
       return completion;
     }
 
-    JERRY_ASSERT (!ecma_is_value_error (completion)
+    JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (completion)
                   && ecma_is_value_number (completion));
 
     ecma_number_t new_len_num = ecma_get_number_from_value (completion);
@@ -255,7 +255,7 @@ ecma_op_array_object_define_own_property (ecma_object_t *obj_p, /**< the array o
           if (!ecma_is_value_true (succeeded))
           {
             JERRY_ASSERT (ecma_is_value_false (succeeded)
-                          || ecma_is_value_error (succeeded));
+                          || ECMA_IS_VALUE_ERROR (succeeded));
 
             // k.
             ret_value = succeeded;

--- a/jerry-core/ecma/operations/ecma-comparison.c
+++ b/jerry-core/ecma/operations/ecma-comparison.c
@@ -108,7 +108,7 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
       // 4.
       ecma_value_t x_num_value = ecma_op_to_number (x);
 
-      if (ecma_is_value_error (x_num_value))
+      if (ECMA_IS_VALUE_ERROR (x_num_value))
       {
         return x_num_value;
       }
@@ -146,7 +146,7 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
       // 9.
       ecma_value_t x_prim_value = ecma_op_to_primitive (x, ECMA_PREFERRED_TYPE_NO);
 
-      if (ecma_is_value_error (x_prim_value))
+      if (ECMA_IS_VALUE_ERROR (x_prim_value))
       {
         return x_prim_value;
       }

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -599,7 +599,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
 
     ecma_deref_ecma_string (enumerable_magic_string_p);
 
-    if (!ecma_is_value_error (ret_value))
+    if (!ECMA_IS_VALUE_ERROR (ret_value))
     {
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
@@ -621,7 +621,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       ecma_deref_ecma_string (configurable_magic_string_p);
     }
 
-    if (!ecma_is_value_error (ret_value))
+    if (!ECMA_IS_VALUE_ERROR (ret_value))
     {
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
@@ -643,7 +643,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       ecma_deref_ecma_string (value_magic_string_p);
     }
 
-    if (!ecma_is_value_error (ret_value))
+    if (!ECMA_IS_VALUE_ERROR (ret_value))
     {
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
@@ -665,7 +665,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       ecma_deref_ecma_string (writable_magic_string_p);
     }
 
-    if (!ecma_is_value_error (ret_value))
+    if (!ECMA_IS_VALUE_ERROR (ret_value))
     {
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
@@ -708,7 +708,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       ecma_deref_ecma_string (get_magic_string_p);
     }
 
-    if (!ecma_is_value_error (ret_value))
+    if (!ECMA_IS_VALUE_ERROR (ret_value))
     {
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
@@ -752,7 +752,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       ecma_deref_ecma_string (set_magic_string_p);
     }
 
-    if (!ecma_is_value_error (ret_value))
+    if (!ECMA_IS_VALUE_ERROR (ret_value))
     {
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
@@ -768,7 +768,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       }
     }
 
-    if (!ecma_is_value_error (ret_value))
+    if (!ECMA_IS_VALUE_ERROR (ret_value))
     {
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
     }

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -601,7 +601,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
         // 3., 4.
         this_binding = ecma_op_to_object (this_arg_value);
 
-        JERRY_ASSERT (!ecma_is_value_error (this_binding));
+        JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (this_binding));
       }
 
       // 5.

--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -162,7 +162,7 @@ ecma_op_create_mutable_binding (ecma_object_t *lex_env_p, /**< lexical environme
                                                is_deletable, /* Configurable */
                                                true); /* Failure handling */
 
-    if (ecma_is_value_error (completion))
+    if (ECMA_IS_VALUE_ERROR (completion))
     {
       return completion;
     }
@@ -218,7 +218,7 @@ ecma_op_set_mutable_binding (ecma_object_t *lex_env_p, /**< lexical environment 
                                                   value,
                                                   is_strict);
 
-    if (ecma_is_value_error (completion))
+    if (ECMA_IS_VALUE_ERROR (completion))
     {
       return completion;
     }

--- a/jerry-core/ecma/operations/ecma-number-object.c
+++ b/jerry-core/ecma/operations/ecma-number-object.c
@@ -43,7 +43,7 @@ ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Numb
 {
   ecma_value_t conv_to_num_completion = ecma_op_to_number (arg);
 
-  if (ecma_is_value_error (conv_to_num_completion))
+  if (ECMA_IS_VALUE_ERROR (conv_to_num_completion))
   {
     return conv_to_num_completion;
   }

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -291,7 +291,7 @@ ecma_arguments_get_mapped_arg_value (ecma_object_t *map_p, /**< [[ParametersMap]
   ecma_string_t *arg_name_p = ecma_get_string_from_value (arg_name_prop_value);
 
   ecma_value_t completion = ecma_op_get_binding_value (lex_env_p, arg_name_p, true);
-  JERRY_ASSERT (!ecma_is_value_error (completion));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (completion));
 
   return completion;
 } /* ecma_arguments_get_mapped_arg_value */

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -424,7 +424,7 @@ ecma_op_general_object_put (ecma_object_t *obj_p, /**< the object */
                                                   &value,
                                                   1);
 
-  if (!ecma_is_value_error (ret_value))
+  if (!ECMA_IS_VALUE_ERROR (ret_value))
   {
     ecma_fast_free_value (ret_value);
     ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
@@ -533,7 +533,7 @@ ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
 
     ecma_deref_ecma_string (function_name_p);
 
-    if (ecma_is_value_error (function_value_get_completion))
+    if (ECMA_IS_VALUE_ERROR (function_value_get_completion))
     {
       return function_value_get_completion;
     }
@@ -552,7 +552,7 @@ ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
 
     ecma_free_value (function_value_get_completion);
 
-    if (ecma_is_value_error (call_completion)
+    if (ECMA_IS_VALUE_ERROR (call_completion)
         || (!ecma_is_value_empty (call_completion)
            && !ecma_is_value_object (call_completion)))
     {

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -306,7 +306,7 @@ ecma_op_create_regexp_object (ecma_string_t *pattern_p, /**< input pattern */
 
   ECMA_FINALIZE (empty);
 
-  if (ecma_is_value_error (ret_value))
+  if (ECMA_IS_VALUE_ERROR (ret_value))
   {
     ecma_deref_object (obj_p);
   }
@@ -552,7 +552,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
           if (!sub_str_p)
           {
             match_value = re_match_regexp (re_ctx_p, bc_p, str_curr_p, &sub_str_p);
-            if (ecma_is_value_error (match_value))
+            if (ECMA_IS_VALUE_ERROR (match_value))
             {
               break;
             }
@@ -561,7 +561,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         }
         while (re_get_opcode (&bc_p) == RE_OP_ALTERNATIVE);
 
-        if (!ecma_is_value_error (match_value))
+        if (!ECMA_IS_VALUE_ERROR (match_value))
         {
           JERRY_DDLOG ("Execute RE_OP_LOOKAHEAD_POS/NEG: ");
           ecma_free_value (match_value);
@@ -578,7 +578,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
           }
         }
 
-        if (!ecma_is_value_error (match_value))
+        if (!ECMA_IS_VALUE_ERROR (match_value))
         {
           if (ecma_is_value_true (match_value))
           {
@@ -707,7 +707,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             *out_str_p = sub_str_p;
             return match_value; /* match */
           }
-          else if (ecma_is_value_error (match_value))
+          else if (ECMA_IS_VALUE_ERROR (match_value))
           {
             return match_value;
           }
@@ -792,7 +792,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
           *out_str_p = sub_str_p;
           return match_value; /* match */
         }
-        else if (ecma_is_value_error (match_value))
+        else if (ECMA_IS_VALUE_ERROR (match_value))
         {
           return match_value;
         }
@@ -850,7 +850,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             *out_str_p = sub_str_p;
             return match_value; /* match */
           }
-          else if (ecma_is_value_error (match_value))
+          else if (ECMA_IS_VALUE_ERROR (match_value))
           {
             return match_value;
           }
@@ -874,7 +874,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             *out_str_p = sub_str_p;
             return match_value; /* match */
           }
-          else if (ecma_is_value_error (match_value))
+          else if (ECMA_IS_VALUE_ERROR (match_value))
           {
             return match_value;
           }
@@ -928,7 +928,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             *out_str_p = sub_str_p;
             return match_value; /* match */
           }
-          else if (ecma_is_value_error (match_value))
+          else if (ECMA_IS_VALUE_ERROR (match_value))
           {
             return match_value;
           }
@@ -997,7 +997,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             *out_str_p = sub_str_p;
             return match_value; /* match */
           }
-          else if (ecma_is_value_error (match_value))
+          else if (ECMA_IS_VALUE_ERROR (match_value))
           {
             return match_value;
           }
@@ -1021,7 +1021,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
               *out_str_p = sub_str_p;
               return match_value; /* match */
             }
-            else if (ecma_is_value_error (match_value))
+            else if (ECMA_IS_VALUE_ERROR (match_value))
             {
               return match_value;
             }
@@ -1042,7 +1042,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             *out_str_p = sub_str_p;
             return match_value; /* match */
           }
-          else if (ecma_is_value_error (match_value))
+          else if (ECMA_IS_VALUE_ERROR (match_value))
           {
             return match_value;
           }
@@ -1077,7 +1077,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
               *out_str_p = sub_str_p;
               return match_value; /* match */
             }
-            else if (ecma_is_value_error (match_value))
+            else if (ECMA_IS_VALUE_ERROR (match_value))
             {
               return match_value;
             }
@@ -1087,7 +1087,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
 
           if (!ecma_is_value_true (match_value))
           {
-            if (ecma_is_value_error (match_value))
+            if (ECMA_IS_VALUE_ERROR (match_value))
             {
               return match_value;
             }
@@ -1120,7 +1120,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
 
           if (!ecma_is_value_true (match_value))
           {
-            if (ecma_is_value_error (match_value))
+            if (ECMA_IS_VALUE_ERROR (match_value))
             {
               return match_value;
             }
@@ -1141,7 +1141,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
             *out_str_p = sub_str_p;
             return match_value; /* match */
           }
-          else if (ecma_is_value_error (match_value))
+          else if (ECMA_IS_VALUE_ERROR (match_value))
           {
             return match_value;
           }

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -60,13 +60,13 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
   {
     ecma_value_t to_str_arg_value = ecma_op_to_string (arguments_list_p[0]);
 
-    if (ecma_is_value_error (to_str_arg_value))
+    if (ECMA_IS_VALUE_ERROR (to_str_arg_value))
     {
       return to_str_arg_value;
     }
     else
     {
-      JERRY_ASSERT (!ecma_is_value_error (to_str_arg_value));
+      JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (to_str_arg_value));
       JERRY_ASSERT (ecma_is_value_string (to_str_arg_value));
 
       prim_prop_str_value_p = ecma_get_string_from_value (to_str_arg_value);

--- a/jerry-core/ecma/operations/ecma-try-catch-macro.h
+++ b/jerry-core/ecma/operations/ecma-try-catch-macro.h
@@ -32,7 +32,7 @@
 #define ECMA_TRY_CATCH(var, op, return_value) \
   JERRY_ASSERT (return_value == ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY)); \
   ecma_value_t var ## _completion = op; \
-  if (unlikely (ecma_is_value_error (var ## _completion))) \
+  if (ECMA_IS_VALUE_ERROR (var ## _completion)) \
   { \
     return_value = var ## _completion; \
   } \

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -517,7 +517,7 @@ jerry_convert_eval_completion_to_retval (jerry_value_t *retval_p, /**< [out] api
 {
   jerry_convert_ecma_value_to_api_value (retval_p, completion);
 
-  return (ecma_is_value_error (completion)) ? JERRY_COMPLETION_CODE_UNHANDLED_EXCEPTION : JERRY_COMPLETION_CODE_OK;
+  return (ECMA_IS_VALUE_ERROR (completion)) ? JERRY_COMPLETION_CODE_UNHANDLED_EXCEPTION : JERRY_COMPLETION_CODE_OK;
 } /* jerry_convert_eval_completion_to_retval */
 
 /**
@@ -729,7 +729,7 @@ jerry_create_array_object (jerry_size_t size) /**< size of array */
 
   jerry_length_t argument_size = 1;
   ecma_value_t new_array_completion = ecma_op_create_array_object (&array_length, argument_size, true);
-  JERRY_ASSERT (!ecma_is_value_error (new_array_completion));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (new_array_completion));
   jerry_object_t *obj_p = ecma_get_object_from_value (new_array_completion);
 
   ecma_free_value (array_length);
@@ -751,7 +751,7 @@ jerry_set_array_index_value (jerry_object_t *array_obj_p, /**< array object */
   ecma_value_t value;
   jerry_convert_api_value_to_ecma_value (&value, value_p);
   ecma_value_t set_completion = ecma_op_object_put (array_obj_p, str_idx_p, value, false);
-  JERRY_ASSERT (!ecma_is_value_error (set_completion));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (set_completion));
 
   ecma_free_value (set_completion);
   ecma_deref_ecma_string (str_idx_p);
@@ -778,7 +778,7 @@ jerry_get_array_index_value (jerry_object_t *array_obj_p, /**< array object */
 {
   ecma_string_t *str_idx_p = ecma_new_ecma_string_from_uint32 ((uint32_t) index);
   ecma_value_t get_completion = ecma_op_object_get (array_obj_p, str_idx_p);
-  JERRY_ASSERT (!ecma_is_value_error (get_completion));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (get_completion));
   jerry_convert_ecma_value_to_api_value (value_p, get_completion);
 
   ecma_free_value (get_completion);
@@ -1104,7 +1104,7 @@ jerry_delete_object_field (jerry_object_t *object_p, /**< object to delete field
                                                           field_name_str_p,
                                                           true);
 
-  if (ecma_is_value_error (delete_completion))
+  if (ECMA_IS_VALUE_ERROR (delete_completion))
   {
     is_successful = false;
   }
@@ -1186,7 +1186,7 @@ jerry_foreach_object_field (jerry_object_t *object_p, /**< object */
   }
   else
   {
-    JERRY_ASSERT (ecma_is_value_error (ret_value));
+    JERRY_ASSERT (ECMA_IS_VALUE_ERROR (ret_value));
 
     ecma_free_value (ret_value);
 
@@ -1220,7 +1220,7 @@ jerry_get_object_field_value_sz (jerry_object_t *object_p, /**< object */
 
   ecma_value_t field_value = ecma_op_object_get (object_p, field_name_str_p);
 
-  if (!ecma_is_value_error (field_value))
+  if (!ECMA_IS_VALUE_ERROR (field_value))
   {
     jerry_convert_ecma_value_to_api_value (field_value_p, field_value);
 
@@ -1287,7 +1287,7 @@ jerry_set_object_field_value_sz (jerry_object_t *object_p, /**< object */
                                                     value_to_put,
                                                     true);
 
-  if (ecma_is_value_error (set_completion))
+  if (ECMA_IS_VALUE_ERROR (set_completion))
   {
     is_successful = false;
   }
@@ -1442,7 +1442,7 @@ jerry_invoke_function (bool is_invoke_as_constructor, /**< true - invoke functio
                                              args_count);
   }
 
-  if (ecma_is_value_error (call_completion))
+  if (ECMA_IS_VALUE_ERROR (call_completion))
   {
     /* unhandled exception during the function call */
     is_successful = false;
@@ -2374,7 +2374,7 @@ jerry_exec_snapshot (const void *snapshot_p, /**< snapshot */
 
     if (ret_code == JERRY_COMPLETION_CODE_UNHANDLED_EXCEPTION)
     {
-      JERRY_ASSERT (ecma_is_value_error (error_value));
+      JERRY_ASSERT (ECMA_IS_VALUE_ERROR (error_value));
       ecma_free_value (error_value);
     }
     else

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -1817,7 +1817,7 @@ lexer_construct_regexp_object (parser_context_t *context_p, /**< context */
                                           current_flags);
   ecma_deref_ecma_string (pattern_str_p);
 
-  bool is_throw = ecma_is_value_error (completion_value);
+  bool is_throw = ECMA_IS_VALUE_ERROR (completion_value);
 
   ecma_free_value (completion_value);
 

--- a/jerry-core/vm/opcodes-ecma-arithmetics.c
+++ b/jerry-core/vm/opcodes-ecma-arithmetics.c
@@ -53,8 +53,8 @@ do_number_arithmetic (number_arithmetic_op op, /**< number arithmetic operation 
                        && ECMA_INTEGER_NUMBER_MIN * 2 >= INT32_MIN,
                        doubled_ecma_numbers_must_fit_into_int32_range);
 
-  JERRY_ASSERT (!ecma_is_value_error (left_value)
-                && !ecma_is_value_error (right_value));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
+                && !ECMA_IS_VALUE_ERROR (right_value));
 
   if (ecma_are_values_integer_numbers (left_value, right_value))
   {
@@ -177,7 +177,7 @@ opfunc_addition (ecma_value_t left_value, /**< left value */
     left_value = ecma_op_object_default_value (obj_p, ECMA_PREFERRED_TYPE_NO);
     free_left_value = true;
 
-    if (ecma_is_value_error (left_value))
+    if (ECMA_IS_VALUE_ERROR (left_value))
     {
       return left_value;
     }
@@ -189,7 +189,7 @@ opfunc_addition (ecma_value_t left_value, /**< left value */
     right_value = ecma_op_object_default_value (obj_p, ECMA_PREFERRED_TYPE_NO);
     free_right_value = true;
 
-    if (ecma_is_value_error (right_value))
+    if (ECMA_IS_VALUE_ERROR (right_value))
     {
       if (free_left_value)
       {

--- a/jerry-core/vm/opcodes-ecma-bitwise.c
+++ b/jerry-core/vm/opcodes-ecma-bitwise.c
@@ -48,8 +48,8 @@ do_number_bitwise_logic (number_bitwise_logic_op op, /**< number bitwise logic o
   JERRY_STATIC_ASSERT ((ECMA_DIRECT_TYPE_MASK | ECMA_VALUE_ERROR_FLAG) == ((1 << ECMA_DIRECT_SHIFT) - 1),
                        direct_type_mask_and_error_flag_must_fill_all_bits_before_the_value_starts);
 
-  JERRY_ASSERT (!ecma_is_value_error (left_value)
-                && !ecma_is_value_error (right_value));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
+                && !ECMA_IS_VALUE_ERROR (right_value));
 
   if (ecma_are_values_integer_numbers (left_value, right_value))
   {

--- a/jerry-core/vm/opcodes-ecma-equality.c
+++ b/jerry-core/vm/opcodes-ecma-equality.c
@@ -44,14 +44,14 @@ ecma_value_t
 opfunc_equal_value (ecma_value_t left_value, /**< left value */
                     ecma_value_t right_value) /**< right value */
 {
-  JERRY_ASSERT (!ecma_is_value_error (left_value)
-                && !ecma_is_value_error (right_value));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
+                && !ECMA_IS_VALUE_ERROR (right_value));
 
   ecma_value_t compare_result = ecma_op_abstract_equality_compare (left_value,
                                                                    right_value);
 
   JERRY_ASSERT (ecma_is_value_boolean (compare_result)
-                || ecma_is_value_error (compare_result));
+                || ECMA_IS_VALUE_ERROR (compare_result));
 
   return compare_result;
 } /* opfunc_equal_value */
@@ -68,16 +68,16 @@ ecma_value_t
 opfunc_not_equal_value (ecma_value_t left_value, /**< left value */
                         ecma_value_t right_value) /**< right value */
 {
-  JERRY_ASSERT (!ecma_is_value_error (left_value)
-                && !ecma_is_value_error (right_value));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
+                && !ECMA_IS_VALUE_ERROR (right_value));
 
   ecma_value_t compare_result = ecma_op_abstract_equality_compare (left_value,
                                                                    right_value);
 
   JERRY_ASSERT (ecma_is_value_boolean (compare_result)
-                || ecma_is_value_error (compare_result));
+                || ECMA_IS_VALUE_ERROR (compare_result));
 
-  if (!ecma_is_value_error (compare_result))
+  if (!ECMA_IS_VALUE_ERROR (compare_result))
   {
     compare_result = ecma_invert_boolean_value (compare_result);
   }

--- a/jerry-core/vm/opcodes-ecma-relational.c
+++ b/jerry-core/vm/opcodes-ecma-relational.c
@@ -41,8 +41,8 @@ ecma_value_t
 opfunc_less_than (ecma_value_t left_value, /**< left value */
                   ecma_value_t right_value) /**< right value */
 {
-  JERRY_ASSERT (!ecma_is_value_error (left_value)
-                && !ecma_is_value_error (right_value));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
+                && !ECMA_IS_VALUE_ERROR (right_value));
 
   if (ecma_are_values_integer_numbers (left_value, right_value))
   {
@@ -55,7 +55,7 @@ opfunc_less_than (ecma_value_t left_value, /**< left value */
 
   ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, true);
 
-  if (ecma_is_value_error (ret_value))
+  if (ECMA_IS_VALUE_ERROR (ret_value))
   {
     return ret_value;
   }
@@ -84,8 +84,8 @@ ecma_value_t
 opfunc_greater_than (ecma_value_t left_value, /**< left value */
                      ecma_value_t right_value) /**< right value */
 {
-  JERRY_ASSERT (!ecma_is_value_error (left_value)
-                && !ecma_is_value_error (right_value));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
+                && !ECMA_IS_VALUE_ERROR (right_value));
 
   if (ecma_are_values_integer_numbers (left_value, right_value))
   {
@@ -98,7 +98,7 @@ opfunc_greater_than (ecma_value_t left_value, /**< left value */
 
   ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, false);
 
-  if (ecma_is_value_error (ret_value))
+  if (ECMA_IS_VALUE_ERROR (ret_value))
   {
     return ret_value;
   }
@@ -127,8 +127,8 @@ ecma_value_t
 opfunc_less_or_equal_than (ecma_value_t left_value, /**< left value */
                            ecma_value_t right_value) /**< right value */
 {
-  JERRY_ASSERT (!ecma_is_value_error (left_value)
-                && !ecma_is_value_error (right_value));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
+                && !ECMA_IS_VALUE_ERROR (right_value));
 
   if (ecma_are_values_integer_numbers (left_value, right_value))
   {
@@ -141,7 +141,7 @@ opfunc_less_or_equal_than (ecma_value_t left_value, /**< left value */
 
   ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, false);
 
-  if (ecma_is_value_error (ret_value))
+  if (ECMA_IS_VALUE_ERROR (ret_value))
   {
     return ret_value;
   }
@@ -172,8 +172,8 @@ ecma_value_t
 opfunc_greater_or_equal_than (ecma_value_t left_value, /**< left value */
                               ecma_value_t right_value) /**< right value */
 {
-  JERRY_ASSERT (!ecma_is_value_error (left_value)
-                && !ecma_is_value_error (right_value));
+  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
+                && !ECMA_IS_VALUE_ERROR (right_value));
 
   if (ecma_are_values_integer_numbers (left_value, right_value))
   {
@@ -186,7 +186,7 @@ opfunc_greater_or_equal_than (ecma_value_t left_value, /**< left value */
 
   ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, true);
 
-  if (ecma_is_value_error (ret_value))
+  if (ECMA_IS_VALUE_ERROR (ret_value))
   {
     return ret_value;
   }

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -113,7 +113,7 @@ vm_op_get_value (ecma_value_t object, /**< base object */
 
   ecma_value_t prop_to_string_result = ecma_op_to_string (property);
 
-  if (ecma_is_value_error (prop_to_string_result))
+  if (ECMA_IS_VALUE_ERROR (prop_to_string_result))
   {
     return prop_to_string_result;
   }
@@ -221,7 +221,7 @@ vm_run_global (ecma_value_t *error_value_p) /**< [out] error value */
                                    NULL,
                                    0);
 
-  if (ecma_is_value_error (ret_value))
+  if (ECMA_IS_VALUE_ERROR (ret_value))
   {
     *error_value_p = ret_value;
     ret_code = JERRY_COMPLETION_CODE_UNHANDLED_EXCEPTION;
@@ -317,7 +317,7 @@ vm_construct_literal_object (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
     ecma_value_t ret_value;
     ret_value = ecma_op_create_regexp_object_from_bytecode ((re_compiled_code_t *) bytecode_p);
 
-    if (ecma_is_value_error (ret_value))
+    if (ECMA_IS_VALUE_ERROR (ret_value))
     {
       /* TODO: throw exception instead of define an 'undefined' value. */
       return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
@@ -347,7 +347,7 @@ vm_get_implicit_this_value (ecma_value_t *this_value_p) /**< [in,out] this value
     {
       ecma_value_t completion_value = ecma_op_implicit_this_value (this_obj_p);
 
-      JERRY_ASSERT (!ecma_is_value_error (completion_value));
+      JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (completion_value));
 
       *this_value_p = completion_value;
       return true;
@@ -520,7 +520,7 @@ opfunc_construct (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         \
         ecma_deref_ecma_string (name_p); \
         \
-        if (ecma_is_value_error (result)) \
+        if (ECMA_IS_VALUE_ERROR (result)) \
         { \
           goto error; \
         } \
@@ -974,7 +974,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           {
             result = ecma_op_to_string (right_value);
 
-            if (ecma_is_value_error (result))
+            if (ECMA_IS_VALUE_ERROR (result))
             {
               goto error;
             }
@@ -1020,7 +1020,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = ecma_op_create_array_object (NULL, 0, false);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1125,7 +1125,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
               result = ecma_raise_reference_error (ECMA_ERR_MSG (""));
             }
 
-            if (ecma_is_value_error (result))
+            if (ECMA_IS_VALUE_ERROR (result))
             {
               ecma_deref_ecma_string (name_p);
               goto error;
@@ -1171,7 +1171,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           result = vm_op_get_value (left_value,
                                     right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             if (opcode >= CBC_PUSH_PROP_REFERENCE && opcode < CBC_PRE_INCR)
             {
@@ -1205,7 +1205,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
           result = ecma_op_to_number (left_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1404,7 +1404,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           result = *(--stack_top_p);
           block_result = frame_ctx_p->call_block_result;
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1445,7 +1445,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           result = *(--stack_top_p);
           block_result = frame_ctx_p->call_block_result;
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1457,7 +1457,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = vm_op_delete_prop (left_value, right_value, is_strict);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1483,7 +1483,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                      frame_ctx_p->lex_env_p,
                                      is_strict);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1545,7 +1545,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_unary_plus (left_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1557,7 +1557,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_unary_minus (left_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1569,7 +1569,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_logical_not (left_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1583,7 +1583,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                             left_value,
                                             left_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1628,7 +1628,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
             ecma_deref_ecma_string (name_p);
 
-            if (ecma_is_value_error (result))
+            if (ECMA_IS_VALUE_ERROR (result))
             {
               goto error;
             }
@@ -1641,7 +1641,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_typeof (left_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1653,7 +1653,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_addition (left_value, right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1665,7 +1665,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                          left_value,
                                          right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1677,7 +1677,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                          left_value,
                                          right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1689,7 +1689,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                          left_value,
                                          right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1701,7 +1701,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                          left_value,
                                          right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1711,7 +1711,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_equal_value (left_value, right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1723,7 +1723,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_not_equal_value (left_value, right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1757,7 +1757,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                             left_value,
                                             right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1769,7 +1769,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                             left_value,
                                             right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1781,7 +1781,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                             left_value,
                                             right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1793,7 +1793,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                             left_value,
                                             right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1805,7 +1805,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                             left_value,
                                             right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1817,7 +1817,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                             left_value,
                                             right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1827,7 +1827,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_less_than (left_value, right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1839,7 +1839,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_greater_than (left_value, right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1851,7 +1851,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_less_or_equal_than (left_value, right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1863,7 +1863,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_greater_or_equal_than (left_value, right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1875,7 +1875,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_in (left_value, right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1887,7 +1887,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           result = opfunc_instanceof (left_value, right_value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -1908,7 +1908,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           result = ecma_op_to_object (value);
           ecma_free_value (value);
 
-          if (ecma_is_value_error (result))
+          if (ECMA_IS_VALUE_ERROR (result))
           {
             goto error;
           }
@@ -2171,7 +2171,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
           ecma_deref_ecma_string (var_name_str_p);
 
-          if (ecma_is_value_error (put_value_result))
+          if (ECMA_IS_VALUE_ERROR (put_value_result))
           {
             ecma_free_value (result);
             result = put_value_result;
@@ -2210,7 +2210,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           ecma_free_value (object);
           ecma_free_value (property);
 
-          if (ecma_is_value_error (set_value_result))
+          if (ECMA_IS_VALUE_ERROR (set_value_result))
           {
             ecma_free_value (result);
             result = set_value_result;
@@ -2244,7 +2244,7 @@ error:
     ecma_fast_free_value (left_value);
     ecma_fast_free_value (right_value);
 
-    if (ecma_is_value_error (result))
+    if (ECMA_IS_VALUE_ERROR (result))
     {
       ecma_value_t *vm_stack_p = stack_top_p;
 
@@ -2276,7 +2276,7 @@ error:
       return result;
     }
 
-    if (!ecma_is_value_error (result))
+    if (!ECMA_IS_VALUE_ERROR (result))
     {
       JERRY_ASSERT (frame_ctx_p->registers_p + register_end + frame_ctx_p->context_depth == stack_top_p);
 
@@ -2412,7 +2412,7 @@ vm_execute (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
 
   completion_value = vm_init_loop (frame_ctx_p);
 
-  if (likely (!ecma_is_value_error (completion_value)))
+  if (!ECMA_IS_VALUE_ERROR (completion_value))
   {
     while (true)
     {


### PR DESCRIPTION
Telling the compiler that error is rare we get another performance improvement:

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 1.166 -> 1.168 : -0.110% | 
3d-raytrace.js | 1.404 -> 1.397 : +0.495% | 
access-binary-trees.js | 0.714 -> 0.707 : +1.002% | 
access-fannkuch.js | 2.831 -> 2.815 : +0.583% | 
access-nbody.js | 1.404 -> 1.390 : +0.999% | 
bitops-3bit-bits-in-byte.js | 0.650 -> 0.642 : +1.246% | 
bitops-bits-in-byte.js | 0.947 -> 0.926 : +2.233% | 
bitops-bitwise-and.js | 1.980 -> 1.847 : +6.726% | 
bitops-nsieve-bits.js | 2.242 -> 2.250 : -0.336% | 
controlflow-recursive.js | 0.495 -> 0.488 : +1.339% | 
crypto-aes.js | 1.288 -> 1.302 : -1.086% | 
crypto-md5.js | 0.877 -> 0.854 : +2.649% | 
crypto-sha1.js | 0.814 -> 0.799 : +1.935% | 
date-format-tofte.js | 1.083 -> 1.079 : +0.352% | 
date-format-xparb.js | 0.563 -> 0.547 : +2.865% | 
math-cordic.js | 1.730 -> 1.666 : +3.734% | 
math-partial-sums.js | 0.981 -> 0.964 : +1.723% | 
math-spectral-norm.js | 0.713 -> 0.719 : -0.894% | 
string-base64.js | 4.631 -> 4.602 : +0.613% | 
string-fasta.js | 2.170 -> 2.154 : +0.751% | 
Geometric mean: | +1.356% | 

Binary size not changed.