### PR TITLE
Remove string copy

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -167,7 +167,7 @@ ecma_init_gc_info (ecma_object_t *object_p) /**< object */
 void
 ecma_ref_object (ecma_object_t *object_p) /**< object */
 {
-  if (object_p->type_flags_refs < ECMA_OBJECT_MAX_REF)
+  if (likely (object_p->type_flags_refs < ECMA_OBJECT_MAX_REF))
   {
     object_p->type_flags_refs = (uint16_t) (object_p->type_flags_refs + ECMA_OBJECT_REF_ONE);
   }

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -384,11 +384,13 @@ ecma_concat_ecma_strings (ecma_string_t *string1_p, /**< first ecma-string */
 
   if (str1_size == 0)
   {
-    return ecma_ref_ecma_string (string2_p);
+    ecma_ref_ecma_string (string2_p);
+    return string2_p;
   }
   else if (str2_size == 0)
   {
-    return ecma_ref_ecma_string (string1_p);
+    ecma_ref_ecma_string (string1_p);
+    return string1_p;
   }
 
   const lit_utf8_size_t new_size = str1_size + str2_size;
@@ -444,11 +446,8 @@ ecma_concat_ecma_strings (ecma_string_t *string1_p, /**< first ecma-string */
 
 /**
  * Increase reference counter of ecma-string.
- *
- * @return pointer to same ecma-string descriptor with increased reference counter
- *         or the ecma-string's copy with reference counter set to 1
  */
-ecma_string_t *
+void
 ecma_ref_ecma_string (ecma_string_t *string_p) /**< string descriptor */
 {
   JERRY_ASSERT (string_p != NULL);
@@ -463,8 +462,6 @@ ecma_ref_ecma_string (ecma_string_t *string_p) /**< string descriptor */
   {
     jerry_fatal (ERR_REF_COUNT_LIMIT);
   }
-
-  return string_p;
 } /* ecma_ref_ecma_string */
 
 /**

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -637,7 +637,8 @@ ecma_copy_value (ecma_value_t value)  /**< value description */
     }
     case ECMA_TYPE_STRING:
     {
-      return ecma_make_string_value (ecma_ref_ecma_string (ecma_get_string_from_value (value)));
+      ecma_ref_ecma_string (ecma_get_string_from_value (value));
+      return value;
     }
     case ECMA_TYPE_OBJECT:
     {

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -637,7 +637,7 @@ ecma_copy_value (ecma_value_t value)  /**< value description */
     }
     case ECMA_TYPE_STRING:
     {
-      return ecma_make_string_value (ecma_copy_or_ref_ecma_string (ecma_get_string_from_value (value)));
+      return ecma_make_string_value (ecma_ref_ecma_string (ecma_get_string_from_value (value)));
     }
     case ECMA_TYPE_OBJECT:
     {

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -584,7 +584,7 @@ ecma_create_named_data_property (ecma_object_t *object_p, /**< object */
 
   uint8_t type_and_flags = ECMA_PROPERTY_TYPE_NAMEDDATA | prop_attributes;
 
-  name_p = ecma_copy_or_ref_ecma_string (name_p);
+  name_p = ecma_ref_ecma_string (name_p);
 
   ecma_property_value_t value;
   value.value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
@@ -610,7 +610,7 @@ ecma_create_named_accessor_property (ecma_object_t *object_p, /**< object */
 
   uint8_t type_and_flags = ECMA_PROPERTY_TYPE_NAMEDACCESSOR | prop_attributes;
 
-  name_p = ecma_copy_or_ref_ecma_string (name_p);
+  name_p = ecma_ref_ecma_string (name_p);
 
   ecma_property_value_t value;
   ECMA_SET_POINTER (value.getter_setter_pair.getter_p, get_p);

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -584,7 +584,7 @@ ecma_create_named_data_property (ecma_object_t *object_p, /**< object */
 
   uint8_t type_and_flags = ECMA_PROPERTY_TYPE_NAMEDDATA | prop_attributes;
 
-  name_p = ecma_ref_ecma_string (name_p);
+  ecma_ref_ecma_string (name_p);
 
   ecma_property_value_t value;
   value.value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
@@ -610,7 +610,7 @@ ecma_create_named_accessor_property (ecma_object_t *object_p, /**< object */
 
   uint8_t type_and_flags = ECMA_PROPERTY_TYPE_NAMEDACCESSOR | prop_attributes;
 
-  name_p = ecma_ref_ecma_string (name_p);
+  ecma_ref_ecma_string (name_p);
 
   ecma_property_value_t value;
   ECMA_SET_POINTER (value.getter_setter_pair.getter_p, get_p);

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -169,7 +169,7 @@ extern ecma_string_t *ecma_new_ecma_string_from_lit_cp (lit_cpointer_t);
 extern ecma_string_t *ecma_new_ecma_string_from_magic_string_id (lit_magic_string_id_t);
 extern ecma_string_t *ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t);
 extern ecma_string_t *ecma_concat_ecma_strings (ecma_string_t *, ecma_string_t *);
-extern ecma_string_t *ecma_ref_ecma_string (ecma_string_t *);
+extern void ecma_ref_ecma_string (ecma_string_t *);
 extern void ecma_deref_ecma_string (ecma_string_t *);
 extern ecma_number_t ecma_string_to_number (const ecma_string_t *);
 extern bool ecma_string_get_array_index (const ecma_string_t *, uint32_t *);

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -169,7 +169,7 @@ extern ecma_string_t *ecma_new_ecma_string_from_lit_cp (lit_cpointer_t);
 extern ecma_string_t *ecma_new_ecma_string_from_magic_string_id (lit_magic_string_id_t);
 extern ecma_string_t *ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t);
 extern ecma_string_t *ecma_concat_ecma_strings (ecma_string_t *, ecma_string_t *);
-extern ecma_string_t *ecma_copy_or_ref_ecma_string (ecma_string_t *);
+extern ecma_string_t *ecma_ref_ecma_string (ecma_string_t *);
 extern void ecma_deref_ecma_string (ecma_string_t *);
 extern ecma_number_t ecma_string_to_number (const ecma_string_t *);
 extern bool ecma_string_get_array_index (const ecma_string_t *, uint32_t *);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -175,7 +175,8 @@ ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_ar
                     ecma_builtin_helper_get_to_locale_string_at_index (obj_p, 0),
                     ret_value);
 
-    ecma_string_t *return_string_p = ecma_ref_ecma_string (ecma_get_string_from_value (first_value));
+    ecma_string_t *return_string_p = ecma_get_string_from_value (first_value);
+    ecma_ref_ecma_string (return_string_p);
 
     /* 9-10. */
     for (uint32_t k = 1; ecma_is_value_empty (ret_value) && (k < length); k++)
@@ -402,7 +403,8 @@ ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argume
                     ecma_op_array_get_to_string_at_index (obj_p, 0),
                     ret_value);
 
-    ecma_string_t *return_string_p = ecma_ref_ecma_string (ecma_get_string_from_value (first_value));
+    ecma_string_t *return_string_p = ecma_get_string_from_value (first_value);
+    ecma_ref_ecma_string (return_string_p);
 
     /* 9-10. */
     for (uint32_t k = 1; ecma_is_value_empty (ret_value) && (k < length); k++)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -175,7 +175,7 @@ ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_ar
                     ecma_builtin_helper_get_to_locale_string_at_index (obj_p, 0),
                     ret_value);
 
-    ecma_string_t *return_string_p = ecma_copy_or_ref_ecma_string (ecma_get_string_from_value (first_value));
+    ecma_string_t *return_string_p = ecma_ref_ecma_string (ecma_get_string_from_value (first_value));
 
     /* 9-10. */
     for (uint32_t k = 1; ecma_is_value_empty (ret_value) && (k < length); k++)
@@ -402,7 +402,7 @@ ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argume
                     ecma_op_array_get_to_string_at_index (obj_p, 0),
                     ret_value);
 
-    ecma_string_t *return_string_p = ecma_copy_or_ref_ecma_string (ecma_get_string_from_value (first_value));
+    ecma_string_t *return_string_p = ecma_ref_ecma_string (ecma_get_string_from_value (first_value));
 
     /* 9-10. */
     for (uint32_t k = 1; ecma_is_value_empty (ret_value) && (k < length); k++)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
@@ -125,11 +125,13 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
 
         if (ecma_string_get_length (name_string_p) == 0)
         {
-          ret_str_p = ecma_ref_ecma_string (msg_string_p);
+          ret_str_p = msg_string_p;
+          ecma_ref_ecma_string (ret_str_p);
         }
         else if (ecma_string_get_length (msg_string_p) == 0)
         {
-          ret_str_p = ecma_ref_ecma_string (name_string_p);
+          ret_str_p = name_string_p;
+          ecma_ref_ecma_string (ret_str_p);
         }
         else
         {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
@@ -125,11 +125,11 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
 
         if (ecma_string_get_length (name_string_p) == 0)
         {
-          ret_str_p = ecma_copy_or_ref_ecma_string (msg_string_p);
+          ret_str_p = ecma_ref_ecma_string (msg_string_p);
         }
         else if (ecma_string_get_length (msg_string_p) == 0)
         {
-          ret_str_p = ecma_copy_or_ref_ecma_string (name_string_p);
+          ret_str_p = ecma_ref_ecma_string (name_string_p);
         }
         else
         {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -992,7 +992,7 @@ ecma_builtin_json_stringify (ecma_value_t this_arg, /**< 'this' argument */
 
         if (num_of_chars < 10)
         {
-          context.gap_str_p = ecma_copy_or_ref_ecma_string (space_str_p);
+          context.gap_str_p = ecma_ref_ecma_string (space_str_p);
         }
         else
         {
@@ -1061,7 +1061,7 @@ ecma_builtin_json_quote (ecma_string_t *string_p) /**< string that should be quo
 {
   /* 1. */
   ecma_string_t *quote_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_DOUBLE_QUOTE_CHAR);
-  ecma_string_t *product_str_p = ecma_copy_or_ref_ecma_string (quote_str_p);
+  ecma_string_t *product_str_p = ecma_ref_ecma_string (quote_str_p);
   ecma_string_t *tmp_str_p;
 
   ECMA_STRING_TO_UTF8_STRING (string_p, string_buff, string_buff_size);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -992,7 +992,8 @@ ecma_builtin_json_stringify (ecma_value_t this_arg, /**< 'this' argument */
 
         if (num_of_chars < 10)
         {
-          context.gap_str_p = ecma_ref_ecma_string (space_str_p);
+          ecma_ref_ecma_string (space_str_p);
+          context.gap_str_p = space_str_p;
         }
         else
         {
@@ -1061,7 +1062,8 @@ ecma_builtin_json_quote (ecma_string_t *string_p) /**< string that should be quo
 {
   /* 1. */
   ecma_string_t *quote_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_DOUBLE_QUOTE_CHAR);
-  ecma_string_t *product_str_p = ecma_ref_ecma_string (quote_str_p);
+  ecma_ref_ecma_string (quote_str_p);
+  ecma_string_t *product_str_p = quote_str_p;
   ecma_string_t *tmp_str_p;
 
   ECMA_STRING_TO_UTF8_STRING (string_p, string_buff, string_buff_size);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -168,7 +168,8 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
         }
         else
         {
-          pattern_string_p = ecma_ref_ecma_string (ecma_get_string_from_value (regexp_str_value));
+          pattern_string_p = ecma_get_string_from_value (regexp_str_value);
+          ecma_ref_ecma_string (pattern_string_p);
         }
 
         ECMA_FINALIZE (regexp_str_value);
@@ -380,8 +381,7 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
 
     ecma_string_t *src_sep_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_SLASH_CHAR);
     ecma_string_t *source_str_p = ecma_get_string_from_value (ecma_get_named_data_property_value (source_prop_p));
-    ecma_string_t *output_str_p = ecma_concat_ecma_strings (src_sep_str_p, ecma_ref_ecma_string (source_str_p));
-    ecma_deref_ecma_string (source_str_p);
+    ecma_string_t *output_str_p = ecma_concat_ecma_strings (src_sep_str_p, source_str_p);
 
     ecma_string_t *concat_p = ecma_concat_ecma_strings (output_str_p, src_sep_str_p);
     ecma_deref_ecma_string (src_sep_str_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -168,7 +168,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
         }
         else
         {
-          pattern_string_p = ecma_copy_or_ref_ecma_string (ecma_get_string_from_value (regexp_str_value));
+          pattern_string_p = ecma_ref_ecma_string (ecma_get_string_from_value (regexp_str_value));
         }
 
         ECMA_FINALIZE (regexp_str_value);
@@ -380,7 +380,7 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
 
     ecma_string_t *src_sep_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_SLASH_CHAR);
     ecma_string_t *source_str_p = ecma_get_string_from_value (ecma_get_named_data_property_value (source_prop_p));
-    ecma_string_t *output_str_p = ecma_concat_ecma_strings (src_sep_str_p, ecma_copy_or_ref_ecma_string (source_str_p));
+    ecma_string_t *output_str_p = ecma_concat_ecma_strings (src_sep_str_p, ecma_ref_ecma_string (source_str_p));
     ecma_deref_ecma_string (source_str_p);
 
     ecma_string_t *concat_p = ecma_concat_ecma_strings (output_str_p, src_sep_str_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
@@ -109,7 +109,7 @@ ecma_builtin_regexp_dispatch_construct (const ecma_value_t *arguments_list_p, /*
       }
       else
       {
-        pattern_string_p = ecma_copy_or_ref_ecma_string (ecma_get_string_from_value (regexp_str_value));
+        pattern_string_p = ecma_ref_ecma_string (ecma_get_string_from_value (regexp_str_value));
       }
 
       ECMA_FINALIZE (regexp_str_value);
@@ -125,7 +125,7 @@ ecma_builtin_regexp_dispatch_construct (const ecma_value_t *arguments_list_p, /*
                       ecma_op_to_string (flags_value),
                       ret_value);
 
-      flags_string_p = ecma_copy_or_ref_ecma_string (ecma_get_string_from_value (flags_str_value));
+      flags_string_p = ecma_ref_ecma_string (ecma_get_string_from_value (flags_str_value));
       ECMA_FINALIZE (flags_str_value);
     }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
@@ -109,7 +109,8 @@ ecma_builtin_regexp_dispatch_construct (const ecma_value_t *arguments_list_p, /*
       }
       else
       {
-        pattern_string_p = ecma_ref_ecma_string (ecma_get_string_from_value (regexp_str_value));
+        pattern_string_p = ecma_get_string_from_value (regexp_str_value);
+        ecma_ref_ecma_string (pattern_string_p);
       }
 
       ECMA_FINALIZE (regexp_str_value);
@@ -125,7 +126,9 @@ ecma_builtin_regexp_dispatch_construct (const ecma_value_t *arguments_list_p, /*
                       ecma_op_to_string (flags_value),
                       ret_value);
 
-      flags_string_p = ecma_ref_ecma_string (ecma_get_string_from_value (flags_str_value));
+      flags_string_p = ecma_get_string_from_value (flags_str_value);
+      ecma_ref_ecma_string (flags_string_p);
+
       ECMA_FINALIZE (flags_str_value);
     }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -79,12 +79,7 @@ ecma_builtin_string_prototype_object_to_string (ecma_value_t this_arg) /**< this
       ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                        ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
 
-      ecma_string_t *prim_value_str_p;
-      prim_value_str_p = ecma_get_string_from_value (ecma_get_internal_property_value (prim_value_prop_p));
-
-      prim_value_str_p = ecma_ref_ecma_string (prim_value_str_p);
-
-      return ecma_make_string_value (prim_value_str_p);
+      return ecma_copy_value (ecma_get_internal_property_value (prim_value_prop_p));
     }
   }
 
@@ -250,10 +245,11 @@ ecma_builtin_string_prototype_object_concat (ecma_value_t this_arg, /**< this ar
                   ret_value);
 
   /* 3 */
-  // No copy performed
+  /* No copy performed */
 
   /* 4 */
-  ecma_string_t *string_to_return = ecma_ref_ecma_string (ecma_get_string_from_value (to_string_val));
+  ecma_string_t *string_to_return = ecma_get_string_from_value (to_string_val);
+  ecma_ref_ecma_string (string_to_return);
 
   /* 5 */
   for (uint32_t arg_index = 0;
@@ -659,7 +655,8 @@ ecma_builtin_string_prototype_object_replace_append_substr (ecma_string_t *base_
   }
   else
   {
-    ret_string_p = ecma_ref_ecma_string (base_string_p);
+    ret_string_p = base_string_p;
+    ecma_ref_ecma_string (ret_string_p);
   }
 
   return ret_string_p;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -82,7 +82,7 @@ ecma_builtin_string_prototype_object_to_string (ecma_value_t this_arg) /**< this
       ecma_string_t *prim_value_str_p;
       prim_value_str_p = ecma_get_string_from_value (ecma_get_internal_property_value (prim_value_prop_p));
 
-      prim_value_str_p = ecma_copy_or_ref_ecma_string (prim_value_str_p);
+      prim_value_str_p = ecma_ref_ecma_string (prim_value_str_p);
 
       return ecma_make_string_value (prim_value_str_p);
     }
@@ -253,7 +253,7 @@ ecma_builtin_string_prototype_object_concat (ecma_value_t this_arg, /**< this ar
   // No copy performed
 
   /* 4 */
-  ecma_string_t *string_to_return = ecma_copy_or_ref_ecma_string (ecma_get_string_from_value (to_string_val));
+  ecma_string_t *string_to_return = ecma_ref_ecma_string (ecma_get_string_from_value (to_string_val));
 
   /* 5 */
   for (uint32_t arg_index = 0;
@@ -659,7 +659,7 @@ ecma_builtin_string_prototype_object_replace_append_substr (ecma_string_t *base_
   }
   else
   {
-    ret_string_p = ecma_copy_or_ref_ecma_string (base_string_p);
+    ret_string_p = ecma_ref_ecma_string (base_string_p);
   }
 
   return ret_string_p;

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -336,7 +336,7 @@ ecma_op_to_string (ecma_value_t value) /**< ecma value */
     if (ecma_is_value_string (value))
     {
       res_p = ecma_get_string_from_value (value);
-      res_p = ecma_ref_ecma_string (res_p);
+      ecma_ref_ecma_string (res_p);
     }
     else if (ecma_is_value_integer_number (value))
     {

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -336,7 +336,7 @@ ecma_op_to_string (ecma_value_t value) /**< ecma value */
     if (ecma_is_value_string (value))
     {
       res_p = ecma_get_string_from_value (value);
-      res_p = ecma_copy_or_ref_ecma_string (res_p);
+      res_p = ecma_ref_ecma_string (res_p);
     }
     else if (ecma_is_value_integer_number (value))
     {

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -123,7 +123,7 @@ ecma_new_standard_error_with_message (ecma_standard_error_t error_type, /**< nat
                                                              ECMA_PROPERTY_CONFIGURABLE_WRITABLE);
 
   ecma_set_named_data_property_value (prop_p,
-                                      ecma_make_string_value (ecma_copy_or_ref_ecma_string (message_string_p)));
+                                      ecma_make_string_value (ecma_ref_ecma_string (message_string_p)));
   ecma_deref_ecma_string (message_magic_string_p);
 
   return new_error_obj_p;

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -122,8 +122,9 @@ ecma_new_standard_error_with_message (ecma_standard_error_t error_type, /**< nat
                                                              message_magic_string_p,
                                                              ECMA_PROPERTY_CONFIGURABLE_WRITABLE);
 
+  ecma_ref_ecma_string (message_string_p);
   ecma_set_named_data_property_value (prop_p,
-                                      ecma_make_string_value (ecma_ref_ecma_string (message_string_p)));
+                                      ecma_make_string_value (message_string_p));
   ecma_deref_ecma_string (message_magic_string_p);
 
   return new_error_obj_p;

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -751,7 +751,7 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
 
         JERRY_ASSERT (name_pos > 0
                       && name_pos <= array_index_named_properties_count + string_named_properties_count);
-        names_p[--name_pos] = ecma_copy_or_ref_ecma_string (name_p);
+        names_p[--name_pos] = ecma_ref_ecma_string (name_p);
       }
     }
 

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -751,7 +751,8 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
 
         JERRY_ASSERT (name_pos > 0
                       && name_pos <= array_index_named_properties_count + string_named_properties_count);
-        names_p[--name_pos] = ecma_ref_ecma_string (name_p);
+        ecma_ref_ecma_string (name_p);
+        names_p[--name_pos] = name_p;
       }
     }
 

--- a/jerry-core/ecma/operations/ecma-reference.c
+++ b/jerry-core/ecma/operations/ecma-reference.c
@@ -96,7 +96,7 @@ ecma_make_reference (ecma_value_t base, /**< base value */
                      ecma_string_t *name_p, /**< referenced name */
                      bool is_strict) /**< strict reference flag */
 {
-  name_p = ecma_ref_ecma_string (name_p);
+  ecma_ref_ecma_string (name_p);
 
   ecma_reference_t ref;
   ref.base = ecma_copy_value (base);

--- a/jerry-core/ecma/operations/ecma-reference.c
+++ b/jerry-core/ecma/operations/ecma-reference.c
@@ -96,7 +96,7 @@ ecma_make_reference (ecma_value_t base, /**< base value */
                      ecma_string_t *name_p, /**< referenced name */
                      bool is_strict) /**< strict reference flag */
 {
-  name_p = ecma_copy_or_ref_ecma_string (name_p);
+  name_p = ecma_ref_ecma_string (name_p);
 
   ecma_reference_t ref;
   ref.base = ecma_copy_value (base);

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -142,7 +142,7 @@ ecma_op_string_object_get_own_property (ecma_object_t *obj_p, /**< a String obje
   {
     uint32_index = property_name_p->u.uint32_number;
 
-    new_prop_name_p = ecma_copy_or_ref_ecma_string (property_name_p);
+    new_prop_name_p = ecma_ref_ecma_string (property_name_p);
   }
   else
   {

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -142,7 +142,8 @@ ecma_op_string_object_get_own_property (ecma_object_t *obj_p, /**< a String obje
   {
     uint32_index = property_name_p->u.uint32_number;
 
-    new_prop_name_p = ecma_ref_ecma_string (property_name_p);
+    new_prop_name_p = property_name_p;
+    ecma_ref_ecma_string (new_prop_name_p);
   }
   else
   {

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -357,7 +357,9 @@ jerry_acquire_string (jerry_string_t *string_p) /**< pointer passed to function 
 {
   jerry_assert_api_available ();
 
-  return ecma_ref_ecma_string (string_p);
+  ecma_ref_ecma_string (string_p);
+
+  return string_p;
 } /* jerry_acquire_string */
 
 /**

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -357,7 +357,7 @@ jerry_acquire_string (jerry_string_t *string_p) /**< pointer passed to function 
 {
   jerry_assert_api_available ();
 
-  return ecma_copy_or_ref_ecma_string (string_p);
+  return ecma_ref_ecma_string (string_p);
 } /* jerry_acquire_string */
 
 /**

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -576,8 +576,8 @@ re_compile_bytecode (const re_compiled_code_t **out_bytecode_p, /**< [out] point
 
     re_compiled_code.header.refs = 1;
     re_compiled_code.header.status_flags = re_ctx.flags;
-    ECMA_SET_NON_NULL_POINTER (re_compiled_code.pattern_cp,
-                               ecma_ref_ecma_string (pattern_str_p));
+    ecma_ref_ecma_string (pattern_str_p);
+    ECMA_SET_NON_NULL_POINTER (re_compiled_code.pattern_cp, pattern_str_p);
     re_compiled_code.num_of_captures = re_ctx.num_of_captures * 2;
     re_compiled_code.num_of_non_captures = re_ctx.num_of_non_captures;
 

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -577,7 +577,7 @@ re_compile_bytecode (const re_compiled_code_t **out_bytecode_p, /**< [out] point
     re_compiled_code.header.refs = 1;
     re_compiled_code.header.status_flags = re_ctx.flags;
     ECMA_SET_NON_NULL_POINTER (re_compiled_code.pattern_cp,
-                               ecma_copy_or_ref_ecma_string (pattern_str_p));
+                               ecma_ref_ecma_string (pattern_str_p));
     re_compiled_code.num_of_captures = re_ctx.num_of_captures * 2;
     re_compiled_code.num_of_non_captures = re_ctx.num_of_non_captures;
 


### PR DESCRIPTION
Changed 'ecma_copy_or_ref_ecma_string' to 'ecma_ref_ecma_string'. It does
not copy the string if the maximum number of reference counter is reached,
but bails out with an error like the 'ecma_ref_object' function does.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com