### PR TITLE
Make Zephyr target more portable

### DIFF
--- a/targets/arduino_101/Makefile
+++ b/targets/arduino_101/Makefile
@@ -51,6 +51,11 @@ KBUILD_VERBOSE = $(V)
 
 APP = main-zephyr.c
 
+ALL_LIBS += $(USER_LIBS)
+export ALL_LIBS
+LDFLAGS_zephyr += $(USER_LIB_INCLUDE_DIR)
+export LDFLAGS_zephyr
+
 include ${ZEPHYR_BASE}/Makefile.inc 
 
 .PHONY = showconfig

--- a/targets/arduino_101/Makefile.arduino_101
+++ b/targets/arduino_101/Makefile.arduino_101
@@ -61,13 +61,19 @@ EXT_CFLAGS += -ffunction-sections -fno-inline-functions
 
 ifeq ($(BOARD),qemu_x86)
 CONFIG_TOOLCHAIN_VARIANT = x86
+CPU = x86
 EXT_CFLAGS += -march=pentium
+EXT_CFLAGS += -mpreferred-stack-boundary=2 -mno-sse
+else ifeq ($(BOARD),qemu_cortex_m3)
+CONFIG_TOOLCHAIN_VARIANT = arm
+CPU = arm7-m
+EXT_CFLAGS += -march=armv7-m -mthumb -mcpu=cortex-m3 -mabi=aapcs
 else
 CONFIG_TOOLCHAIN_VARIANT = iamcu
+CPU = lakemont
 EXT_CFLAGS += -march=lakemont -mtune=lakemont -miamcu -msoft-float
-endif
-
 EXT_CFLAGS += -mpreferred-stack-boundary=2 -mno-sse
+endif
 
 EXT_CFLAGS += -Wall -Wno-format-zero-length -Wno-pointer-sign
 EXT_CFLAGS += -Werror=format -Werror=implicit-int -Wno-unused-but-set-variable
@@ -89,12 +95,12 @@ EXTERNAL_LIB = $(INTERM)/lib$(TYPE).external$(VARIETY)-entry.a
 ZEPHYR_BIN = $(OUTPUT)/zephyr/zephyr.strip
 
 PREFIX = $(TYPE)$(VARIETY)
-LIBS = $(TYPE).external$(VARIETY)-entry $(PREFIX).jerry-core $(PREFIX).jerry-libm.lib $(TOOLCHAIN_LIBS) c
+LIBS = $(TYPE).external$(VARIETY)-entry $(PREFIX).jerry-core $(PREFIX).jerry-libm.lib
 
 # TODO @sergioamr Change how we link the library to USER_LDFLAGS
 # https://gerrit.zephyrproject.org/r/#/c/2048/
 
-BUILD_CONFIG = O="$(OUTPUT)/zephyr" V=$(V) TOOLCHAIN_LIBS="$(LIBS)" LIB_INCLUDE_DIR="$(LIB_INCLUDE_DIR)"
+BUILD_CONFIG = O="$(OUTPUT)/zephyr" V=$(V) USER_LIBS="$(LIBS)" USER_LIB_INCLUDE_DIR="-L $(CURDIR)/$(OUTPUT)"
 
 .PHONY: all
 all: jerry zephyr
@@ -112,7 +118,7 @@ endif
 	 -DCMAKE_VERBOSE_MAKEFILE=$(V) \
 	 -DEXTERNAL_CMAKE_C_COMPILER=$(CC) \
 	 -DEXTERNAL_CMAKE_C_COMPILER_ID=GNU \
-	 -DEXTERNAL_CMAKE_SYSTEM_PROCESSOR=x86 \
+	 -DEXTERNAL_CMAKE_SYSTEM_PROCESSOR=$(CPU) \
 	 -DEXTERNAL_MEM_HEAP_SIZE_KB=$(JERRYHEAP) \
 	 -DEXTERNAL_COMPILE_FLAGS="$(EXT_CFLAGS)" \
 	 -DEXTERNAL_CMAKE_SYSTEM_PROCESSOR=lakemont \


### PR DESCRIPTION
This patch updates recently merged Zephyr Arduino 101 target to be more portable to other hardware platforms  supported by Zephyr: https://github.com/Samsung/jerryscript/pull/1108 . With these changes, it's possible to build Zephyr target for ARM architecture, as tested for `qemu_cortex_m3` target. 

Submitted is a sequence of short patches, to make it easier to review what/how/why was changed, I can squash them on a request. The changes themselves follow guidelines of Zephyr developers on how to link with external libraries: https://gerrit.zephyrproject.org/r/#/c/2476/

After this patch is merged, it would be fair to rename `targets/arduino_101` to `targets/zephyr`. But as this is my first patch to the project, I don't want to include too many changes in it, and my plan is to follow up with another PR if/when this one is merged.

Thanks!
