### PR TITLE
Fix Date construct helper

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -619,6 +619,8 @@ ecma_number_negate (ecma_number_t num) /**< ecma-number */
 ecma_number_t
 ecma_number_trunc (ecma_number_t num) /**< ecma-number */
 {
+  JERRY_ASSERT (!ecma_number_is_nan (num));
+
   uint64_t fraction;
   int32_t exponent;
   const int32_t dot_shift = ecma_number_get_fraction_and_exponent (num, &fraction, &exponent);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -136,18 +136,14 @@ ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to t
 
   if (ecma_is_value_empty (ret_value))
   {
-    if (!ecma_number_is_nan (year) && !ecma_number_is_infinity (year))
+    if (!ecma_number_is_nan (year))
     {
       /* 8. */
-      int32_t y = ecma_number_to_int32 (year);
+      ecma_number_t y = ecma_number_trunc (year);
 
       if (y >= 0 && y <= 99)
       {
-        year = (ecma_number_t) (1900 + y);
-      }
-      else
-      {
-        year = (ecma_number_t) y;
+        year = 1900 + y;
       }
     }
 

--- a/tests/jerry/regression-test-issue-1071.js
+++ b/tests/jerry/regression-test-issue-1071.js
@@ -1,0 +1,23 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright 2016 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var d = new Date(864858163349847396, 1, 1, 1, 1, 1, 1, 1)
+assert (d.toGMTString() === "Invalid Date");
+
+d = new Date(864858, 1, 1, 1, 1, 1, 1, 1)
+assert (d.toGMTString() === "Invalid Date");
+
+d = new Date(86485, 1, 1, 1, 1, 1, 1, 1)
+assert (d.toGMTString() !== "Invalid Date");


### PR DESCRIPTION
Correct behaviour of step 8, 15.9.3.1, ECMA-262 v5.1.
 - Change ToInt32(y) to ToInteger(y).
 - If ToInteger(y) is not between 0 and 99 then yr = y

Related issue: #1071

JerryScript-DCO-1.0-Signed-off-by: Hanjoung Lee hanjoung.lee@samsung.com