### PR TITLE
Fix `errol0_dtoa` for DBL_MAX

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-errol.c
+++ b/jerry-core/ecma/base/ecma-helpers-errol.c
@@ -164,7 +164,13 @@ ecma_errol0_dtoa (ecma_number_t val, /**< ecma number */
   ecma_high_prec_t high_bound, low_bound;
 
   high_bound.value = mid.value;
-  high_bound.offset = mid.offset + (ECMA_NEXT_FLOAT (val) - val) * power_of_10 / (2.0 + ERROL0_EPSILON);
+  high_bound.offset = mid.offset;
+
+  if (ECMA_NEXT_FLOAT (val) != INFINITY)
+  {
+    high_bound.offset += (ECMA_NEXT_FLOAT (val) - val) * power_of_10 / (2.0 + ERROL0_EPSILON);
+  }
+
   low_bound.value = mid.value;
   low_bound.offset = mid.offset + (ECMA_PREV_FLOAT (val) - val) * power_of_10 / (2.0 + ERROL0_EPSILON);
 

--- a/tests/jerry/regression-test-issue-1054.js
+++ b/tests/jerry/regression-test-issue-1054.js
@@ -1,0 +1,20 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright 2016 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  new String(Number.MAX_VALUE)
+} catch(e) {
+  assert(false);
+}


### PR DESCRIPTION
When `val` is DBL_MAX, we get +inf from `ECMA_NEXT_FLOAT (val)`.
It is necessary to handle this case specially.

Related issue: #1054

JerryScript-DCO-1.0-Signed-off-by: Hanjoung Lee hanjoung.lee@samsung.com