### PR TITLE
Remove LIST_LAZY_PROPERTY_NAMES_ROUTINE_NAME macro function.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
@@ -30,8 +30,6 @@
 
 #define PROPERTY_DESCRIPTOR_LIST_NAME \
   PASTE (PASTE (ecma_builtin_, BUILTIN_UNDERSCORED_ID), _property_descriptor_list)
-#define LIST_LAZY_PROPERTY_NAMES_ROUTINE_NAME \
-  PASTE (PASTE (ecma_builtin_, BUILTIN_UNDERSCORED_ID), _list_lazy_property_names)
 #define DISPATCH_ROUTINE_ROUTINE_NAME \
   PASTE (PASTE (ecma_builtin_, BUILTIN_UNDERSCORED_ID), _dispatch_routine)
 
@@ -51,19 +49,6 @@
 #undef ROUTINE_ARG_LIST_1
 #undef ROUTINE_ARG_LIST_0
 #undef ROUTINE_ARG
-
-#define ECMA_BUILTIN_PROPERTY_NAMES \
-  PASTE (PASTE (ecma_builtin_property_names, _), BUILTIN_UNDERSCORED_ID)
-
-static const lit_magic_string_id_t ECMA_BUILTIN_PROPERTY_NAMES[] =
-{
-#define SIMPLE_VALUE(name, simple_value, prop_attributes) name,
-#define NUMBER_VALUE(name, number_value, prop_attributes) name,
-#define STRING_VALUE(name, magic_string_id, prop_attributes) name,
-#define OBJECT_VALUE(name, obj_builtin_id, prop_attributes) name,
-#define ROUTINE(name, c_function_name, args_number, length_prop_value) name,
-#include BUILTIN_INC_HEADER_NAME
-};
 
 #define ECMA_BUILTIN_PROPERTY_NAME_INDEX(name) \
   PASTE (PASTE (PASTE (PASTE (ecma_builtin_property_names, _), BUILTIN_UNDERSCORED_ID), _), name)
@@ -133,114 +118,6 @@ const ecma_builtin_property_descriptor_t PROPERTY_DESCRIPTOR_LIST_NAME[] =
 };
 
 /**
- * List names of the built-in object's lazy instantiated properties
- *
- * See also:
- *          TRY_TO_INSTANTIATE_PROPERTY_ROUTINE_NAME
- *
- * @return string values collection
- */
-void
-LIST_LAZY_PROPERTY_NAMES_ROUTINE_NAME (ecma_object_t *object_p, /**< a built-in object */
-                                       bool separate_enumerable, /**< true -  list enumerable properties
-                                                                              into main collection,
-                                                                              and non-enumerable to
-                                                                              collection of 'skipped
-                                                                              non-enumerable'
-                                                                              properties,
-                                                                      false - list all properties into
-                                                                              main collection. */
-                                       ecma_collection_header_t *main_collection_p, /**< 'main' collection */
-                                       ecma_collection_header_t *non_enum_collection_p) /**< skipped 'non-enumerable'
-                                                                                             collection */
-{
-  ecma_collection_header_t *for_enumerable_p = main_collection_p;
-  (void) for_enumerable_p;
-
-  ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? non_enum_collection_p : main_collection_p;
-
-#define OBJECT_ID(builtin_id) const ecma_builtin_id_t builtin_object_id = builtin_id;
-#include BUILTIN_INC_HEADER_NAME
-
-  JERRY_ASSERT (ecma_builtin_is (object_p, builtin_object_id));
-
-  const ecma_length_t properties_number = (ecma_length_t) (sizeof (ECMA_BUILTIN_PROPERTY_NAMES) /
-                                                           sizeof (ECMA_BUILTIN_PROPERTY_NAMES[0]));
-
-  for (ecma_length_t index = 0;
-       index < properties_number;
-       index++)
-  {
-    lit_magic_string_id_t name = ECMA_BUILTIN_PROPERTY_NAMES[index];
-
-    uint32_t bit;
-    ecma_internal_property_id_t mask_prop_id;
-
-    if (index >= 32)
-    {
-      mask_prop_id = ECMA_INTERNAL_PROPERTY_NON_INSTANTIATED_BUILT_IN_MASK_32_63;
-      bit = (uint32_t) 1u << (index - 32);
-    }
-    else
-    {
-      mask_prop_id = ECMA_INTERNAL_PROPERTY_NON_INSTANTIATED_BUILT_IN_MASK_0_31;
-      bit = (uint32_t) 1u << index;
-    }
-
-    ecma_property_t *mask_prop_p = ecma_find_internal_property (object_p, mask_prop_id);
-    bool is_instantiated = false;
-    if (mask_prop_p == NULL)
-    {
-      is_instantiated = true;
-    }
-    else
-    {
-      uint32_t bit_mask = ecma_get_internal_property_value (mask_prop_p);
-
-      if (bit_mask & bit)
-      {
-        is_instantiated = true;
-      }
-      else
-      {
-        is_instantiated = false;
-      }
-    }
-
-    bool is_existing;
-
-    ecma_string_t *name_p = ecma_get_magic_string (name);
-
-    if (!is_instantiated)
-    {
-      /* will be instantiated upon first request */
-      is_existing = true;
-    }
-    else
-    {
-      if (ecma_op_object_get_own_property (object_p, name_p) == NULL)
-      {
-        is_existing = false;
-      }
-      else
-      {
-        is_existing = true;
-      }
-    }
-
-    if (is_existing)
-    {
-      ecma_append_to_values_collection (for_non_enumerable_p,
-                                        ecma_make_string_value (name_p),
-                                        true);
-    }
-
-    ecma_deref_ecma_string (name_p);
-  }
-} /* LIST_LAZY_PROPERTY_NAMES_ROUTINE_NAME */
-
-
-/**
  * Dispatcher of the built-in's routines
  *
  * @return ecma value
@@ -294,9 +171,7 @@ DISPATCH_ROUTINE_ROUTINE_NAME (uint16_t builtin_routine_id, /**< built-in wide r
 #undef PASTE_
 #undef PASTE
 #undef PROPERTY_DESCRIPTOR_LIST_NAME
-#undef LIST_LAZY_PROPERTY_NAMES_ROUTINE_NAME
 #undef DISPATCH_ROUTINE_ROUTINE_NAME
 #undef BUILTIN_UNDERSCORED_ID
 #undef BUILTIN_INC_HEADER_NAME
-#undef ECMA_BUILTIN_PROPERTY_NAMES
 #undef ECMA_BUILTIN_PROPERTY_NAME_INDEX

--- a/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
@@ -123,12 +123,7 @@ extern ecma_value_t \
 ecma_builtin_ ## lowercase_name ## _dispatch_routine (uint16_t builtin_routine_id, \
                                                       ecma_value_t this_arg_value, \
                                                       const ecma_value_t [], \
-                                                      ecma_length_t); \
-extern void \
-ecma_builtin_ ## lowercase_name ## _list_lazy_property_names (ecma_object_t *, \
-                                                              bool, \
-                                                              ecma_collection_header_t *, \
-                                                              ecma_collection_header_t *);
+                                                      ecma_length_t);
 #include "ecma-builtins.inc.h"
 
 #endif /* !ECMA_BUILTINS_INTERNAL_H */


### PR DESCRIPTION
8K binary save (164K -> 156K), a small slowdown (1%). I think 8K worth it.