### PR TITLE
Remove GCC 4.7 build requirement.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,17 +26,6 @@ project (Jerry C ASM)
   endif()
  endif()
 
- if(CMAKE_COMPILER_IS_GNUCC)
-  # Require gcc of version >= 4.7.0
-   execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
-                   OUTPUT_VARIABLE GNU_CC_VERSION
-                   OUTPUT_STRIP_TRAILING_WHITESPACE)
-   if(${GNU_CC_VERSION} VERSION_LESS 4.7.0)
-    message(FATAL_ERROR "gcc compiler version 4.7.0 or higher required")
-   endif()
- endif()
-
-
 # Imported targets prefix
  set(PREFIX_IMPORTED_LIB imported_)
 


### PR DESCRIPTION
The GCC 4.7 check is is a leftover from the times when JerryScript was a C++11 codebase, it was there to ensure that JerryScript is compiled with a GCC version which has sufficient support for C++11.

Today JerryScript is a pure C99 codebase (enforced by building all the sources with -std=c99) and this check is no longer necessary. JerryScript should now build just fine even with rather old versions of GCC.

JerryScript-DCO-1.0-Signed-off-by: Tilmann Scheller t.scheller@samsung.com