### PR TITLE
Build fix for ALL_IN_ONE and COMPILER_DEFAULT_LIBC

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -150,6 +150,9 @@ project (JerryCore C ASM)
  # Jerry port
  if(NOT ("${PORT_DIR}" STREQUAL ""))
   file(GLOB SOURCE_PORT_FILES ${PORT_DIR}/*.c)
+  if (NOT USE_JERRY_LIBC)
+   set (DEFINES_JERRY ${DEFINES_JERRY} _BSD_SOURCE)
+  endif()
  endif()
 
  # All-in-one build

--- a/targets/default/jerry-port-default-date.c
+++ b/targets/default/jerry-port-default-date.c
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#define _BSD_SOURCE
 #include <sys/time.h>
 
 #include "jerry-port.h"


### PR DESCRIPTION
The build fails with enabled ALL_ON_ONE and enabled COMPILER_DEFAULT_LIBC options,
because the _BSD_SOURCE doesn't defined before including sys/time.h.

In case of glibc, the 'timezone' is not part of C99 but part of POSIX, so we need
to define the _BSD_SOURCE feature test macro before including sys/time.h to get
the prototype for this struct.

JerryScript-DCO-1.0-Signed-off-by: Robert Sipka rsipka.uszeged@partner.samsung.com