### PR TITLE
Enforce pure C99 build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,7 @@ project (Jerry C ASM)
     endforeach()
   endmacro()
 
-  add_jerry_compile_warnings(all extra format-nonliteral init-self conversion sign-conversion format-security missing-declarations pedantic)
+  add_jerry_compile_warnings(all extra format-nonliteral init-self conversion sign-conversion format-security missing-declarations)
   add_jerry_compile_flags(-Wno-stack-protector -Wno-attributes)
   if(CMAKE_COMPILER_IS_GNUCC)
     if(${USE_JERRY_LIBC})
@@ -286,7 +286,7 @@ project (Jerry C ASM)
   endif()
 
  # C
-  set(C_FLAGS_JERRY "-std=c99")
+  set(C_FLAGS_JERRY "-std=c99 -pedantic")
 
  # Platform-specific
   # MCU


### PR DESCRIPTION
Building with -std=c99 is not sufficient to enforce a pure C99 build as it still allows GNU extensions which don't conflict with C99 to be used. Add -pedantic to the build options to ensure that the codebase is only using C99 constructs and the build will fail whenever any compiler extension is used. This helps to ensure that JerryScript remains portable and can be built with any C99-compatible C compiler.

Removing -Wpedantic, as any warnings of that type will already trigger an error when building with -pedantic.

JerryScript-DCO-1.0-Signed-off-by: Tilmann Scheller t.scheller@samsung.com