### PR TITLE
Remove ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION to free an object type.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -430,13 +430,11 @@ typedef enum
   ECMA_OBJECT_TYPE_GENERAL = 0, /**< all objects that are not String (15.5), Function (15.3),
                                  Arguments (10.6), Array (15.4) specification-defined objects */
   ECMA_OBJECT_TYPE_FUNCTION = 1, /**< Function objects (15.3), created through 13.2 routine */
-  ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION = 2, /** One of built-in functions described in section 15
-                                           *  of ECMA-262 v5 specification */
+  ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION = 2, /**< External (host) function object */
   ECMA_OBJECT_TYPE_ARRAY = 3, /**< Array object (15.4) */
   ECMA_OBJECT_TYPE_STRING = 4, /**< String objects (15.5) */
-  ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION = 5, /**< External (host) function object */
-  ECMA_OBJECT_TYPE_BOUND_FUNCTION = 6, /**< Function objects (15.3), created through 15.3.4.5 routine */
-  ECMA_OBJECT_TYPE_ARGUMENTS = 7, /**< Arguments object (10.6) */
+  ECMA_OBJECT_TYPE_BOUND_FUNCTION = 5, /**< Function objects (15.3), created through 15.3.4.5 routine */
+  ECMA_OBJECT_TYPE_ARGUMENTS = 6, /**< Arguments object (10.6) */
 
   ECMA_OBJECT_TYPE__MAX = ECMA_OBJECT_TYPE_ARGUMENTS /**< maximum value */
 } ecma_object_type_t;
@@ -448,7 +446,7 @@ typedef enum
 {
   /* ECMA_OBJECT_TYPE_GENERAL (0) with built-in flag. */
   /* ECMA_OBJECT_TYPE_FUNCTION (1) with built-in flag. */
-  /* ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION (2) with built-in flag. */
+  /* ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION (2) with built-in flag. */
   /* ECMA_OBJECT_TYPE_ARRAY (3) with built-in flag. */
   /* ECMA_OBJECT_TYPE_STRING (4) with built-in flag. */
   ECMA_LEXICAL_ENVIRONMENT_DECLARATIVE = 5, /**< declarative lexical environment */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
@@ -50,21 +50,11 @@
 #undef ROUTINE_ARG_LIST_0
 #undef ROUTINE_ARG
 
-#define ECMA_BUILTIN_PROPERTY_NAME_INDEX(name) \
-  PASTE (PASTE (PASTE (PASTE (ecma_builtin_property_names, _), BUILTIN_UNDERSCORED_ID), _), name)
-
 enum
 {
-#define SIMPLE_VALUE(name, simple_value, prop_attributes) \
-  ECMA_BUILTIN_PROPERTY_NAME_INDEX(name),
-#define NUMBER_VALUE(name, number_value, prop_attributes) \
-  ECMA_BUILTIN_PROPERTY_NAME_INDEX(name),
-#define STRING_VALUE(name, magic_string_id, prop_attributes) \
-  ECMA_BUILTIN_PROPERTY_NAME_INDEX(name),
-#define OBJECT_VALUE(name, obj_builtin_id, prop_attributes) \
-  ECMA_BUILTIN_PROPERTY_NAME_INDEX(name),
+  PASTE (ECMA_ROUTINE_START_, BUILTIN_UNDERSCORED_ID) = ECMA_BUILTIN_ID__COUNT - 1,
 #define ROUTINE(name, c_function_name, args_number, length_prop_value) \
-  ECMA_BUILTIN_PROPERTY_NAME_INDEX(name),
+  ECMA_ROUTINE_ ## name ## c_function_name,
 #include BUILTIN_INC_HEADER_NAME
 };
 
@@ -78,7 +68,7 @@ const ecma_builtin_property_descriptor_t PROPERTY_DESCRIPTOR_LIST_NAME[] =
     name, \
     ECMA_BUILTIN_PROPERTY_ROUTINE, \
     ECMA_PROPERTY_CONFIGURABLE_WRITABLE, \
-    length_prop_value \
+    ECMA_ROUTINE_VALUE (ECMA_ROUTINE_ ## name ## c_function_name, length_prop_value) \
   },
 #define OBJECT_VALUE(name, obj_builtin_id, prop_attributes) \
   { \
@@ -148,7 +138,7 @@ DISPATCH_ROUTINE_ROUTINE_NAME (uint16_t builtin_routine_id, /**< built-in wide r
 #define ROUTINE_ARG_LIST_3 ROUTINE_ARG_LIST_2, ROUTINE_ARG(3)
 #define ROUTINE_ARG_LIST_NON_FIXED , arguments_list, arguments_number
 #define ROUTINE(name, c_function_name, args_number, length_prop_value) \
-       case name: \
+       case ECMA_ROUTINE_ ## name ## c_function_name: \
        { \
          return c_function_name (this_arg_value ROUTINE_ARG_LIST_ ## args_number); \
        }

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -34,6 +34,21 @@ typedef enum
   ECMA_BUILTIN_ID__COUNT /**< number of built-in objects */
 } ecma_builtin_id_t;
 
+/**
+ * Construct a routine value
+ */
+#define ECMA_ROUTINE_VALUE(id, length) (((id) << 4) | length)
+
+/**
+ * Get routine length
+ */
+#define ECMA_GET_ROUTINE_LENGTH(value) ((uint8_t) ((value) & 0xf))
+
+/**
+ * Get routine ID
+ */
+#define ECMA_GET_ROUTINE_ID(value) ((uint16_t) ((value) >> 4))
+
 /* ecma-builtins.c */
 extern void ecma_init_builtins (void);
 extern void ecma_finalize_builtins (void);
@@ -55,4 +70,7 @@ extern bool
 ecma_builtin_is (ecma_object_t *, ecma_builtin_id_t);
 extern ecma_object_t *
 ecma_builtin_get (ecma_builtin_id_t);
+extern bool
+ecma_builtin_function_is_routine (ecma_object_t *);
+
 #endif /* !ECMA_BUILTINS_H */

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -39,13 +39,12 @@
 #ifndef JERRY_NDEBUG
 #define JERRY_ASSERT_OBJECT_TYPE_IS_VALID(type) \
   JERRY_ASSERT (type == ECMA_OBJECT_TYPE_GENERAL \
-                || type == ECMA_OBJECT_TYPE_ARRAY \
                 || type == ECMA_OBJECT_TYPE_FUNCTION \
-                || type == ECMA_OBJECT_TYPE_BOUND_FUNCTION \
-                || type == ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION \
+                || type == ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION \
+                || type == ECMA_OBJECT_TYPE_ARRAY \
                 || type == ECMA_OBJECT_TYPE_STRING \
-                || type == ECMA_OBJECT_TYPE_ARGUMENTS \
-                || type == ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION);
+                || type == ECMA_OBJECT_TYPE_BOUND_FUNCTION \
+                || type == ECMA_OBJECT_TYPE_ARGUMENTS);
 #else /* JERRY_NDEBUG */
 #define JERRY_ASSERT_OBJECT_TYPE_IS_VALID(type)
 #endif /* !JERRY_NDEBUG */
@@ -71,12 +70,11 @@ ecma_op_object_get (ecma_object_t *obj_p, /**< the object */
   switch (type)
   {
     case ECMA_OBJECT_TYPE_GENERAL:
-    case ECMA_OBJECT_TYPE_ARRAY:
     case ECMA_OBJECT_TYPE_FUNCTION:
-    case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     case ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION:
-    case ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION:
+    case ECMA_OBJECT_TYPE_ARRAY:
     case ECMA_OBJECT_TYPE_STRING:
+    case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     {
       return ecma_op_general_object_get (obj_p, property_name_p);
     }
@@ -112,10 +110,9 @@ ecma_op_object_get_own_property_longpath (ecma_object_t *obj_p, /**< the object 
   switch (type)
   {
     case ECMA_OBJECT_TYPE_GENERAL:
+    case ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION:
     case ECMA_OBJECT_TYPE_ARRAY:
     case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
-    case ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION:
-    case ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION:
     {
       prop_p = ecma_op_general_object_get_own_property (obj_p, property_name_p);
 
@@ -142,6 +139,7 @@ ecma_op_object_get_own_property_longpath (ecma_object_t *obj_p, /**< the object 
 
       break;
     }
+
     default:
     {
       JERRY_UNREACHABLE ();
@@ -213,13 +211,12 @@ ecma_op_object_get_property (ecma_object_t *obj_p, /**< the object */
    * static const get_property_ptr_t get_property [ECMA_OBJECT_TYPE__COUNT] =
    * {
    *   [ECMA_OBJECT_TYPE_GENERAL]           = &ecma_op_general_object_get_property,
-   *   [ECMA_OBJECT_TYPE_ARRAY]             = &ecma_op_general_object_get_property,
    *   [ECMA_OBJECT_TYPE_FUNCTION]          = &ecma_op_general_object_get_property,
-   *   [ECMA_OBJECT_TYPE_BOUND_FUNCTION]    = &ecma_op_general_object_get_property,
    *   [ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION] = &ecma_op_general_object_get_property,
-   *   [ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION] = &ecma_op_general_object_get_property,
-   *   [ECMA_OBJECT_TYPE_ARGUMENTS]         = &ecma_op_general_object_get_property,
-   *   [ECMA_OBJECT_TYPE_STRING]            = &ecma_op_general_object_get_property
+   *   [ECMA_OBJECT_TYPE_ARRAY]             = &ecma_op_general_object_get_property,
+   *   [ECMA_OBJECT_TYPE_STRING]            = &ecma_op_general_object_get_property,
+   *   [ECMA_OBJECT_TYPE_BOUND_FUNCTION]    = &ecma_op_general_object_get_property,
+   *   [ECMA_OBJECT_TYPE_ARGUMENTS]         = &ecma_op_general_object_get_property
    * };
    *
    * return get_property[type] (obj_p, property_name_p);
@@ -254,13 +251,12 @@ ecma_op_object_put (ecma_object_t *obj_p, /**< the object */
    * static const put_ptr_t put [ECMA_OBJECT_TYPE__COUNT] =
    * {
    *   [ECMA_OBJECT_TYPE_GENERAL]           = &ecma_op_general_object_put,
-   *   [ECMA_OBJECT_TYPE_ARRAY]             = &ecma_op_general_object_put,
    *   [ECMA_OBJECT_TYPE_FUNCTION]          = &ecma_op_general_object_put,
-   *   [ECMA_OBJECT_TYPE_BOUND_FUNCTION]    = &ecma_op_general_object_put,
    *   [ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION] = &ecma_op_general_object_put,
-   *   [ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION] = &ecma_op_general_object_put,
-   *   [ECMA_OBJECT_TYPE_ARGUMENTS]         = &ecma_op_general_object_put,
-   *   [ECMA_OBJECT_TYPE_STRING]            = &ecma_op_general_object_put
+   *   [ECMA_OBJECT_TYPE_ARRAY]             = &ecma_op_general_object_put,
+   *   [ECMA_OBJECT_TYPE_STRING]            = &ecma_op_general_object_put,
+   *   [ECMA_OBJECT_TYPE_BOUND_FUNCTION]    = &ecma_op_general_object_put,
+   *   [ECMA_OBJECT_TYPE_ARGUMENTS]         = &ecma_op_general_object_put
    * };
    *
    * return put[type] (obj_p, property_name_p);
@@ -292,12 +288,11 @@ ecma_op_object_delete (ecma_object_t *obj_p, /**< the object */
   switch (type)
   {
     case ECMA_OBJECT_TYPE_GENERAL:
-    case ECMA_OBJECT_TYPE_ARRAY:
     case ECMA_OBJECT_TYPE_FUNCTION:
-    case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     case ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION:
-    case ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION:
+    case ECMA_OBJECT_TYPE_ARRAY:
     case ECMA_OBJECT_TYPE_STRING:
+    case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     {
       return ecma_op_general_object_delete (obj_p,
                                             property_name_p,
@@ -342,13 +337,12 @@ ecma_op_object_default_value (ecma_object_t *obj_p, /**< the object */
    * static const default_value_ptr_t default_value [ECMA_OBJECT_TYPE__COUNT] =
    * {
    *   [ECMA_OBJECT_TYPE_GENERAL]           = &ecma_op_general_object_default_value,
-   *   [ECMA_OBJECT_TYPE_ARRAY]             = &ecma_op_general_object_default_value,
    *   [ECMA_OBJECT_TYPE_FUNCTION]          = &ecma_op_general_object_default_value,
-   *   [ECMA_OBJECT_TYPE_BOUND_FUNCTION]    = &ecma_op_general_object_default_value,
    *   [ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION] = &ecma_op_general_object_default_value,
-   *   [ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION] = &ecma_op_general_object_default_value,
-   *   [ECMA_OBJECT_TYPE_ARGUMENTS]         = &ecma_op_general_object_default_value,
-   *   [ECMA_OBJECT_TYPE_STRING]            = &ecma_op_general_object_default_value
+   *   [ECMA_OBJECT_TYPE_ARRAY]             = &ecma_op_general_object_default_value,
+   *   [ECMA_OBJECT_TYPE_STRING]            = &ecma_op_general_object_default_value,
+   *   [ECMA_OBJECT_TYPE_BOUND_FUNCTION]    = &ecma_op_general_object_default_value,
+   *   [ECMA_OBJECT_TYPE_ARGUMENTS]         = &ecma_op_general_object_default_value
    * };
    *
    * return default_value[type] (obj_p, property_name_p);
@@ -383,10 +377,9 @@ ecma_op_object_define_own_property (ecma_object_t *obj_p, /**< the object */
   {
     case ECMA_OBJECT_TYPE_GENERAL:
     case ECMA_OBJECT_TYPE_FUNCTION:
-    case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     case ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION:
-    case ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION:
     case ECMA_OBJECT_TYPE_STRING:
+    case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     {
       return ecma_op_general_object_define_own_property (obj_p,
                                                          property_name_p,
@@ -435,8 +428,8 @@ ecma_op_object_has_instance (ecma_object_t *obj_p, /**< the object */
 
   switch (type)
   {
-    case ECMA_OBJECT_TYPE_ARRAY:
     case ECMA_OBJECT_TYPE_GENERAL:
+    case ECMA_OBJECT_TYPE_ARRAY:
     case ECMA_OBJECT_TYPE_STRING:
     case ECMA_OBJECT_TYPE_ARGUMENTS:
     {
@@ -444,12 +437,12 @@ ecma_op_object_has_instance (ecma_object_t *obj_p, /**< the object */
     }
 
     case ECMA_OBJECT_TYPE_FUNCTION:
-    case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     case ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION:
-    case ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION:
+    case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     {
       return ecma_op_function_has_instance (obj_p, value);
     }
+
     default:
     {
       JERRY_UNREACHABLE ();
@@ -559,12 +552,11 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
           break;
         }
 
-        case ECMA_OBJECT_TYPE_ARRAY:
         case ECMA_OBJECT_TYPE_GENERAL:
-        case ECMA_OBJECT_TYPE_ARGUMENTS:
-        case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
         case ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION:
-        case ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION:
+        case ECMA_OBJECT_TYPE_ARRAY:
+        case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
+        case ECMA_OBJECT_TYPE_ARGUMENTS:
         {
           break;
         }
@@ -865,9 +857,8 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
       return LIT_MAGIC_STRING_ARGUMENTS_UL;
     }
     case ECMA_OBJECT_TYPE_FUNCTION:
-    case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     case ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION:
-    case ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION:
+    case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     {
       return LIT_MAGIC_STRING_FUNCTION_UL;
     }


### PR DESCRIPTION
Cleanup patch. The effect is negligible.