### PR TITLE
Four byte optimized memcpy.

### DIFF
--- a/jerry-libc/jerry-libc.c
+++ b/jerry-libc/jerry-libc.c
@@ -103,6 +103,24 @@ memcpy (void *s1, /**< destination */
         const void *s2, /**< source */
         size_t n) /**< bytes number */
 {
+  /* Aligned fast case. */
+  if (n >= 4 && !(((uintptr_t) s1) & 0x3) && !(((uintptr_t) s2) & 0x3))
+  {
+    size_t chunks = (n >> 2);
+    uint32_t *area1_p = (uint32_t *) s1;
+    const uint32_t *area2_p = (const uint32_t *) s2;
+
+    do
+    {
+      *area1_p++ = *area2_p++;
+    }
+    while (--chunks);
+
+    n &= 0x3;
+    s1 = area1_p;
+    s2 = area2_p;
+  }
+
   uint8_t *area1_p = (uint8_t *) s1;
   const uint8_t *area2_p = (const uint8_t *) s2;
 


### PR DESCRIPTION
Binary unchanged.

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 1.152 -> 1.147 : +0.378% | 
3d-raytrace.js | 1.371 -> 1.315 : +4.092% | 
access-binary-trees.js | 0.674 -> 0.673 : +0.062% | 
access-fannkuch.js | 2.854 -> 2.845 : +0.315% | 
access-nbody.js | 1.386 -> 1.387 : -0.047% | 
bitops-3bit-bits-in-byte.js | 0.630 -> 0.631 : -0.154% | 
bitops-bits-in-byte.js | 0.917 -> 0.917 : -0.063% | 
bitops-bitwise-and.js | 1.920 -> 1.923 : -0.123% | 
bitops-nsieve-bits.js | 2.276 -> 2.240 : +1.578% | 
controlflow-recursive.js | 0.475 -> 0.475 : +0.026% | 
crypto-aes.js | 1.251 -> 1.244 : +0.622% | 
crypto-md5.js | 0.849 -> 0.845 : +0.473% | 
crypto-sha1.js | 0.792 -> 0.789 : +0.432% | 
date-format-tofte.js | 1.023 -> 1.019 : +0.409% | 
date-format-xparb.js | 0.556 -> 0.551 : +0.820% | 
math-cordic.js | 1.669 -> 1.667 : +0.100% | 
math-partial-sums.js | 0.986 -> 0.986 : -0.013% | 
math-spectral-norm.js | 0.705 -> 0.700 : +0.740% | 
string-base64.js | 4.597 -> 2.241 : +51.246% | 
string-fasta.js | 2.145 -> 2.124 : +1.000% | 
Geometric mean: | +4.046% | 