### PR TITLE
Check error values in API functions

### DIFF
--- a/jerry-core/jerry-api.h
+++ b/jerry-core/jerry-api.h
@@ -144,6 +144,7 @@ bool jerry_value_to_boolean (const jerry_value_t);
 jerry_value_t jerry_value_to_number (const jerry_value_t);
 jerry_value_t jerry_value_to_object (const jerry_value_t);
 jerry_value_t jerry_value_to_string (const jerry_value_t);
+jerry_value_t jerry_value_remove_error_flag (const jerry_value_t);
 
 /**
  * Create functions of 'jerry_value_t'

--- a/main-unix.c
+++ b/main-unix.c
@@ -501,6 +501,7 @@ main (int argc,
     }
     else if (!jerry_value_is_undefined (err_value))
     {
+      err_value = jerry_value_remove_error_flag (err_value);
       err_str_p = jerry_get_string_value (jerry_value_to_string (err_value));
       jerry_release_value (err_value);
     }


### PR DESCRIPTION
Internal functions cannot handle error values, so it must be avoided to
pass error values to the engine.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com