### PR TITLE
[zephyr] rename SOURCE_DIR to ZEPHYR_TARGET_SRC_DIR in Makefile.zephyr

### DIFF
--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -30,7 +30,7 @@ BOARD_NAME ?= qemu_x86
 endif
 
 TARGET_ZEPHYR ?= ./targets/zephyr
-SOURCE_DIR = $(TARGET_ZEPHYR)/src
+TARGET_ZEPHYR_SRC_DIR = $(TARGET_ZEPHYR)/src
 
 TYPE  ?= release
 JERRYHEAP ?= 16
@@ -129,7 +129,7 @@ endif
 	 -DEXTERNAL_CMAKE_SYSTEM_PROCESSOR=lakemont \
 	 -DEXTERNAL_LIBC_INTERFACE="$(ZEPHYR_LIBC_INC)" \
 	 -DCMAKE_TOOLCHAIN_FILE=build/configs/toolchain_external.cmake \
-	 -DEXTERNAL_BUILD_ENTRY_FILE=$(SOURCE_DIR)/jerry-entry.c
+	 -DEXTERNAL_BUILD_ENTRY_FILE=$(TARGET_ZEPHYR_SRC_DIR)/jerry-entry.c
 
 	make -C $(INTERM) $(TYPE).external$(VARIETY) V=1
 	cp `cat $(INTERM)/$(TYPE).external$(VARIETY)/list` $(OUTPUT)/.
@@ -184,8 +184,8 @@ clean:
 	@echo "Clearing Jerryscript"
 	@rm -rf $(OUTPUT)
 	@rm -rf $(INTERM)
-	@rm -f $(SOURCE_DIR)/.*.o.cmd
-	@rm -f $(SOURCE_DIR)/*.o
+	@rm -f $(TARGET_ZEPHYR_SRC_DIR)/.*.o.cmd
+	@rm -f $(TARGET_ZEPHYR_SRC_DIR)/*.o
 	@echo "Clearing Zephyr"
 	make -f $(TARGET_ZEPHYR)/Makefile clean
 	make -f $(TARGET_ZEPHYR)/Makefile pristine


### PR DESCRIPTION
In Makefile.zephyr the SOURCE_DIR variable was introduced recently.

However, the SOURCE_DIR variable is heavily used in zephyr. If you try to build
the jerryscript zephyr port from a zephyr project using the makefiles, the
SOURCE_DIR gets set by the zephyr build system and points to wrong place here.

This patch creates unique name to avoid the name clash.

JerryScript-DCO-1.0-Signed-off-by: Sakari Poussa sakari.poussa@intel.com