### PR TITLE
ecma_make_boolean_value(bool) function is added

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -336,6 +336,18 @@ ecma_make_simple_value (const ecma_simple_value_t simple_value) /**< simple valu
 } /* ecma_make_simple_value */
 
 /**
+ * Creates an ecma value from the given raw boolean.
+ *
+ * @return boolean ecma_value
+ */
+inline ecma_value_t __attr_const___ __attr_always_inline___
+ecma_make_boolean_value (bool boolean_value) /**< raw bool value from which the ecma value will be created */
+{
+  return ecma_make_simple_value (boolean_value ? ECMA_SIMPLE_VALUE_TRUE
+                                               : ECMA_SIMPLE_VALUE_FALSE);
+} /* ecma_make_boolean_value */
+
+/**
  * Encode an integer number into an ecma-value without allocating memory
  *
  * Note:

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -132,6 +132,7 @@ extern bool ecma_is_value_object (ecma_value_t) __attr_pure___;
 extern void ecma_check_value_type_is_spec_defined (ecma_value_t);
 
 extern ecma_value_t ecma_make_simple_value (const ecma_simple_value_t value) __attr_const___;
+extern ecma_value_t ecma_make_boolean_value (bool) __attr_const___;
 extern ecma_value_t ecma_make_integer_value (ecma_integer_value_t) __attr_const___;
 extern ecma_value_t ecma_make_nan_value (void);
 extern ecma_value_t ecma_make_number_value (ecma_number_t);

--- a/jerry-core/ecma/operations/ecma-boolean-object.c
+++ b/jerry-core/ecma/operations/ecma-boolean-object.c
@@ -58,8 +58,7 @@ ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boo
   ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                       ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
 
-  ecma_value_t prim_value = ecma_make_simple_value (boolean_value ? ECMA_SIMPLE_VALUE_TRUE
-                                                                  : ECMA_SIMPLE_VALUE_FALSE);
+  ecma_value_t prim_value = ecma_make_boolean_value (boolean_value);
 
   ecma_set_internal_property_value (prim_value_prop_p, prim_value);
 

--- a/jerry-core/ecma/operations/ecma-comparison.c
+++ b/jerry-core/ecma/operations/ecma-comparison.c
@@ -81,7 +81,7 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
       JERRY_ASSERT (is_x_equal_to_y == is_x_equal_to_y_check);
 #endif /* !JERRY_NDEBUG */
 
-      return ecma_make_simple_value (is_x_equal_to_y ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+      return ecma_make_boolean_value (is_x_equal_to_y);
     }
 
     /* Swap values. */
@@ -100,7 +100,7 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
 
       bool is_equal = ecma_compare_ecma_strings (x_str_p, y_str_p);
 
-      return ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+      return ecma_make_boolean_value (is_equal);
     }
 
     if (ecma_is_value_number (y))
@@ -175,7 +175,7 @@ ecma_op_abstract_equality_compare (ecma_value_t x, /**< first operand */
     // 2., 3.
     bool is_equal = ecma_is_value_undefined (y) || ecma_is_value_null (y);
 
-    return ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+    return ecma_make_boolean_value (is_equal);
   }
 
   return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
@@ -375,7 +375,7 @@ ecma_op_abstract_relational_compare (ecma_value_t x, /**< first operand */
       JERRY_ASSERT (is_x_less_than_y_check == is_x_less_than_y);
 #endif /* !JERRY_NDEBUG */
 
-      ret_value = ecma_make_simple_value (is_x_less_than_y ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+      ret_value = ecma_make_boolean_value (is_x_less_than_y);
     }
 
     ECMA_OP_TO_NUMBER_FINALIZE (ny);
@@ -390,7 +390,7 @@ ecma_op_abstract_relational_compare (ecma_value_t x, /**< first operand */
 
     bool is_px_less = ecma_compare_ecma_strings_relational (str_x_p, str_y_p);
 
-    ret_value = ecma_make_simple_value (is_px_less ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE);
+    ret_value = ecma_make_boolean_value (is_px_less);
   }
 
   ECMA_FINALIZE (prim_second_converted_value);

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -472,8 +472,7 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
 
     // b.
     const bool is_writable = (src_prop_desc_p->is_writable);
-    prop_desc.value = ecma_make_simple_value (is_writable ? ECMA_SIMPLE_VALUE_TRUE
-                                                          : ECMA_SIMPLE_VALUE_FALSE);
+    prop_desc.value = ecma_make_boolean_value (is_writable);
 
     ecma_string_t *writable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_WRITABLE);
     completion = ecma_op_object_define_own_property (obj_p,
@@ -527,8 +526,7 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
   }
 
   const bool is_enumerable = src_prop_desc_p->is_enumerable;
-  prop_desc.value = ecma_make_simple_value (is_enumerable ? ECMA_SIMPLE_VALUE_TRUE
-                                            : ECMA_SIMPLE_VALUE_FALSE);
+  prop_desc.value = ecma_make_boolean_value (is_enumerable);
 
   ecma_string_t *enumerable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_ENUMERABLE);
   completion = ecma_op_object_define_own_property (obj_p,
@@ -539,8 +537,7 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
   JERRY_ASSERT (ecma_is_value_true (completion));
 
   const bool is_configurable = src_prop_desc_p->is_configurable;
-  prop_desc.value = ecma_make_simple_value (is_configurable ? ECMA_SIMPLE_VALUE_TRUE
-                                            : ECMA_SIMPLE_VALUE_FALSE);
+  prop_desc.value = ecma_make_boolean_value (is_configurable);
 
   ecma_string_t *configurable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CONFIGURABLE);
   completion = ecma_op_object_define_own_property (obj_p,

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -151,8 +151,6 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp obejct */
                                          prop_p,
                                          ecma_make_string_value (source_p));
 
-  ecma_simple_value_t prop_value;
-
   /* Set global property. ECMA-262 v5, 15.10.7.2 */
   magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL);
   prop_p = ecma_find_named_property (re_obj_p, magic_string_p);
@@ -165,9 +163,8 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp obejct */
   }
 
   ecma_deref_ecma_string (magic_string_p);
-  prop_value = (flags & RE_FLAG_GLOBAL) ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE;
   JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
-  ecma_set_named_data_property_value (prop_p, ecma_make_simple_value (prop_value));
+  ecma_set_named_data_property_value (prop_p, ecma_make_boolean_value (flags & RE_FLAG_GLOBAL));
 
   /* Set ignoreCase property. ECMA-262 v5, 15.10.7.3 */
   magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_IGNORECASE_UL);
@@ -181,9 +178,8 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp obejct */
   }
 
   ecma_deref_ecma_string (magic_string_p);
-  prop_value = (flags & RE_FLAG_IGNORE_CASE) ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE;
   JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
-  ecma_set_named_data_property_value (prop_p, ecma_make_simple_value (prop_value));
+  ecma_set_named_data_property_value (prop_p, ecma_make_boolean_value (flags & RE_FLAG_IGNORE_CASE));
 
   /* Set multiline property. ECMA-262 v5, 15.10.7.4 */
   magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MULTILINE);
@@ -197,9 +193,8 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp obejct */
   }
 
   ecma_deref_ecma_string (magic_string_p);
-  prop_value = (flags & RE_FLAG_MULTILINE) ? ECMA_SIMPLE_VALUE_TRUE : ECMA_SIMPLE_VALUE_FALSE;
   JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA);
-  ecma_set_named_data_property_value (prop_p, ecma_make_simple_value (prop_value));
+  ecma_set_named_data_property_value (prop_p, ecma_make_boolean_value (flags & RE_FLAG_MULTILINE));
 
   /* Set lastIndex property. ECMA-262 v5, 15.10.7.5 */
   magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -277,8 +277,7 @@ jerry_create_undefined_value (void)
 jerry_value_t
 jerry_create_boolean_value (bool value) /**< bool value from which a jerry_value_t will be created */
 {
-  return (value ? ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE)
-                : ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE));
+  return ecma_make_boolean_value (value);
 } /* jerry_create_boolean_value */
 
 /**

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1735,8 +1735,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           bool is_equal = ecma_op_strict_equality_compare (left_value, right_value);
 
-          result = ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_TRUE
-                                                    : ECMA_SIMPLE_VALUE_FALSE);
+          result = ecma_make_boolean_value (is_equal);
 
           *stack_top_p++ = result;
           goto free_both_values;
@@ -1745,8 +1744,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           bool is_equal = ecma_op_strict_equality_compare (left_value, right_value);
 
-          result = ecma_make_simple_value (is_equal ? ECMA_SIMPLE_VALUE_FALSE
-                                                    : ECMA_SIMPLE_VALUE_TRUE);
+          result = ecma_make_boolean_value (!is_equal);
 
           *stack_top_p++ = result;
           goto free_both_values;


### PR DESCRIPTION
ecma_make_boolean_value(bool) function is added in order to make ecma_value form a raw bool.

JerryScript-DCO-1.0-Signed-off-by: István Kádár ikadar@inf.u-szeged.hu