### PR TITLE
targets/zephyr: Add support for NXP FRDM-K64F board.

### DIFF
--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -66,7 +66,7 @@ CONFIG_TOOLCHAIN_VARIANT = x86
 CPU = x86
 EXT_CFLAGS += -march=pentium
 EXT_CFLAGS += -mpreferred-stack-boundary=2 -mno-sse
-else ifeq ($(BOARD),qemu_cortex_m3)
+else ifeq ($(BOARD),$(filter $(BOARD),qemu_cortex_m3 frdm_k64f))
 CONFIG_TOOLCHAIN_VARIANT = arm
 CPU = arm7-m
 EXT_CFLAGS += -march=armv7-m -mthumb -mcpu=cortex-m3 -mabi=aapcs

--- a/targets/zephyr/README.md
+++ b/targets/zephyr/README.md
@@ -25,7 +25,8 @@ harmony
 
 2. Target boards/emulations
 
-Following Zephyr boards were tested: qemu_x86, qemu_cortex_m3, arduino_101.
+Following Zephyr boards were tested: qemu_x86, qemu_cortex_m3, arduino_101,
+frdm_k64f.
 
 
 #### 2. Prepare Zephyr


### PR DESCRIPTION
Tested to boot and run "test" one-liner.

JerryScript-DCO-1.0-Signed-off-by: Paul Sokolovsky paul.sokolovsky@linaro.org