### PR TITLE
Optimize comparison in VM.

### DIFF
--- a/jerry-core/vm/opcodes-ecma-relational.c
+++ b/jerry-core/vm/opcodes-ecma-relational.c
@@ -44,15 +44,6 @@ opfunc_less_than (ecma_value_t left_value, /**< left value */
   JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
                 && !ECMA_IS_VALUE_ERROR (right_value));
 
-  if (ecma_are_values_integer_numbers (left_value, right_value))
-  {
-    if ((ecma_integer_value_t) left_value < (ecma_integer_value_t) right_value)
-    {
-      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
-    }
-    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
-  }
-
   ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, true);
 
   if (ECMA_IS_VALUE_ERROR (ret_value))
@@ -87,15 +78,6 @@ opfunc_greater_than (ecma_value_t left_value, /**< left value */
   JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
                 && !ECMA_IS_VALUE_ERROR (right_value));
 
-  if (ecma_are_values_integer_numbers (left_value, right_value))
-  {
-    if ((ecma_integer_value_t) left_value > (ecma_integer_value_t) right_value)
-    {
-      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
-    }
-    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
-  }
-
   ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, false);
 
   if (ECMA_IS_VALUE_ERROR (ret_value))
@@ -129,15 +111,6 @@ opfunc_less_or_equal_than (ecma_value_t left_value, /**< left value */
 {
   JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
                 && !ECMA_IS_VALUE_ERROR (right_value));
-
-  if (ecma_are_values_integer_numbers (left_value, right_value))
-  {
-    if ((ecma_integer_value_t) left_value <= (ecma_integer_value_t) right_value)
-    {
-      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
-    }
-    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
-  }
 
   ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, false);
 
@@ -174,15 +147,6 @@ opfunc_greater_or_equal_than (ecma_value_t left_value, /**< left value */
 {
   JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
                 && !ECMA_IS_VALUE_ERROR (right_value));
-
-  if (ecma_are_values_integer_numbers (left_value, right_value))
-  {
-    if ((ecma_integer_value_t) left_value >= (ecma_integer_value_t) right_value)
-    {
-      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
-    }
-    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
-  }
 
   ecma_value_t ret_value = ecma_op_abstract_relational_compare (left_value, right_value, true);
 

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1968,6 +1968,24 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_LESS:
         {
+          if (ecma_are_values_integer_numbers (left_value, right_value))
+          {
+            ecma_integer_value_t left_integer = (ecma_integer_value_t) left_value;
+            ecma_integer_value_t right_integer = (ecma_integer_value_t) right_value;
+
+            *stack_top_p++ = ecma_make_boolean_value (left_integer < right_integer);
+            continue;
+          }
+
+          if (ecma_is_value_number (left_value) && ecma_is_value_number (right_value))
+          {
+            ecma_number_t left_number = ecma_get_number_from_value (left_value);
+            ecma_number_t right_number = ecma_get_number_from_value (right_value);
+
+            *stack_top_p++ = ecma_make_boolean_value (left_number < right_number);
+            goto free_both_values;
+          }
+
           result = opfunc_less_than (left_value, right_value);
 
           if (ECMA_IS_VALUE_ERROR (result))
@@ -1980,6 +1998,24 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_GREATER:
         {
+          if (ecma_are_values_integer_numbers (left_value, right_value))
+          {
+            ecma_integer_value_t left_integer = (ecma_integer_value_t) left_value;
+            ecma_integer_value_t right_integer = (ecma_integer_value_t) right_value;
+
+            *stack_top_p++ = ecma_make_boolean_value (left_integer > right_integer);
+            continue;
+          }
+
+          if (ecma_is_value_number (left_value) && ecma_is_value_number (right_value))
+          {
+            ecma_number_t left_number = ecma_get_number_from_value (left_value);
+            ecma_number_t right_number = ecma_get_number_from_value (right_value);
+
+            *stack_top_p++ = ecma_make_boolean_value (left_number > right_number);
+            goto free_both_values;
+          }
+
           result = opfunc_greater_than (left_value, right_value);
 
           if (ECMA_IS_VALUE_ERROR (result))
@@ -1992,6 +2028,24 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_LESS_EQUAL:
         {
+          if (ecma_are_values_integer_numbers (left_value, right_value))
+          {
+            ecma_integer_value_t left_integer = (ecma_integer_value_t) left_value;
+            ecma_integer_value_t right_integer = (ecma_integer_value_t) right_value;
+
+            *stack_top_p++ = ecma_make_boolean_value (left_integer <= right_integer);
+            continue;
+          }
+
+          if (ecma_is_value_number (left_value) && ecma_is_value_number (right_value))
+          {
+            ecma_number_t left_number = ecma_get_number_from_value (left_value);
+            ecma_number_t right_number = ecma_get_number_from_value (right_value);
+
+            *stack_top_p++ = ecma_make_boolean_value (left_number <= right_number);
+            goto free_both_values;
+          }
+
           result = opfunc_less_or_equal_than (left_value, right_value);
 
           if (ECMA_IS_VALUE_ERROR (result))
@@ -2004,6 +2058,24 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_GREATER_EQUAL:
         {
+          if (ecma_are_values_integer_numbers (left_value, right_value))
+          {
+            ecma_integer_value_t left_integer = (ecma_integer_value_t) left_value;
+            ecma_integer_value_t right_integer = (ecma_integer_value_t) right_value;
+
+            *stack_top_p++ = ecma_make_boolean_value (left_integer >= right_integer);
+            continue;
+          }
+
+          if (ecma_is_value_number (left_value) && ecma_is_value_number (right_value))
+          {
+            ecma_number_t left_number = ecma_get_number_from_value (left_value);
+            ecma_number_t right_number = ecma_get_number_from_value (right_value);
+
+            *stack_top_p++ = ecma_make_boolean_value (left_number >= right_number);
+            goto free_both_values;
+          }
+
           result = opfunc_greater_or_equal_than (left_value, right_value);
 
           if (ECMA_IS_VALUE_ERROR (result))


### PR DESCRIPTION
5% improvement on 3d-cube and 8% on math-cordic

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 1.035 -> 0.980 : +5.308% | 
3d-raytrace.js | 1.162 -> 1.135 : +2.333% | 
access-binary-trees.js | 0.622 -> 0.620 : +0.234% | 
access-fannkuch.js | 2.706 -> 2.673 : +1.229% | 
access-nbody.js | 1.164 -> 1.154 : +0.828% | 
bitops-3bit-bits-in-byte.js | 0.586 -> 0.584 : +0.345% | 
bitops-bits-in-byte.js | 0.875 -> 0.860 : +1.734% | 
bitops-bitwise-and.js | 1.460 -> 1.459 : +0.050% | 
bitops-nsieve-bits.js | 1.924 -> 1.899 : +1.284% | 
controlflow-recursive.js | 0.434 -> 0.434 : +0.157% | 
crypto-aes.js | 1.207 -> 1.202 : +0.451% | 
crypto-md5.js | 0.773 -> 0.773 : +0.117% | 
crypto-sha1.js | 0.729 -> 0.727 : +0.226% | 
date-format-tofte.js | 0.914 -> 0.909 : +0.528% | 
date-format-xparb.js | 0.494 -> 0.495 : -0.204% | 
math-cordic.js | 1.562 -> 1.434 : +8.226% | 
math-partial-sums.js | 0.814 -> 0.812 : +0.231% | 
math-spectral-norm.js | 0.619 -> 0.610 : +1.437% | 
string-base64.js | 2.132 -> 2.118 : +0.688% | 
string-fasta.js | 1.982 -> 1.919 : +3.191% | 
Geometric mean: | +1.441% | 

Binary size 156236 (unchanged).