### PR TITLE
Optimize conditional jumps.

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1519,31 +1519,78 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           continue;
         }
         case VM_OC_BRANCH_IF_TRUE:
-        case VM_OC_BRANCH_IF_FALSE:
-        case VM_OC_BRANCH_IF_LOGICAL_TRUE:
-        case VM_OC_BRANCH_IF_LOGICAL_FALSE:
         {
-          uint32_t opcode_flags = VM_OC_GROUP_GET_INDEX (opcode_data) - VM_OC_BRANCH_IF_TRUE;
           ecma_value_t value = *(--stack_top_p);
 
-          bool boolean_value = ecma_op_to_boolean (value);
-
-          if (opcode_flags & VM_OC_BRANCH_IF_FALSE_FLAG)
-          {
-            boolean_value = !boolean_value;
-          }
-
-          if (boolean_value)
+          if (value == ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE))
           {
             byte_code_p = byte_code_start_p + branch_offset;
-            if (opcode_flags & VM_OC_LOGICAL_BRANCH_FLAG)
-            {
-              /* "Push" the value back to the stack. */
-              ++stack_top_p;
-              continue;
-            }
+            continue;
           }
 
+          if (value == ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE))
+          {
+            continue;
+          }
+
+          if (ecma_op_to_boolean (value))
+          {
+            byte_code_p = byte_code_start_p + branch_offset;
+          }
+
+          ecma_fast_free_value (value);
+          continue;
+        }
+        case VM_OC_BRANCH_IF_FALSE:
+        {
+          ecma_value_t value = *(--stack_top_p);
+
+          if (value == ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE))
+          {
+            byte_code_p = byte_code_start_p + branch_offset;
+            continue;
+          }
+
+          if (value == ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE))
+          {
+            continue;
+          }
+
+          if (!ecma_op_to_boolean (value))
+          {
+            byte_code_p = byte_code_start_p + branch_offset;
+          }
+
+          ecma_fast_free_value (value);
+          continue;
+        }
+        case VM_OC_BRANCH_IF_LOGICAL_TRUE:
+        {
+          ecma_value_t value = stack_top_p[-1];
+
+          if (ecma_op_to_boolean (value))
+          {
+            /* Keep the value on the stack. */
+            byte_code_p = byte_code_start_p + branch_offset;
+            continue;
+          }
+
+          stack_top_p--;
+          ecma_fast_free_value (value);
+          continue;
+        }
+        case VM_OC_BRANCH_IF_LOGICAL_FALSE:
+        {
+          ecma_value_t value = stack_top_p[-1];
+
+          if (!ecma_op_to_boolean (value))
+          {
+            /* Keep the value on the stack. */
+            byte_code_p = byte_code_start_p + branch_offset;
+            continue;
+          }
+
+          stack_top_p--;
           ecma_fast_free_value (value);
           continue;
         }

--- a/jerry-core/vm/vm.h
+++ b/jerry-core/vm/vm.h
@@ -222,16 +222,6 @@ typedef enum
 #define VM_OC_IDENT_INCR_DECR_OPERATOR_FLAG 0x4
 
 /**
- * Jump to target offset if input value is logical false.
- */
-#define VM_OC_BRANCH_IF_FALSE_FLAG 0x1
-
-/**
- * Branch optimized for logical and/or opcodes.
- */
-#define VM_OC_LOGICAL_BRANCH_FLAG 0x2
-
-/**
  * Position of "put result" opcode.
  */
 #define VM_OC_PUT_RESULT_SHIFT 10


### PR DESCRIPTION
Small improvement, not sure it is worth it. Anyway, lets discuss it.

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 0.980 -> 0.971 : +0.965% | 
3d-raytrace.js | 1.134 -> 1.136 : -0.164% | 
access-binary-trees.js | 0.620 -> 0.617 : +0.461% | 
access-fannkuch.js | 2.679 -> 2.682 : -0.111% | 
access-nbody.js | 1.153 -> 1.155 : -0.197% | 
bitops-3bit-bits-in-byte.js | 0.584 -> 0.580 : +0.615% | 
bitops-bits-in-byte.js | 0.860 -> 0.849 : +1.318% | 
bitops-bitwise-and.js | 1.461 -> 1.436 : +1.687% | 
bitops-nsieve-bits.js | 1.900 -> 1.869 : +1.647% | 
controlflow-recursive.js | 0.434 -> 0.424 : +2.151% | 
crypto-aes.js | 1.202 -> 1.202 : -0.001% | 
crypto-md5.js | 0.772 -> 0.785 : -1.703% | 
crypto-sha1.js | 0.727 -> 0.737 : -1.283% | 
date-format-tofte.js | 0.908 -> 0.893 : +1.623% | 
date-format-xparb.js | 0.496 -> 0.498 : -0.391% | 
math-cordic.js | 1.433 -> 1.412 : +1.481% | 
math-partial-sums.js | 0.812 -> 0.830 : -2.254% | 
math-spectral-norm.js | 0.611 -> 0.611 : -0.019% | 
string-base64.js | 2.118 -> 2.128 : -0.438% | 
string-fasta.js | 1.916 -> 1.907 : +0.519% | 
Geometric mean: | +0.302% | 
