### PR TITLE
Small performance optimizations of the interpreter.

### DIFF
--- a/jerry-core/ecma/operations/ecma-reference.h
+++ b/jerry-core/ecma/operations/ecma-reference.h
@@ -26,26 +26,8 @@
  * @{
  */
 
-/**
- * ECMA-reference (see also: ECMA-262 v5, 8.7).
- */
-typedef struct
-{
-  /** base value */
-  ecma_value_t base;
-
-  /** referenced name */
-  __extension__ jmem_cpointer_t referenced_name_cp : ECMA_POINTER_FIELD_WIDTH;
-
-  /** strict reference flag */
-  unsigned int is_strict : 1;
-} ecma_reference_t;
-
 extern ecma_object_t *ecma_op_resolve_reference_base (ecma_object_t *, ecma_string_t *);
-
-extern ecma_reference_t ecma_op_get_identifier_reference (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_reference_t ecma_make_reference (ecma_value_t, ecma_string_t *, bool);
-extern void ecma_free_reference (ecma_reference_t);
+extern ecma_value_t ecma_op_resolve_reference_value (ecma_object_t *, ecma_string_t *, bool);
 
 /**
  * @}

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -260,42 +260,24 @@ vm_op_delete_prop (ecma_value_t object, /**< base object */
  */
 ecma_value_t
 vm_op_delete_var (jmem_cpointer_t name_literal, /**< name literal */
-                  ecma_object_t *lex_env_p, /**< lexical environment */
-                  bool is_strict) /**< strict mode */
+                  ecma_object_t *lex_env_p) /**< lexical environment */
 {
   ecma_value_t completion_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
   ecma_string_t *var_name_str_p = JMEM_CP_GET_NON_NULL_POINTER (ecma_string_t, name_literal);
 
-  ecma_reference_t ref = ecma_op_get_identifier_reference (lex_env_p,
-                                                           var_name_str_p,
-                                                           is_strict);
+  ecma_object_t *ref_base_lex_env_p = ecma_op_resolve_reference_base (lex_env_p, var_name_str_p);
 
-  JERRY_ASSERT (!ref.is_strict);
-
-  if (ecma_is_value_undefined (ref.base))
+  if (ref_base_lex_env_p == NULL)
   {
     completion_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
   else
   {
-    ecma_object_t *ref_base_lex_env_p = ecma_op_resolve_reference_base (lex_env_p, var_name_str_p);
-
     JERRY_ASSERT (ecma_is_lexical_environment (ref_base_lex_env_p));
 
-    ECMA_TRY_CATCH (delete_op_ret_val,
-                    ecma_op_delete_binding (ref_base_lex_env_p,
-                                            ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                                                       ref.referenced_name_cp)),
-                    completion_value);
-
-    completion_value = delete_op_ret_val;
-
-    ECMA_FINALIZE (delete_op_ret_val);
-
+    completion_value = ecma_op_delete_binding (ref_base_lex_env_p, var_name_str_p);
   }
-
-  ecma_free_reference (ref);
 
   return completion_value;
 } /* vm_op_delete_var */

--- a/jerry-core/vm/opcodes.h
+++ b/jerry-core/vm/opcodes.h
@@ -107,7 +107,7 @@ ecma_value_t
 vm_op_delete_prop (ecma_value_t, ecma_value_t, bool);
 
 ecma_value_t
-vm_op_delete_var (jmem_cpointer_t, ecma_object_t *, bool);
+vm_op_delete_var (jmem_cpointer_t, ecma_object_t *);
 
 ecma_collection_header_t *
 opfunc_for_in (ecma_value_t, ecma_value_t *);


### PR DESCRIPTION
All tests are improved. Binary size unchanged.

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 0.981 -> 0.949 : +3.313% | 
3d-raytrace.js | 1.136 -> 1.114 : +1.904% | 
access-binary-trees.js | 0.620 -> 0.585 : +5.724% | 
access-fannkuch.js | 2.673 -> 2.566 : +3.992% | 
access-nbody.js | 1.153 -> 1.075 : +6.798% | 
bitops-3bit-bits-in-byte.js | 0.584 -> 0.570 : +2.297% | 
bitops-bits-in-byte.js | 0.861 -> 0.850 : +1.281% | 
bitops-bitwise-and.js | 1.461 -> 1.197 : +18.099% | 
bitops-nsieve-bits.js | 1.901 -> 1.818 : +4.368% | 
controlflow-recursive.js | 0.434 -> 0.402 : +7.427% | 
crypto-aes.js | 1.202 -> 1.145 : +4.744% | 
crypto-md5.js | 0.772 -> 0.753 : +2.445% | 
crypto-sha1.js | 0.727 -> 0.709 : +2.522% | 
date-format-tofte.js | 0.908 -> 0.887 : +2.280% | 
date-format-xparb.js | 0.495 -> 0.481 : +2.671% | 
math-cordic.js | 1.434 -> 1.350 : +5.867% | 
math-partial-sums.js | 0.812 -> 0.747 : +8.064% | 
math-spectral-norm.js | 0.610 -> 0.596 : +2.278% | 
string-base64.js | 2.116 -> 2.093 : +1.122% | 
string-fasta.js | 1.915 -> 1.856 : +3.109% | 
Geometric mean: | +4.592% | 
