### PR TITLE
Fix signed left shift in vm_loop().

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -143,19 +143,27 @@ typedef int32_t ecma_integer_value_t;
  * Maximum integer number for an ecma value
  */
 #if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32
-#define ECMA_INTEGER_NUMBER_MAX 0x7fffff
+#define ECMA_INTEGER_NUMBER_MAX         0x7fffff
+#define ECMA_INTEGER_NUMBER_MAX_SHIFTED 0x7fffff0
 #else /* CONFIG_ECMA_NUMBER_TYPE != CONFIG_ECMA_NUMBER_FLOAT32 */
-#define ECMA_INTEGER_NUMBER_MAX 0x7ffffff
+#define ECMA_INTEGER_NUMBER_MAX         0x7ffffff
+#define ECMA_INTEGER_NUMBER_MAX_SHIFTED 0x7ffffff0
 #endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32 */
 
 /**
  * Minimum integer number for an ecma value
  */
 #if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32
-#define ECMA_INTEGER_NUMBER_MIN -0x7fffff
+#define ECMA_INTEGER_NUMBER_MIN         -0x7fffff
+#define ECMA_INTEGER_NUMBER_MIN_SHIFTED -0x7fffff0
 #else /* CONFIG_ECMA_NUMBER_TYPE != CONFIG_ECMA_NUMBER_FLOAT32 */
-#define ECMA_INTEGER_NUMBER_MIN -0x8000000
+#define ECMA_INTEGER_NUMBER_MIN         -0x8000000
+#define ECMA_INTEGER_NUMBER_MIN_SHIFTED (-0x7fffffff - 1) /* -0x80000000 */
 #endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32 */
+
+#if ECMA_DIRECT_SHIFT != 4
+#error "Please update ECMA_INTEGER_NUMBER_MIN/MAX_SHIFTED according to the new value of ECMA_DIRECT_SHIFT."
+#endif
 
 /**
  * Checks whether the integer number is in the integer number range.

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1215,12 +1215,12 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
             if (opcode_flags & VM_OC_DECREMENT_OPERATOR_FLAG)
             {
-              if (int_value > (ECMA_INTEGER_NUMBER_MIN << ECMA_DIRECT_SHIFT))
+              if (int_value > ECMA_INTEGER_NUMBER_MIN_SHIFTED)
               {
                 int_increase = -(1 << ECMA_DIRECT_SHIFT);
               }
             }
-            else if (int_value < (ECMA_INTEGER_NUMBER_MAX << ECMA_DIRECT_SHIFT))
+            else if (int_value < ECMA_INTEGER_NUMBER_MAX_SHIFTED)
             {
               int_increase = 1 << ECMA_DIRECT_SHIFT;
             }


### PR DESCRIPTION
Signed left shift operations are undefined in C. Add constants for the minimum/maximum integer value which are already shifted. Technically, the constant for the shifted maximum value is not required, adding it for consistency/increased readability.

The bug was detected by -Wshift-negative-value both with GCC 6.x and Clang.

This fixes #1174.

JerryScript-DCO-1.0-Signed-off-by: Tilmann Scheller t.scheller@samsung.com