### PR TITLE
Simplify string management.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -817,8 +817,7 @@ typedef struct
  */
 typedef enum
 {
-  ECMA_STRING_CONTAINER_HEAP_ASCII_STRING, /**< actual data is on the heap as an ascii string */
-  ECMA_STRING_CONTAINER_HEAP_UTF8_STRING, /**< actual data is on the heap as an utf-8 string */
+  ECMA_STRING_CONTAINER_HEAP_UTF8_STRING, /**< actual data is on the heap as an utf-8 (cesu8) string */
   ECMA_STRING_CONTAINER_UINT32_IN_DESC, /**< actual data is UInt32-represeneted Number
                                              stored locally in the string's descriptor */
   ECMA_STRING_CONTAINER_MAGIC_STRING, /**< the ecma-string is equal to one of ECMA magic strings */
@@ -880,25 +879,14 @@ typedef struct ecma_string_t
    */
   union
   {
-    /** Index of string in literal table */
-    jmem_cpointer_t lit_cp;
-
-    /** Compressed pointer to an ecma_collection_header_t */
-    jmem_cpointer_t utf8_collection_cp;
-
     /**
-    * Actual data of an ascii string type
+    * Actual data of an utf-8 string type
     */
     struct
     {
-      /** Compressed pointer to a raw character array */
-      jmem_cpointer_t ascii_collection_cp;
-      /** Size of ascii string in bytes */
-      uint16_t size;
-    } ascii_string;
-
-    /** Compressed pointer to an ecma_number_t */
-    jmem_cpointer_t number_cp;
+      uint16_t size; /**< Size of this utf-8 string in bytes */
+      uint16_t length; /**< Length of this utf-8 string in characters */
+    } utf8_string;
 
     /** UInt32-represented number placed locally in the descriptor */
     uint32_t uint32_number;

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -179,6 +179,7 @@ ecma_lcache_lookup (ecma_object_t *object_p, /**< object */
 
   ecma_lcache_hash_entry_t *entry_p = ecma_lcache_hash_table[ecma_lcache_row_idx (object_cp, prop_name_p)];
   ecma_lcache_hash_entry_t *entry_end_p = entry_p + ECMA_LCACHE_HASH_ROW_LENGTH;
+  ecma_string_container_t prop_container = ECMA_STRING_GET_CONTAINER (prop_name_p);
 
   while (entry_p < entry_end_p)
   {
@@ -189,8 +190,10 @@ ecma_lcache_lookup (ecma_object_t *object_p, /**< object */
 
       JERRY_ASSERT ((prop_name_p->hash & ECMA_LCACHE_HASH_MASK) == (entry_prop_name_p->hash & ECMA_LCACHE_HASH_MASK));
 
-      if (ECMA_STRING_GET_CONTAINER (prop_name_p) == ECMA_STRING_GET_CONTAINER (entry_prop_name_p)
-          && prop_name_p->u.common_field == entry_prop_name_p->u.common_field)
+      if (prop_name_p == entry_prop_name_p
+          || (prop_container != ECMA_STRING_CONTAINER_HEAP_UTF8_STRING
+              && prop_container == ECMA_STRING_GET_CONTAINER (entry_prop_name_p)
+              && prop_name_p->u.common_field == entry_prop_name_p->u.common_field))
       {
         ecma_property_t *prop_p = entry_p->prop_p;
         JERRY_ASSERT (prop_p != NULL && ecma_is_property_lcached (prop_p));


### PR DESCRIPTION
Allocate a single memory block for strings, rather than a separate string header
and string characters block. In the past strings were split into 8 byte chunks,
and large amount of legacy code is designed for that representation. However the
current allocator allows block allocation so we don't need those complicated
algorithms anymore. This patch is a cleanup rather than an optimization.

Small speedup is achieved though. Binary size unchanged.

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 0.950 -> 0.955 : -0.573% | 
3d-raytrace.js | 1.113 -> 1.120 : -0.587% | 
access-binary-trees.js | 0.586 -> 0.585 : +0.221% | 
access-fannkuch.js | 2.568 -> 2.575 : -0.276% | 
access-nbody.js | 1.075 -> 1.070 : +0.476% | 
bitops-3bit-bits-in-byte.js | 0.571 -> 0.575 : -0.792% | 
bitops-bits-in-byte.js | 0.849 -> 0.861 : -1.359% | 
bitops-bitwise-and.js | 1.199 -> 1.107 : +7.667% | 
bitops-nsieve-bits.js | 1.820 -> 1.849 : -1.578% | 
controlflow-recursive.js | 0.402 -> 0.394 : +1.882% | 
crypto-aes.js | 1.149 -> 1.168 : -1.711% | 
crypto-md5.js | 0.753 -> 0.747 : +0.757% | 
crypto-sha1.js | 0.709 -> 0.703 : +0.852% | 
date-format-tofte.js | 0.886 -> 0.871 : +1.733% | 
date-format-xparb.js | 0.482 -> 0.466 : +3.213% | 
math-cordic.js | 1.352 -> 1.341 : +0.865% | 
math-partial-sums.js | 0.747 -> 0.724 : +3.168% | 
math-spectral-norm.js | 0.595 -> 0.589 : +1.132% | 
string-base64.js | 2.088 -> 2.082 : +0.259% | 
string-fasta.js | 1.858 -> 1.831 : +1.443% | 
Geometric mean: | +0.862% | 
