### PR TITLE
More gc-friendly property hashmap allocation.

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.h
+++ b/jerry-core/ecma/base/ecma-gc.h
@@ -30,7 +30,7 @@ extern void ecma_gc_init (void);
 extern void ecma_init_gc_info (ecma_object_t *);
 extern void ecma_ref_object (ecma_object_t *);
 extern void ecma_deref_object (ecma_object_t *);
-extern void ecma_gc_run (void);
+extern void ecma_gc_run (jmem_free_unused_memory_severity_t);
 extern void ecma_free_unused_memory (jmem_free_unused_memory_severity_t);
 
 /**

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -54,7 +54,7 @@ ecma_finalize (void)
 
   ecma_finalize_environment ();
   ecma_finalize_builtins ();
-  ecma_gc_run ();
+  ecma_gc_run (JMEM_FREE_UNUSED_MEMORY_SEVERITY_LOW);
   ecma_finalize_lit_storage ();
 } /* ecma_finalize */
 

--- a/jerry-core/ecma/base/ecma-property-hashmap.c
+++ b/jerry-core/ecma/base/ecma-property-hashmap.c
@@ -110,7 +110,13 @@ ecma_property_hashmap_create (ecma_object_t *object_p) /**< object */
 
   size_t total_size = ECMA_PROPERTY_HASHMAP_GET_TOTAL_SIZE (max_property_count);
 
-  ecma_property_hashmap_t *hashmap_p = (ecma_property_hashmap_t *) jmem_heap_alloc_block (total_size);
+  ecma_property_hashmap_t *hashmap_p = (ecma_property_hashmap_t *) jmem_heap_alloc_block_null_on_error (total_size);
+
+  if (hashmap_p == NULL)
+  {
+    return;
+  }
+
   memset (hashmap_p, 0, total_size);
 
   hashmap_p->header.types[0].type_and_flags = ECMA_PROPERTY_TYPE_HASHMAP;

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -224,7 +224,7 @@ jerry_gc (void)
 {
   jerry_assert_api_available ();
 
-  ecma_gc_run ();
+  ecma_gc_run (JMEM_FREE_UNUSED_MEMORY_SEVERITY_LOW);
 } /* jerry_gc */
 
 /**

--- a/jerry-core/jmem/jmem-heap.h
+++ b/jerry-core/jmem/jmem-heap.h
@@ -32,6 +32,7 @@
 extern void jmem_heap_init (void);
 extern void jmem_heap_finalize (void);
 extern void *jmem_heap_alloc_block (const size_t);
+extern void *jmem_heap_alloc_block_null_on_error (const size_t);
 extern void jmem_heap_free_block (void *, const size_t);
 extern void *jmem_heap_alloc_block_store_size (size_t);
 extern void jmem_heap_free_block_size_stored (void *);


### PR DESCRIPTION
- New allocator is added that returns null on out of memory, property hasmap create function uses this allocator for now.
- Property hashmaps of objects are removed durring a high severity gc.

A follow up patch is in progress.

JerryScript-DCO-1.0-Signed-off-by: István Kádár ikadar@inf.u-szeged.hu