### PR TITLE
targets/zephyr: REPL: Print expression result, or exception value.

### DIFF
--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -44,6 +44,7 @@ ifndef ZEPHYR_BASE
 $(error Missing Zephyr base, did you source zephyr-env.sh? )
 endif
 
+# -cp is required for user-friendly error messages in REPL
 VARIETY ?= -cp_minimal
 
 INTERM     = build/$(BOARD)/obj-$(BOARD)


### PR DESCRIPTION
With this change, REPL works almost the same as a standard JS REPL does
(browser console, Node.js, etc.). A result of each expression is
printed, e.g. "2+2" will print "4". Result is printed even if its
value is "undefined", e.g. "print(1)" will print "1", and on the next
line "undefined" (which is again how "normal" JS console work, except
a normal JS way to print to console is console.log()).

If an exception occured, a message "Error executing statement:", followed
by external representation of exception object, is printed. Note that
distinctive exception objects are supported only in "cp" (compact profile),
not in "cp_minimal". In the latter case, there's only exception hierarchy
top-level prototype, so any error message will look like:

    Error executing statement: [object Function]

(That's the reason why there's error message prefix - so it weren't too
confusing even if used in cp_minimal config. Unfortunately, compile-time
JerryScript configuration isn't available to Zephyr's main.c, so there's
no easy way to implement cp vs cp_minimal distinction).

JerryScript-DCO-1.0-Signed-off-by: Paul Sokolovsky paul.sokolovsky@linaro.org