### PR TITLE
Improve resolve reference.

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -74,29 +74,19 @@ ecma_op_object_get (ecma_object_t *obj_p, /**< the object */
 
   const ecma_object_type_t type = ecma_get_object_type (obj_p);
 
-  switch (type)
+  if (unlikely (type == ECMA_OBJECT_TYPE_ARGUMENTS))
   {
-    case ECMA_OBJECT_TYPE_GENERAL:
-    case ECMA_OBJECT_TYPE_FUNCTION:
-    case ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION:
-    case ECMA_OBJECT_TYPE_ARRAY:
-    case ECMA_OBJECT_TYPE_STRING:
-    case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
-    {
-      return ecma_op_general_object_get (obj_p, property_name_p);
-    }
-
-    case ECMA_OBJECT_TYPE_ARGUMENTS:
-    {
-      return ecma_op_arguments_object_get (obj_p, property_name_p);
-    }
-    default:
-    {
-      JERRY_ASSERT (false);
-
-      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
-    }
+    return ecma_op_arguments_object_get (obj_p, property_name_p);
   }
+
+  JERRY_ASSERT (type == ECMA_OBJECT_TYPE_GENERAL
+                || type == ECMA_OBJECT_TYPE_FUNCTION
+                || type == ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION
+                || type == ECMA_OBJECT_TYPE_ARRAY
+                || type == ECMA_OBJECT_TYPE_STRING
+                || type == ECMA_OBJECT_TYPE_BOUND_FUNCTION);
+
+  return ecma_op_general_object_get (obj_p, property_name_p);
 } /* ecma_op_object_get */
 
 /**

--- a/jerry-core/ecma/operations/ecma-reference.c
+++ b/jerry-core/ecma/operations/ecma-reference.c
@@ -15,6 +15,7 @@
  */
 
 #include "ecma-exceptions.h"
+#include "ecma-function-object.h"
 #include "ecma-gc.h"
 #include "ecma-globals.h"
 #include "ecma-helpers.h"
@@ -106,9 +107,24 @@ ecma_op_resolve_reference_value (ecma_object_t *lex_env_p, /**< starting lexical
 
       ecma_property_t *property_p = ecma_op_object_get_property (binding_obj_p, name_p);
 
-      if (property_p != NULL)
+      if (likely (property_p != NULL))
       {
-        return ecma_op_object_get (binding_obj_p, name_p);
+        if (ECMA_PROPERTY_GET_TYPE (property_p) == ECMA_PROPERTY_TYPE_NAMEDDATA)
+        {
+          return ecma_fast_copy_value (ecma_get_named_data_property_value (property_p));
+        }
+
+        ecma_object_t *getter_p = ecma_get_named_accessor_property_getter (property_p);
+
+        if (getter_p == NULL)
+        {
+          return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+        }
+
+        return ecma_op_function_call (getter_p,
+                                      ecma_make_object_value (binding_obj_p),
+                                      NULL,
+                                      0);
       }
     }
 


### PR DESCRIPTION
Simple patch, but 17% improvement on bitops-bitwise-and.js.

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 0.950 -> 0.944 : +0.690% | 
3d-raytrace.js | 1.132 -> 1.115 : +1.506% | 
access-binary-trees.js | 0.588 -> 0.582 : +1.004% | 
access-fannkuch.js | 2.371 -> 2.361 : +0.424% | 
access-nbody.js | 1.070 -> 1.065 : +0.491% | 
bitops-3bit-bits-in-byte.js | 0.582 -> 0.582 : +0.003% | 
bitops-bits-in-byte.js | 0.869 -> 0.868 : +0.059% | 
bitops-bitwise-and.js | 1.142 -> 0.938 : +17.802% | 
bitops-nsieve-bits.js | 1.810 -> 1.800 : +0.545% | 
controlflow-recursive.js | 0.401 -> 0.380 : +5.430% | 
crypto-aes.js | 1.140 -> 1.114 : +2.210% | 
crypto-md5.js | 0.753 -> 0.734 : +2.542% | 
crypto-sha1.js | 0.714 -> 0.696 : +2.495% | 
date-format-tofte.js | 0.879 -> 0.866 : +1.455% | 
date-format-xparb.js | 0.476 -> 0.456 : +4.267% | 
math-cordic.js | 1.351 -> 1.319 : +2.370% | 
math-partial-sums.js | 0.723 -> 0.692 : +4.258% | 
math-spectral-norm.js | 0.598 -> 0.584 : +2.307% | 
string-base64.js | 2.075 -> 2.050 : +1.179% | 
string-fasta.js | 1.814 -> 1.763 : +2.820% | 
Geometric mean: | +2.772% | 
