### PR TITLE
Move log level to default port

### DIFF
--- a/jerry-core/jerry-api.h
+++ b/jerry-core/jerry-api.h
@@ -156,14 +156,6 @@ typedef bool (*jerry_object_property_foreach_t) (const jerry_value_t property_na
                                                  const jerry_value_t property_value,
                                                  void *user_data_p);
 
-
-/**
- * Logger
- */
-#ifdef JERRY_ENABLE_LOG
-extern int jerry_debug_level;
-#endif /* JERRY_ENABLE_LOG */
-
 /**
  * General engine functions
  */

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -79,15 +79,6 @@ static const char *wrong_args_msg_p = "wrong type of argument";
  * @{
  */
 
-#ifdef JERRY_ENABLE_LOG
-
-/**
- * Verbosity level of logging
- */
-int jerry_debug_level = 0;
-
-#endif /* JERRY_ENABLE_LOG */
-
 /**
  * Assert that it is correct to call API in current state.
  *

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -83,19 +83,8 @@ extern void __noreturn jerry_unimplemented (const char *, const char *, const ch
 #define JERRY_UNUSED(x) ((void) (x))
 
 #ifdef JERRY_ENABLE_LOG
-#define JERRY_LOG(lvl, ...) \
-  do \
-  { \
-    if (lvl <= jerry_debug_level) \
-    { \
-      jerry_port_log (JERRY_LOG_LEVEL_DEBUG, __VA_ARGS__); \
-    } \
-  } \
-  while (0)
-
-#define JERRY_DLOG(...) JERRY_LOG (1, __VA_ARGS__)
-#define JERRY_DDLOG(...) JERRY_LOG (2, __VA_ARGS__)
-#define JERRY_DDDLOG(...) JERRY_LOG (3, __VA_ARGS__)
+#define JERRY_DLOG(...) jerry_port_log (JERRY_LOG_LEVEL_DEBUG, __VA_ARGS__)
+#define JERRY_DDLOG(...) jerry_port_log (JERRY_LOG_LEVEL_TRACE, __VA_ARGS__)
 #else /* !JERRY_ENABLE_LOG */
 #define JERRY_DLOG(...) \
   do \
@@ -106,7 +95,6 @@ extern void __noreturn jerry_unimplemented (const char *, const char *, const ch
     } \
   } while (0)
 #define JERRY_DDLOG(...) JERRY_DLOG (__VA_ARGS__)
-#define JERRY_DDDLOG(...) JERRY_DLOG (__VA_ARGS__)
 #endif /* JERRY_ENABLE_LOG */
 
 #define JERRY_ERROR_MSG(...) jerry_port_log (JERRY_LOG_LEVEL_ERROR, __VA_ARGS__)

--- a/main-unix.c
+++ b/main-unix.c
@@ -235,7 +235,7 @@ main (int argc,
 
 #ifdef JERRY_ENABLE_LOG
       flags |= JERRY_INIT_ENABLE_LOG;
-      jerry_debug_level = argv[i][0] - '0';
+      jerry_port_default_set_log_level (argv[i][0] - '0');
 #endif /* JERRY_ENABLE_LOG */
     }
     else if (!strcmp ("--abort-on-fail", argv[i]))

--- a/targets/default/jerry-port-default-io.c
+++ b/targets/default/jerry-port-default-io.c
@@ -16,6 +16,32 @@
 #include <stdarg.h>
 
 #include "jerry-port.h"
+#include "jerry-port-default.h"
+
+/**
+ * Actual log level
+ */
+static jerry_log_level_t jerry_log_level = JERRY_LOG_LEVEL_ERROR;
+
+/**
+ * Get the log level
+ *
+ * @return current log level
+ */
+jerry_log_level_t
+jerry_port_default_get_log_level (void)
+{
+  return jerry_log_level;
+} /* jerry_port_default_get_log_level */
+
+/**
+ * Set the log level
+ */
+void
+jerry_port_default_set_log_level (jerry_log_level_t level) /**< log level */
+{
+  jerry_log_level = level;
+} /* jerry_port_default_set_log_level */
 
 /**
  * Provide console message implementation for the engine.
@@ -38,10 +64,11 @@ jerry_port_log (jerry_log_level_t level, /**< log level */
                 const char *format, /**< format string */
                 ...)  /**< parameters */
 {
-  (void) level; /* default port implementation ignores the log level */
-
-  va_list args;
-  va_start (args, format);
-  vfprintf (stderr, format, args);
-  va_end (args);
+  if (level <= jerry_log_level)
+  {
+    va_list args;
+    va_start (args, format);
+    vfprintf (stderr, format, args);
+    va_end (args);
+  }
 } /* jerry_port_log */

--- a/targets/default/jerry-port-default.h
+++ b/targets/default/jerry-port-default.h
@@ -17,6 +17,8 @@
 #ifndef JERRY_PORT_DEFAULT_H
 #define JERRY_PORT_DEFAULT_H
 
+#include "jerry-port.h"
+
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -31,6 +33,9 @@ extern "C"
 
 void jerry_port_default_set_abort_on_fail (bool);
 bool jerry_port_default_is_abort_on_fail (void);
+
+jerry_log_level_t jerry_port_default_get_log_level (void);
+void jerry_port_default_set_log_level (jerry_log_level_t);
 
 /**
  * @}


### PR DESCRIPTION
Setting the log level should be specified by the actual port.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com