### PR TITLE
Remove arbitrary case conversion tests.

### DIFF
--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -482,13 +482,6 @@ lit_char_to_lower_case (ecma_char_t character, /**< input character value */
     return 1;
   }
 
-  if (character == 0x130)
-  {
-    output_buffer_p[0] = LIT_CHAR_LOWERCASE_I;
-    output_buffer_p[1] = 0x307;
-    return 2;
-  }
-
   output_buffer_p[0] = character;
   return 1;
 } /* lit_char_to_lower_case */
@@ -514,21 +507,6 @@ lit_char_to_upper_case (ecma_char_t character, /**< input character value */
   {
     output_buffer_p[0] = (ecma_char_t) (character - (LIT_CHAR_LOWERCASE_A - LIT_CHAR_UPPERCASE_A));
     return 1;
-  }
-
-  if (character == 0xdf)
-  {
-    output_buffer_p[0] = LIT_CHAR_UPPERCASE_S;
-    output_buffer_p[1] = LIT_CHAR_UPPERCASE_S;
-    return 2;
-  }
-
-  if (character == 0x1fd7)
-  {
-    output_buffer_p[0] = 0x399;
-    output_buffer_p[1] = 0x308;
-    output_buffer_p[2] = 0x342;
-    return 3;
   }
 
   output_buffer_p[0] = character;

--- a/tests/jerry/string-upper-lower-case-conversion.js
+++ b/tests/jerry/string-upper-lower-case-conversion.js
@@ -20,14 +20,6 @@ assert ("0123456789abcdefghijklmnopqrstuvwxzyABCDEFGHIJKLMNOPQRSTUVWXYZ".toLower
 assert ("0123456789abcdefghijklmnopqrstuvwxzyABCDEFGHIJKLMNOPQRSTUVWXYZ".toUpperCase()
         == "0123456789ABCDEFGHIJKLMNOPQRSTUVWXZYABCDEFGHIJKLMNOPQRSTUVWXYZ");
 
-assert ("\u0130".toLowerCase() == "i\u0307");
-assert ("\xdf".toUpperCase() == "SS");
-assert ("\u1fd7".toUpperCase() == "\u0399\u0308\u0342");
-
-assert ("H\u0130-+".toLowerCase() == "hi\u0307-+");
-assert ("\xdf\u1fd7\xdf".toUpperCase() == "SS\u0399\u0308\u0342SS");
-assert ("\u0130\u0130\u0130".toLowerCase() == "i\u0307i\u0307i\u0307");
-
 // Although codepoint 0x10400 and 0x10428 are an upper-lowercase pair,
 // we must not do their conversion in JavaScript. We must also ignore
 // stray surrogates.


### PR DESCRIPTION
Since upper/lower case conversions are unspecified by the standard,
we convert ASCII characters only, and a few other characters for
testing purposes. Because these are just random cases, it is better
to remove them before the release. At some point we could add a
unicode compatible case conversion which can be enabled at compile
time.