### PR TITLE
Fix bug in jerry_string_to_char_buffer.

### DIFF
--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -999,7 +999,7 @@ jerry_string_to_char_buffer (const jerry_value_t value, /**< input string value 
 
   ecma_string_t *str_p = ecma_get_string_from_value (value);
 
-  if (ecma_string_get_size (str_p) < buffer_size)
+  if (ecma_string_get_size (str_p) > buffer_size)
   {
     return 0;
   }

--- a/tests/unit/test-api.c
+++ b/tests/unit/test-api.c
@@ -187,30 +187,31 @@ foreach (const jerry_value_t name, /**< field name */
   jerry_size_t sz = jerry_string_to_char_buffer (name, (jerry_char_t *) str_buf_p, 128);
   str_buf_p[sz] = '\0';
 
-  if (sz == 0)
-  {
-    JERRY_ASSERT (!strncmp ((const char *) user_data, "user_data", 9));
-    return true;
-  }
+  JERRY_ASSERT (!strncmp ((const char *) user_data, "user_data", 9));
+  JERRY_ASSERT (sz > 0);
 
   if (!strncmp (str_buf_p, "alpha", (size_t) sz))
   {
     JERRY_ASSERT (jerry_value_is_number (value));
     JERRY_ASSERT (jerry_get_number_value (value) == 32.0);
+    return true;
   }
   else if (!strncmp (str_buf_p, "bravo", (size_t) sz))
   {
     JERRY_ASSERT (jerry_value_is_boolean (value));
     JERRY_ASSERT (jerry_get_boolean_value (value) == false);
+    return true;
   }
   else if (!strncmp (str_buf_p, "charlie", (size_t) sz))
   {
     JERRY_ASSERT (jerry_value_is_object (value));
+    return true;
   }
   else if (!strncmp (str_buf_p, "delta", (size_t) sz))
   {
     JERRY_ASSERT (jerry_value_is_number (value));
     JERRY_ASSERT (jerry_get_number_value (value) == 123.45);
+    return true;
   }
   else if (!strncmp (str_buf_p, "echo", (size_t) sz))
   {
@@ -220,6 +221,7 @@ foreach (const jerry_value_t name, /**< field name */
                                                         128);
     str_buf_p[echo_sz] = '\0';
     JERRY_ASSERT (!strncmp (str_buf_p, "foobar", (size_t) echo_sz));
+    return true;
   }
 
   JERRY_ASSERT (false);


### PR DESCRIPTION
Str_len can smaller than buffer_size.

```
  if (ecma_string_get_size (str_p) > buffer_size)
  {
    return 0;
  }
```
It should be ">" in the comparison.

And also change the related code in unit-test-api.c. 
Before, in the `foreach`, it only sunk into
```
  if (sz == 0)
  {
    JERRY_ASSERT (!strncmp ((const char *) user_data, "user_data", 9));
    return true;
  }
```

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com