### PR TITLE
fix bug of "deref bytecode twice" in jerry_exec_snapshot

### DIFF
--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -2266,13 +2266,13 @@ jerry_exec_snapshot (const void *snapshot_p, /**< snapshot */
   if (header_p->is_run_global)
   {
     ret_val = vm_run_global (bytecode_p);
+    ecma_bytecode_deref (bytecode_p);
   }
   else
   {
     ret_val = vm_run_eval (bytecode_p, false);
   }
 
-  ecma_bytecode_deref (bytecode_p);
   return ret_val;
 #else /* !JERRY_ENABLE_SNAPSHOT_EXEC */
   JERRY_UNUSED (snapshot_p);

--- a/tests/unit/test-api.c
+++ b/tests/unit/test-api.c
@@ -725,8 +725,7 @@ main (void)
   jerry_cleanup ();
 
   // Dump / execute snapshot
-  // FIXME: support save/load snapshot for optimized parser
-  if (false)
+  if (true)
   {
     static uint8_t global_mode_snapshot_buffer[1024];
     static uint8_t eval_mode_snapshot_buffer[1024];
@@ -760,8 +759,13 @@ main (void)
                                false);
 
     JERRY_ASSERT (!jerry_value_has_error_flag (res));
-    JERRY_ASSERT (jerry_value_is_undefined (res));
+    JERRY_ASSERT (jerry_value_is_string (res));
+    sz = jerry_get_string_size (res);
+    JERRY_ASSERT (sz == 20);
+    sz = jerry_string_to_char_buffer (res, (jerry_char_t *) buffer, sz);
+    JERRY_ASSERT (sz == 20);
     jerry_release_value (res);
+    JERRY_ASSERT (!strncmp (buffer, "string from snapshot", (size_t) sz));
 
     res = jerry_exec_snapshot (eval_mode_snapshot_buffer,
                                eval_mode_snapshot_size,


### PR DESCRIPTION
in `jerry_exec_snapshot`, if the snapshot is is_run_eval, then the bytecode will deref in `vm_run_eval`. The `jerry_exec_snapshot` shouldn't call deref function after `vm_run_eval`.

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com