### PR TITLE
Move built-in, external string, and interpreter globals to the global context

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -161,19 +161,6 @@ ecma_deref_object (ecma_object_t *object_p) /**< object */
 } /* ecma_deref_object */
 
 /**
- * Initialize garbage collector
- */
-void
-ecma_gc_init (void)
-{
-  JERRY_CONTEXT (ecma_gc_objects_lists) [ECMA_GC_COLOR_WHITE_GRAY] = NULL;
-  JERRY_CONTEXT (ecma_gc_objects_lists) [ECMA_GC_COLOR_BLACK] = NULL;
-  JERRY_CONTEXT (ecma_gc_visited_flip_flag) = false;
-  JERRY_CONTEXT (ecma_gc_objects_number) = 0;
-  JERRY_CONTEXT (ecma_gc_new_objects) = 0;
-} /* ecma_gc_init */
-
-/**
  * Mark referenced object from property
  */
 static void

--- a/jerry-core/ecma/base/ecma-gc.h
+++ b/jerry-core/ecma/base/ecma-gc.h
@@ -26,7 +26,6 @@
  * @{
  */
 
-extern void ecma_gc_init (void);
 extern void ecma_init_gc_info (ecma_object_t *);
 extern void ecma_ref_object (ecma_object_t *);
 extern void ecma_deref_object (ecma_object_t *);

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -35,10 +35,7 @@
 void
 ecma_init (void)
 {
-  ecma_gc_init ();
-  ecma_init_builtins ();
   ecma_lcache_init ();
-  ecma_init_lit_storage ();
   ecma_init_global_lex_env ();
 
   jmem_register_free_unused_memory_callback (ecma_free_unused_memory);

--- a/jerry-core/ecma/base/ecma-literal-storage.c
+++ b/jerry-core/ecma/base/ecma-literal-storage.c
@@ -29,16 +29,6 @@ JERRY_STATIC_ASSERT (sizeof (ecma_lit_storage_item_t) <= sizeof (uint64_t),
                      size_of_ecma_lit_storage_item_t_must_be_less_than_or_equal_to_8_bytes);
 
 /**
- * Initialize literal storage
- */
-void
-ecma_init_lit_storage (void)
-{
-  JERRY_CONTEXT (string_list_first_p) = NULL;
-  JERRY_CONTEXT (number_list_first_p) = NULL;
-} /* ecma_init_lit_storage */
-
-/**
  * Free string list
  */
 static void

--- a/jerry-core/ecma/base/ecma-literal-storage.h
+++ b/jerry-core/ecma/base/ecma-literal-storage.h
@@ -37,7 +37,6 @@ typedef struct
   jmem_cpointer_t literal_offset; /**< literal offset */
 } lit_mem_to_snapshot_id_map_entry_t;
 
-extern void ecma_init_lit_storage (void);
 extern void ecma_finalize_lit_storage (void);
 
 extern jmem_cpointer_t ecma_find_or_create_literal_string (const lit_utf8_byte_t *, lit_utf8_size_t);

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -50,7 +50,6 @@ typedef enum
 #define ECMA_GET_ROUTINE_ID(value) ((uint16_t) ((value) >> 4))
 
 /* ecma-builtins.c */
-extern void ecma_init_builtins (void);
 extern void ecma_finalize_builtins (void);
 
 extern ecma_value_t

--- a/jerry-core/jmem/jmem-allocator.c
+++ b/jerry-core/jmem/jmem-allocator.c
@@ -34,7 +34,6 @@ void
 jmem_init (void)
 {
   jmem_heap_init ();
-  jmem_pools_init ();
 } /* jmem_init */
 
 /**

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -150,9 +150,7 @@ jmem_heap_init (void)
 
   JERRY_ASSERT ((uintptr_t) JERRY_HEAP_CONTEXT (area) % JMEM_ALIGNMENT == 0);
 
-  JERRY_CONTEXT (jmem_heap_allocated_size) = 0;
   JERRY_CONTEXT (jmem_heap_limit) = CONFIG_MEM_HEAP_DESIRED_LIMIT;
-  JERRY_CONTEXT (jmem_free_unused_memory_callback) = NULL;
 
   jmem_heap_free_t *const region_p = (jmem_heap_free_t *) JERRY_HEAP_CONTEXT (area);
 
@@ -163,10 +161,6 @@ jmem_heap_init (void)
   JERRY_HEAP_CONTEXT (first).next_offset = JMEM_HEAP_GET_OFFSET_FROM_ADDR (region_p);
 
   JERRY_CONTEXT (jmem_heap_list_skip_p) = &JERRY_HEAP_CONTEXT (first);
-
-#ifdef JERRY_VALGRIND_FREYA
-  JERRY_CONTEXT (valgrind_freya_mempool_request) = false;
-#endif /* JERRY_VALGRIND_FREYA */
 
   VALGRIND_NOACCESS_SPACE (JERRY_HEAP_CONTEXT (area), JMEM_HEAP_AREA_SIZE);
 
@@ -681,8 +675,6 @@ jmem_heap_stats_print (void)
 static void
 jmem_heap_stat_init ()
 {
-  memset (&JERRY_CONTEXT (jmem_heap_stats), 0, sizeof (jmem_heap_stats_t));
-
   JERRY_CONTEXT (jmem_heap_stats).size = JMEM_HEAP_AREA_SIZE;
 } /* jmem_heap_stat_init */
 

--- a/jerry-core/jmem/jmem-poolman.c
+++ b/jerry-core/jmem/jmem-poolman.c
@@ -36,19 +36,16 @@
 
 #ifdef JMEM_STATS
 
-static void jmem_pools_stat_init (void);
 static void jmem_pools_stat_free_pool (void);
 static void jmem_pools_stat_new_alloc (void);
 static void jmem_pools_stat_reuse (void);
 static void jmem_pools_stat_dealloc (void);
 
-#  define JMEM_POOLS_STAT_INIT() jmem_pools_stat_init ()
 #  define JMEM_POOLS_STAT_FREE_POOL() jmem_pools_stat_free_pool ()
 #  define JMEM_POOLS_STAT_NEW_ALLOC() jmem_pools_stat_new_alloc ()
 #  define JMEM_POOLS_STAT_REUSE() jmem_pools_stat_reuse ()
 #  define JMEM_POOLS_STAT_DEALLOC() jmem_pools_stat_dealloc ()
 #else /* !JMEM_STATS */
-#  define JMEM_POOLS_STAT_INIT()
 #  define JMEM_POOLS_STAT_FREE_POOL()
 #  define JMEM_POOLS_STAT_NEW_ALLOC()
 #  define JMEM_POOLS_STAT_REUSE()
@@ -80,19 +77,8 @@ static void jmem_pools_stat_dealloc (void);
 # define VALGRIND_FREYA_FREELIKE_SPACE(p)
 #endif /* JERRY_VALGRIND_FREYA */
 
-/**
- * Initialize pool manager
- */
-void
-jmem_pools_init (void)
-{
-  JERRY_STATIC_ASSERT (sizeof (jmem_pools_chunk_t) <= JMEM_POOL_CHUNK_SIZE,
-                       size_of_mem_pools_chunk_t_must_be_less_than_or_equal_to_MEM_POOL_CHUNK_SIZE);
-
-  JERRY_CONTEXT (jmem_free_chunk_p) = NULL;
-
-  JMEM_POOLS_STAT_INIT ();
-} /* jmem_pools_init */
+JERRY_STATIC_ASSERT (sizeof (jmem_pools_chunk_t) <= JMEM_POOL_CHUNK_SIZE,
+                     size_of_mem_pools_chunk_t_must_be_less_than_or_equal_to_MEM_POOL_CHUNK_SIZE);
 
 /**
  * Finalize pool manager
@@ -218,15 +204,6 @@ jmem_pools_stats_print (void)
                   pools_stats->reused_count / pools_stats->new_alloc_count,
                   pools_stats->reused_count % pools_stats->new_alloc_count * 10000 / pools_stats->new_alloc_count);
 } /* jmem_pools_stats_print */
-
-/**
- * Initalize pools' memory usage statistics account structure
- */
-static void
-jmem_pools_stat_init (void)
-{
-  memset (&JERRY_CONTEXT (jmem_pools_stats), 0, sizeof (jmem_pools_stats_t));
-} /* jmem_pools_stat_init */
 
 /**
  * Account for allocation of new pool chunk

--- a/jerry-core/jmem/jmem-poolman.h
+++ b/jerry-core/jmem/jmem-poolman.h
@@ -29,7 +29,6 @@
  * @{
  */
 
-extern void jmem_pools_init (void);
 extern void jmem_pools_finalize (void);
 extern void *jmem_pools_alloc (void);
 extern void jmem_pools_free (void *);

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -13,27 +13,9 @@
  * limitations under the License.
  */
 
+#include "jcontext.h"
 #include "lit-magic-strings.h"
-
 #include "lit-strings.h"
-
-/**
- * External magic strings data array, count and lengths
- */
-static const lit_utf8_byte_t **lit_magic_string_ex_array = NULL;
-static uint32_t lit_magic_string_ex_count = 0;
-static const lit_utf8_size_t *lit_magic_string_ex_sizes = NULL;
-
-/**
- * Initialize external magic strings
- */
-void
-lit_magic_strings_ex_init (void)
-{
-  lit_magic_string_ex_array = NULL;
-  lit_magic_string_ex_count = 0;
-  lit_magic_string_ex_sizes = NULL;
-} /* lit_magic_strings_ex_init */
 
 /**
  * Get number of external magic strings
@@ -44,7 +26,7 @@ lit_magic_strings_ex_init (void)
 uint32_t
 lit_get_magic_string_ex_count (void)
 {
-  return lit_magic_string_ex_count;
+  return JERRY_CONTEXT (lit_magic_string_ex_count);
 } /* lit_get_magic_string_ex_count */
 
 /**
@@ -97,9 +79,9 @@ lit_get_magic_string_size (lit_magic_string_id_t id) /**< magic string id */
 const lit_utf8_byte_t *
 lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t id) /**< extern magic string id */
 {
-  if (lit_magic_string_ex_array && id < lit_magic_string_ex_count)
+  if (JERRY_CONTEXT (lit_magic_string_ex_array) && id < JERRY_CONTEXT (lit_magic_string_ex_count))
   {
-    return lit_magic_string_ex_array[id];
+    return JERRY_CONTEXT (lit_magic_string_ex_array)[id];
   }
 
   JERRY_UNREACHABLE ();
@@ -113,7 +95,7 @@ lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t id) /**< extern magic str
 lit_utf8_size_t
 lit_get_magic_string_ex_size (lit_magic_string_ex_id_t id) /**< external magic string id */
 {
-  return lit_magic_string_ex_sizes[id];
+  return JERRY_CONTEXT (lit_magic_string_ex_sizes)[id];
 } /* lit_get_magic_string_ex_size */
 
 /**
@@ -129,22 +111,23 @@ lit_magic_strings_ex_set (const lit_utf8_byte_t **ex_str_items, /**< character a
   JERRY_ASSERT (count > 0);
   JERRY_ASSERT (ex_str_sizes != NULL);
 
-  JERRY_ASSERT (lit_magic_string_ex_array == NULL);
-  JERRY_ASSERT (lit_magic_string_ex_count == 0);
-  JERRY_ASSERT (lit_magic_string_ex_sizes == NULL);
+  JERRY_ASSERT (JERRY_CONTEXT (lit_magic_string_ex_array) == NULL);
+  JERRY_ASSERT (JERRY_CONTEXT (lit_magic_string_ex_count) == 0);
+  JERRY_ASSERT (JERRY_CONTEXT (lit_magic_string_ex_sizes) == NULL);
 
   /* Set external magic strings information */
-  lit_magic_string_ex_array = ex_str_items;
-  lit_magic_string_ex_count = count;
-  lit_magic_string_ex_sizes = ex_str_sizes;
+  JERRY_CONTEXT (lit_magic_string_ex_array) = ex_str_items;
+  JERRY_CONTEXT (lit_magic_string_ex_count) = count;
+  JERRY_CONTEXT (lit_magic_string_ex_sizes) = ex_str_sizes;
 
 #ifndef JERRY_NDEBUG
   for (lit_magic_string_ex_id_t id = (lit_magic_string_ex_id_t) 0;
-       id < lit_magic_string_ex_count;
+       id < JERRY_CONTEXT (lit_magic_string_ex_count);
        id = (lit_magic_string_ex_id_t) (id + 1))
   {
-    JERRY_ASSERT (lit_magic_string_ex_sizes[id] == lit_zt_utf8_string_size (lit_get_magic_string_ex_utf8 (id)));
-    JERRY_ASSERT (lit_magic_string_ex_sizes[id] <= LIT_MAGIC_STRING_LENGTH_LIMIT);
+    lit_utf8_size_t string_size = lit_zt_utf8_string_size (lit_get_magic_string_ex_utf8 (id));
+    JERRY_ASSERT (JERRY_CONTEXT (lit_magic_string_ex_sizes)[id] == string_size);
+    JERRY_ASSERT (JERRY_CONTEXT (lit_magic_string_ex_sizes)[id] <= LIT_MAGIC_STRING_LENGTH_LIMIT);
   }
 #endif /* !JERRY_NDEBUG */
 } /* lit_magic_strings_ex_set */
@@ -195,7 +178,7 @@ bool lit_is_ex_utf8_string_magic (const lit_utf8_byte_t *string_p, /**< utf-8 st
   /* TODO: Improve performance of search */
 
   for (lit_magic_string_ex_id_t id = (lit_magic_string_ex_id_t) 0;
-       id < lit_magic_string_ex_count;
+       id < JERRY_CONTEXT (lit_magic_string_ex_count);
        id = (lit_magic_string_ex_id_t) (id + 1))
   {
     if (lit_compare_utf8_string_and_magic_string_ex (string_p, string_size, id))
@@ -206,7 +189,7 @@ bool lit_is_ex_utf8_string_magic (const lit_utf8_byte_t *string_p, /**< utf-8 st
     }
   }
 
-  *out_id_p = lit_magic_string_ex_count;
+  *out_id_p = JERRY_CONTEXT (lit_magic_string_ex_count);
 
   return false;
 } /* lit_is_ex_utf8_string_magic */

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -41,8 +41,6 @@ typedef enum
  */
 typedef uint32_t lit_magic_string_ex_id_t;
 
-extern void lit_magic_strings_ex_init (void);
-
 extern uint32_t lit_get_magic_string_ex_count (void);
 
 extern const lit_utf8_byte_t *lit_get_magic_string_utf8 (lit_magic_string_id_t);

--- a/tests/unit/test-literal-storage.c
+++ b/tests/unit/test-literal-storage.c
@@ -65,7 +65,6 @@ main ()
   lit_utf8_size_t lengths[test_sub_iters];
 
   jmem_init ();
-  ecma_init_lit_storage ();
 
   for (uint32_t i = 0; i < test_iters; i++)
   {


### PR DESCRIPTION
There are still globals left.