### PR TITLE
Initial RAM optimization for ESP8266

### DIFF
--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -40,6 +40,17 @@
 # define __attr_pure___ __attribute__((pure))
 #endif /* !__attr_pure___ */
 
+/**
+ * Normally compilers store const(ant)s in ROM. Thus saving RAM.
+ * But if your compiler does not support it then the directive below can force it.
+ *
+ * For the moment it is mainly meant for the following targets:
+ *      - ESP8266
+ */
+#ifndef JERRY_CONST_DATA
+# define JERRY_CONST_DATA
+#endif /* JERRY_CONST_DATA */
+
 #ifndef __GNUC__
 #define __extension__
 #endif /* !__GNUC__ */

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -37,7 +37,7 @@ lit_get_magic_string_ex_count (void)
 const lit_utf8_byte_t *
 lit_get_magic_string_utf8 (lit_magic_string_id_t id) /**< magic string id */
 {
-  static const lit_utf8_byte_t * const magic_strings[] =
+  static const lit_utf8_byte_t * const magic_strings[] JERRY_CONST_DATA =
   {
 #define LIT_MAGIC_STRING_DEF(id, utf8_string) \
     (const lit_utf8_byte_t *) utf8_string,
@@ -58,7 +58,7 @@ lit_get_magic_string_utf8 (lit_magic_string_id_t id) /**< magic string id */
 lit_utf8_size_t
 lit_get_magic_string_size (lit_magic_string_id_t id) /**< magic string id */
 {
-  static const lit_magic_size_t lit_magic_string_sizes[] =
+  static const lit_magic_size_t lit_magic_string_sizes[] JERRY_CONST_DATA =
   {
 #define LIT_MAGIC_STRING_DEF(id, utf8_string) \
     sizeof(utf8_string) - 1,

--- a/jerry-core/lit/lit-unicode-ranges.inc.h
+++ b/jerry-core/lit/lit-unicode-ranges.inc.h
@@ -30,7 +30,7 @@
  * The characters covered by these intervalse are from
  * the following Unicode categories: Lu, Ll, Lt, Lm, Lo, Nl
  */
-static const uint16_t unicode_letter_interv_sps[] =
+static const uint16_t unicode_letter_interv_sps[] JERRY_CONST_DATA =
 {
 /*
  * these are handled separetely
@@ -67,7 +67,7 @@ static const uint16_t unicode_letter_interv_sps[] =
  * The characters covered by these intervalse are from
  * the following Unicode categories: Lu, Ll, Lt, Lm, Lo, Nl
  */
-static const uint8_t unicode_letter_interv_lens[] =
+static const uint8_t unicode_letter_interv_lens[] JERRY_CONST_DATA =
 {
   22, 30, 255, 39, 17, 93, 8, 6,
   1, 4, 2, 19, 43, 7, 25, 129, 56, 1,
@@ -100,7 +100,7 @@ static const uint8_t unicode_letter_interv_lens[] =
  * The characters are from the following Unicode categories:
  * Lu, Ll, Lt, Lm, Lo, Nl
  */
-static const uint16_t unicode_letter_chars[] =
+static const uint16_t unicode_letter_chars[] JERRY_CONST_DATA =
 {
   0x00AA, 0x00B5, 0x00BA, 0x02EE, 0x037A, 0x0386, 0x038C, 0x0559, 0x06D5, 0x0710,
   0x093D, 0x0950, 0x09B2, 0x0A5E, 0x0A8D, 0x0ABD, 0x0AD0, 0x0AE0, 0x0B3D, 0x0B9C,
@@ -117,7 +117,7 @@ static const uint16_t unicode_letter_chars[] =
  * The characters covered by these intervalse are from
  * the following Unicode categories: Nd, Mn, Mc, Pc
  */
-static const uint16_t unicode_non_letter_ident_part_interv_sps[] =
+static const uint16_t unicode_non_letter_ident_part_interv_sps[] JERRY_CONST_DATA =
 {
 /*
  * decimal digits: handled separately

--- a/jerry-core/parser/js/byte-code.c
+++ b/jerry-core/parser/js/byte-code.c
@@ -32,7 +32,7 @@
 /**
  * Flags of the opcodes.
  */
-const uint8_t cbc_flags[] =
+const uint8_t cbc_flags[] JERRY_CONST_DATA =
 {
   CBC_OPCODE_LIST
 };

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -184,7 +184,7 @@ vm_op_set_value (ecma_value_t object, /**< base object */
 /**
  * Decode table for both opcodes and extended opcodes.
  */
-static const uint16_t vm_decode_table[] =
+static const uint16_t vm_decode_table[] JERRY_CONST_DATA =
 {
   CBC_OPCODE_LIST
   CBC_EXT_OPCODE_LIST

--- a/targets/esp8266/Makefile.esp8266
+++ b/targets/esp8266/Makefile.esp8266
@@ -30,9 +30,21 @@ ESPTOOL    ?= /opt/Espressif/esptool-py/esptool.py
 
 # compile flags
 ESP_CFLAGS := -D__TARGET_ESP8266 -D__attr_always_inline___=
+
+MFORCE32 = `xtensa-lx106-elf-gcc --help=target | grep mforce-l32`
+
+ifneq ($(MFORCE32),)
+    # Your compiler supports the -mforce-l32 flag which means that 
+    # constants can be placed in ROM to free additional RAM
+    ESP_CFLAGS += -DJERRY_CONST_DATA="__attribute__((aligned(4))) __attribute__((section(\".irom.text\")))"
+endif
+
 ESP_CFLAGS += -Wl,-EL -fno-inline-functions
 ESP_CFLAGS += -ffunction-sections -fdata-sections
 ESP_CFLAGS += -mlongcalls -mtext-section-literals -mno-serialize-volatile
+ifneq ($(MFORCE32),)
+	ESP_CFLAGS += -mforce-l32
+endif
 
 # include path
 ESP_LIBS_INC :=$(CURDIR)/targets/esp8266/include

--- a/targets/esp8266/readme.md
+++ b/targets/esp8266/readme.md
@@ -68,3 +68,46 @@ Sample program here works with LED and a SW with below connection.
 * Connect GPIO0 between VCC > 4K resistor and GND
 
 If GPIO0 is High then LED is turned on longer. If L vice versa.
+
+### 6. Optimizing initial RAM usage (ESP8266 specific)
+The existing open source gcc compiler with Xtensa support stores const(ants) in
+the same limited RAM where our code needs to run. 
+
+It is possible to force the compiler to 1)store a constant into ROM and also 2) read it from there thus saving 1.1) RAM.
+It will require two things though:
+1. To add the attribute JERRY_CONST_DATA to your constant. For example
+
+```C
+static const lit_magic_size_t lit_magic_string_sizes[] =
+```
+
+can be modified to
+
+```C
+static const lit_magic_size_t lit_magic_string_sizes[] JERRY_CONST_DATA =
+```
+
+That is already done to some constants in jerry-core. 
+
+1.1) Below is a short list:
+
+
+Bytes  | Name
+-------- | ---------
+928 | magic_strings$2428
+610 | vm_decode_table
+424 | unicode_letter_interv_sps
+235 | cbc_flags
+232 | lit_magic_string_sizes
+212 | unicode_letter_interv_len
+196 | unicode_non_letter_ident_
+112 | unicode_letter_chars
+
+Which frees 2949 bytes in RAM. 
+
+2. To compile your code with compiler that supports the `-mforce-l32` parameter. You can check if your compiler is 
+supporting that parameter by calling:
+```bash
+xtensa-lx106-elf-gcc --help=target | grep mforce-l32
+```
+If the command above does not provide a result then you will need to upgrade your compiler.


### PR DESCRIPTION
by putting big constants into ROM, instead of residing in RAM.
Related to https://github.com/Samsung/jerryscript/issues/1224.

JerryScript-DCO-1.0-Signed-off-by: Slavey Karadzhov slaff@attachix.com