### PR TITLE
Avoid `(void) ` and use `JERRY_UNUSED`

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1038,8 +1038,8 @@ ecma_assert_object_contains_the_property (const ecma_object_t *object_p, /**< ec
   JERRY_UNREACHABLE ();
 
 #else /* JERRY_NDEBUG */
-  (void) object_p;
-  (void) prop_p;
+  JERRY_UNUSED (object_p);
+  JERRY_UNUSED (prop_p);
 #endif /* !JERRY_NDEBUG */
 } /* ecma_assert_object_contains_the_property */
 

--- a/jerry-core/ecma/base/ecma-property-hashmap.c
+++ b/jerry-core/ecma/base/ecma-property-hashmap.c
@@ -209,7 +209,7 @@ ecma_property_hashmap_create (ecma_object_t *object_p) /**< object */
                                     prop_iter_p->next_property_cp);
   }
 #else /* CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
-  (void) object_p;
+  JERRY_UNUSED (object_p);
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 } /* ecma_property_hashmap_create */
 
@@ -234,7 +234,7 @@ ecma_property_hashmap_free (ecma_object_t *object_p) /**< object */
   jmem_heap_free_block (hashmap_p,
                         ECMA_PROPERTY_HASHMAP_GET_TOTAL_SIZE (hashmap_p->max_property_count));
 #else /* CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
-  (void) object_p;
+  JERRY_UNUSED (object_p);
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 } /* ecma_property_hashmap_free */
 
@@ -315,10 +315,10 @@ ecma_property_hashmap_insert (ecma_object_t *object_p, /**< object */
     *bits_p = (uint8_t) ((*bits_p) | mask);
   }
 #else /* CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
-  (void) object_p;
-  (void) name_p;
-  (void) property_pair_p;
-  (void) property_index;
+  JERRY_UNUSED (object_p);
+  JERRY_UNUSED (name_p);
+  JERRY_UNUSED (property_pair_p);
+  JERRY_UNUSED (property_index);
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 } /* ecma_property_hashmap_insert */
 
@@ -394,9 +394,9 @@ ecma_property_hashmap_delete (ecma_object_t *object_p, /**< object */
 #endif /* !JERRY_NDEBUG */
   }
 #else /* CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
-  (void) object_p;
-  (void) name_p;
-  (void) property_p;
+  JERRY_UNUSED (object_p);
+  JERRY_UNUSED (name_p);
+  JERRY_UNUSED (property_p);
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 } /* ecma_property_hashmap_delete */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
@@ -124,9 +124,9 @@ DISPATCH_ROUTINE_ROUTINE_NAME (uint16_t builtin_routine_id, /**< built-in wide r
                                                                     arguments' list */
 {
   /* the arguments may be unused for some built-ins */
-  (void) this_arg_value;
-  (void) arguments_list;
-  (void) arguments_number;
+  JERRY_UNUSED (this_arg_value);
+  JERRY_UNUSED (arguments_list);
+  JERRY_UNUSED (arguments_number);
 
   switch (builtin_routine_id)
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -567,7 +567,7 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
       && ecma_builtin_function_is_routine (object_p))
   {
     ecma_collection_header_t *for_enumerable_p = main_collection_p;
-    (void) for_enumerable_p;
+    JERRY_UNUSED (for_enumerable_p);
 
     ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? non_enum_collection_p : main_collection_p;
 

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -85,7 +85,7 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
     }
   }
 #else
-  (void) error_type;
+  JERRY_UNUSED (error_type);
   ecma_builtin_id_t prototype_id = ECMA_BUILTIN_ID_ERROR_PROTOTYPE;
 #endif /* !CONFIG_DISABLE_ERROR_BUILTINS */
 

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -248,7 +248,7 @@ ecma_op_function_list_lazy_property_names (bool separate_enumerable, /**< true -
                                                                                              *   collection */
 {
   ecma_collection_header_t *for_enumerable_p = main_collection_p;
-  (void) for_enumerable_p;
+  JERRY_UNUSED (for_enumerable_p);
 
   ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? non_enum_collection_p : main_collection_p;
 

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -233,7 +233,7 @@ ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p, /**< a String obj
   ecma_collection_header_t *for_enumerable_p = main_collection_p;
 
   ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? main_collection_p : non_enum_collection_p;
-  (void) for_non_enumerable_p;
+  JERRY_UNUSED (for_non_enumerable_p);
 
   ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
                                                                    ECMA_INTERNAL_PROPERTY_ECMA_VALUE);

--- a/jerry-core/jmem/jmem-allocator.c
+++ b/jerry-core/jmem/jmem-allocator.c
@@ -51,7 +51,7 @@ jmem_finalize (bool is_show_mem_stats) /**< show heap memory stats
     jmem_stats_print ();
   }
 #else /* !JMEM_STATS */
-  (void) is_show_mem_stats;
+  JERRY_UNUSED (is_show_mem_stats);
 #endif /* JMEM_STATS */
 
   jmem_heap_finalize ();

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -1836,7 +1836,7 @@ lexer_construct_regexp_object (parser_context_t *context_p, /**< context */
   context_p->lit_object.index = (uint16_t) (context_p->literal_count - 1);
   context_p->lit_object.type = LEXER_LITERAL_OBJECT_ANY;
 #else /* CONFIG_DISABLE_REGEXP_BUILTIN */
-  (void) parse_only;
+  JERRY_UNUSED (parse_only);
   parser_raise_error (context_p, PARSER_ERR_UNSUPPORTED_REGEXP);
 #endif /* !CONFIG_DISABLE_REGEXP_BUILTIN */
 } /* lexer_construct_regexp_object */

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -2235,7 +2235,7 @@ parser_set_show_instrs (int show_instrs) /**< flag indicating whether to dump by
 #ifdef PARSER_DUMP_BYTE_CODE
   parser_show_instrs = show_instrs;
 #else /* !PARSER_DUMP_BYTE_CODE */
-  (void) show_instrs;
+  JERRY_UNUSED (show_instrs);
 #endif /* PARSER_DUMP_BYTE_CODE */
 } /* parser_set_show_instrs */
 


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu