### PR TITLE
Integrate JS parser module better with JRT

### DIFF
--- a/jerry-core/parser/js/common.h
+++ b/jerry-core/parser/js/common.h
@@ -34,10 +34,6 @@
  */
 
 #ifndef JERRY_NDEBUG
-#define PARSER_DEBUG
-#endif /* !JERRY_NDEBUG */
-
-#ifndef JERRY_NDEBUG
 /* Note: This flag is independent from debug mode. */
 #define PARSER_DUMP_BYTE_CODE
 #endif /* !JERRY_NDEBUG */
@@ -136,11 +132,6 @@ void util_print_literal (lexer_literal_t *);
 #define PARSER_TRY_END \
     } \
   }
-
-/* Other */
-
-#define PARSER_INLINE inline
-#define PARSER_NOINLINE __attribute__ ((noinline))
 
 /**
  * @}

--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -43,7 +43,7 @@ static const uint8_t parser_binary_precedence_table[36] =
 /**
  * Generate byte code for operators with lvalue.
  */
-static PARSER_INLINE void
+static inline void
 parser_push_result (parser_context_t *context_p) /**< context */
 {
   if (CBC_NO_RESULT_COMPOUND_ASSIGMENT (context_p->last_cbc_opcode))

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -223,9 +223,9 @@ typedef struct parser_saved_context_t
   uint32_t byte_code_size;                    /**< byte code size for branches */
   parser_mem_data_t literal_pool_data;        /**< literal list */
 
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
   uint16_t context_stack_depth;               /**< current context stack depth */
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 } parser_saved_context_t;
 
 /**
@@ -271,10 +271,10 @@ typedef struct
   parser_mem_page_t *free_page_p;             /**< space for fast allocation */
   uint8_t stack_top_uint8;                    /**< top byte stored on the stack */
 
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
   /* Variables for debugging / logging. */
   uint16_t context_stack_depth;               /**< current context stack depth */
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
 #ifdef PARSER_DUMP_BYTE_CODE
   int is_show_opcodes;                        /**< show opcodes */

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -171,7 +171,7 @@ typedef struct
  *
  * @return size consumed by a statement.
  */
-static PARSER_INLINE size_t
+static inline size_t
 parser_statement_length (uint8_t type) /**< type of statement */
 {
   static const uint8_t statement_lengths[12] =
@@ -211,7 +211,7 @@ parser_statement_length (uint8_t type) /**< type of statement */
 /**
  * Initialize a range from the current location.
  */
-static PARSER_INLINE void
+static inline void
 parser_save_range (parser_context_t *context_p, /**< context */
                    lexer_range_t *range_p, /**< destination range */
                    const uint8_t *source_end_p) /**< source end */
@@ -225,7 +225,7 @@ parser_save_range (parser_context_t *context_p, /**< context */
 /**
  * Set the current location on the stack.
  */
-static PARSER_INLINE void
+static inline void
 parser_set_range (parser_context_t *context_p, /**< context */
                   lexer_range_t *range_p) /**< destination range */
 {
@@ -238,7 +238,7 @@ parser_set_range (parser_context_t *context_p, /**< context */
 /**
  * Initialize stack iterator.
  */
-static PARSER_INLINE void
+static inline void
 parser_stack_iterator_init (parser_context_t *context_p, /**< context */
                             parser_stack_iterator_t *iterator) /**< iterator */
 {
@@ -249,7 +249,7 @@ parser_stack_iterator_init (parser_context_t *context_p, /**< context */
 /**
  * Read the next byte from the stack.
  */
-static PARSER_INLINE uint8_t
+static inline uint8_t
 parser_stack_iterator_read_uint8 (parser_stack_iterator_t *iterator) /**< iterator */
 {
   JERRY_ASSERT (iterator->current_position > 0 && iterator->current_position <= PARSER_STACK_PAGE_SIZE);
@@ -259,7 +259,7 @@ parser_stack_iterator_read_uint8 (parser_stack_iterator_t *iterator) /**< iterat
 /**
  * Change last byte of the stack.
  */
-static PARSER_INLINE void
+static inline void
 parser_stack_change_last_uint8 (parser_context_t *context_p, /**< context */
                                 uint8_t new_value) /**< new value */
 {
@@ -275,7 +275,7 @@ parser_stack_change_last_uint8 (parser_context_t *context_p, /**< context */
 /**
  * Parse expression enclosed in parens.
  */
-static PARSER_INLINE void
+static inline void
 parser_parse_enclosed_expr (parser_context_t *context_p) /**< context */
 {
   lexer_next_token (context_p);
@@ -494,9 +494,9 @@ parser_parse_with_statement_start (parser_context_t *context_p) /**< context */
 
   parser_parse_enclosed_expr (context_p);
 
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
   PARSER_PLUS_EQUAL_U16 (context_p->context_stack_depth, PARSER_WITH_CONTEXT_STACK_ALLOCATION);
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
   context_p->status_flags |= PARSER_INSIDE_WITH | PARSER_LEXICAL_ENV_NEEDED;
   parser_emit_cbc_ext_forward_branch (context_p,
@@ -525,9 +525,9 @@ parser_parse_with_statement_end (parser_context_t *context_p) /**< context */
 
   parser_flush_cbc (context_p);
   PARSER_MINUS_EQUAL_U16 (context_p->stack_depth, PARSER_WITH_CONTEXT_STACK_ALLOCATION);
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
   PARSER_MINUS_EQUAL_U16 (context_p->context_stack_depth, PARSER_WITH_CONTEXT_STACK_ALLOCATION);
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
   parser_emit_cbc (context_p, CBC_CONTEXT_END);
   parser_set_branch_to_current_position (context_p, &with_statement.branch);
@@ -638,7 +638,7 @@ parser_parse_while_statement_start (parser_context_t *context_p) /**< context */
 /**
  * Parse while statement (ending part).
  */
-static void PARSER_NOINLINE
+static void __attr_noinline___
 parser_parse_while_statement_end (parser_context_t *context_p) /**< context */
 {
   parser_while_statement_t while_statement;
@@ -720,9 +720,9 @@ parser_parse_for_statement_start (parser_context_t *context_p) /**< context */
       parser_raise_error (context_p, PARSER_ERR_RIGHT_PAREN_EXPECTED);
     }
 
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
     PARSER_PLUS_EQUAL_U16 (context_p->context_stack_depth, PARSER_FOR_IN_CONTEXT_STACK_ALLOCATION);
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
     parser_emit_cbc_ext_forward_branch (context_p,
                                         CBC_EXT_FOR_IN_CREATE_CONTEXT,
@@ -878,7 +878,7 @@ parser_parse_for_statement_start (parser_context_t *context_p) /**< context */
 /**
  * Parse for statement (ending part).
  */
-static void PARSER_NOINLINE
+static void __attr_noinline___
 parser_parse_for_statement_end (parser_context_t *context_p) /**< context */
 {
   parser_for_statement_t for_statement;
@@ -953,7 +953,7 @@ parser_parse_for_statement_end (parser_context_t *context_p) /**< context */
 /**
  * Parse switch statement (starting part).
  */
-static void PARSER_NOINLINE
+static void __attr_noinline___
 parser_parse_switch_statement_start (parser_context_t *context_p) /**< context */
 {
   parser_switch_statement_t switch_statement;
@@ -1120,9 +1120,9 @@ parser_parse_try_statement_end (parser_context_t *context_p) /**< context */
   {
     parser_flush_cbc (context_p);
     PARSER_MINUS_EQUAL_U16 (context_p->stack_depth, PARSER_TRY_CONTEXT_STACK_ALLOCATION);
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
     PARSER_MINUS_EQUAL_U16 (context_p->context_stack_depth, PARSER_TRY_CONTEXT_STACK_ALLOCATION);
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
     parser_emit_cbc (context_p, CBC_CONTEXT_END);
     parser_set_branch_to_current_position (context_p, &try_statement.branch);
@@ -1137,9 +1137,9 @@ parser_parse_try_statement_end (parser_context_t *context_p) /**< context */
       {
         parser_flush_cbc (context_p);
         PARSER_MINUS_EQUAL_U16 (context_p->stack_depth, PARSER_TRY_CONTEXT_STACK_ALLOCATION);
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
         PARSER_MINUS_EQUAL_U16 (context_p->context_stack_depth, PARSER_TRY_CONTEXT_STACK_ALLOCATION);
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
         parser_emit_cbc (context_p, CBC_CONTEXT_END);
         parser_flush_cbc (context_p);
@@ -1641,9 +1641,9 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
   while (context_p->token.type != LEXER_EOS
          || context_p->stack_top_uint8 != PARSER_STATEMENT_START)
   {
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
     JERRY_ASSERT (context_p->stack_depth == context_p->context_stack_depth);
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
     switch (context_p->token.type)
     {
@@ -1747,9 +1747,9 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
           parser_raise_error (context_p, PARSER_ERR_LEFT_BRACE_EXPECTED);
         }
 
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
         PARSER_PLUS_EQUAL_U16 (context_p->context_stack_depth, PARSER_TRY_CONTEXT_STACK_ALLOCATION);
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
         try_statement.type = parser_try_block;
         parser_emit_cbc_ext_forward_branch (context_p,
@@ -1922,9 +1922,9 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
           parser_stack_pop_uint8 (context_p);
           context_p->last_statement.current_p = NULL;
           JERRY_ASSERT (context_p->stack_depth == 0);
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
           JERRY_ASSERT (context_p->context_stack_depth == 0);
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
           /* There is no lexer_next_token here, since the
            * next token belongs to the parent context. */
           return;
@@ -2015,9 +2015,9 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
 
           parser_flush_cbc (context_p);
           PARSER_MINUS_EQUAL_U16 (context_p->stack_depth, PARSER_FOR_IN_CONTEXT_STACK_ALLOCATION);
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
           PARSER_MINUS_EQUAL_U16 (context_p->context_stack_depth, PARSER_FOR_IN_CONTEXT_STACK_ALLOCATION);
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
           parser_emit_cbc_ext_backward_branch (context_p,
                                                CBC_EXT_BRANCH_IF_FOR_IN_HAS_NEXT,
@@ -2044,9 +2044,9 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
   }
 
   JERRY_ASSERT (context_p->stack_depth == 0);
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
   JERRY_ASSERT (context_p->context_stack_depth == 0);
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
   parser_stack_pop_uint8 (context_p);
   context_p->last_statement.current_p = NULL;
@@ -2060,7 +2060,7 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
 /**
  * Free jumps stored on the stack if a parse error is occured.
  */
-void PARSER_NOINLINE
+void __attr_noinline___
 parser_free_jumps (parser_stack_iterator_t iterator) /**< iterator position */
 {
   while (PARSER_TRUE)

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -388,7 +388,7 @@ parser_compute_indicies (parser_context_t *context_p, /**< context */
  *
  * @return position after the encoded values
  */
-static PARSER_INLINE uint8_t *
+static inline uint8_t *
 parser_encode_literal (uint8_t *dst_p, /**< destination buffer */
                        uint16_t literal_index, /**< literal index */
                        uint16_t literal_one_byte_limit) /**< maximum value of a literal
@@ -445,9 +445,9 @@ parser_generate_initializers (parser_context_t *context_p, /**< context */
   if (context_p->status_flags & PARSER_HAS_INITIALIZED_VARS)
   {
     const uint8_t expected_status_flags = LEXER_FLAG_VAR | LEXER_FLAG_NO_REG_STORE | LEXER_FLAG_INITIALIZED;
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
     uint16_t next_index = uninitialized_var_end;
-#endif
+#endif /* !JERRY_NDEBUG */
 
     context_p->status_flags |= PARSER_LEXICAL_ENV_NEEDED;
 
@@ -474,10 +474,10 @@ parser_generate_initializers (parser_context_t *context_p, /**< context */
         uint16_t init_index;
 
         JERRY_ASSERT (literal_p->type == LEXER_IDENT_LITERAL);
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
         JERRY_ASSERT (literal_p->prop.index == next_index);
         next_index++;
-#endif
+#endif /* !JERRY_NDEBUG */
         literal_p->status_flags = (uint8_t) (literal_p->status_flags & ~LEXER_FLAG_INITIALIZED);
 
 
@@ -1849,9 +1849,9 @@ parser_parse_source (const uint8_t *source_p, /**< valid UTF-8 source code */
                     (uint32_t) ((128 - sizeof (void *)) / sizeof (lexer_literal_t)));
   parser_stack_init (&context);
 
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
   context.context_stack_depth = 0;
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
 #ifdef PARSER_DUMP_BYTE_CODE
   context.is_show_opcodes = parser_show_instrs;
@@ -1967,9 +1967,9 @@ parser_parse_function (parser_context_t *context_p, /**< context */
   saved_context.byte_code_size = context_p->byte_code_size;
   saved_context.literal_pool_data = context_p->literal_pool.data;
 
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
   saved_context.context_stack_depth = context_p->context_stack_depth;
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
   /* Reset private part of the context. */
 
@@ -1990,9 +1990,9 @@ parser_parse_function (parser_context_t *context_p, /**< context */
   context_p->byte_code_size = 0;
   parser_list_reset (&context_p->literal_pool);
 
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
   context_p->context_stack_depth = 0;
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
 #ifdef PARSER_DUMP_BYTE_CODE
   if (context_p->is_show_opcodes)
@@ -2184,9 +2184,9 @@ parser_parse_function (parser_context_t *context_p, /**< context */
   context_p->byte_code_size = saved_context.byte_code_size;
   context_p->literal_pool.data = saved_context.literal_pool_data;
 
-#ifdef PARSER_DEBUG
+#ifndef JERRY_NDEBUG
   context_p->context_stack_depth = saved_context.context_stack_depth;
-#endif /* PARSER_DEBUG */
+#endif /* !JERRY_NDEBUG */
 
   return compiled_code_p;
 } /* parser_parse_function */


### PR DESCRIPTION
The fact that the JS parser had been developed as a separate
component for a while is still visible from some macros that mirror
things from JRT. This patch removes those duplicates and makes the
JS parser rely on jrt.h. (The removed macros are: `PARSER_DEBUG`,
`PARSER_INLINE`, `PARSER_NOINLINE`.)

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu