### PR TITLE
Fix the OSX build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,13 @@ endif()
 if("${PLATFORM}" STREQUAL "DARWIN")
   set(ENABLE_LTO "OFF")
   set(ENABLE_ALL_IN_ONE "ON")
+  set(JERRY_LIBC "OFF")
+  set(JERRY_LIBM "OFF")
+  set(COMPILER_DEFAULT_LIBC "ON")
+endif()
+
+if(JERRY_LIBC AND COMPILER_DEFAULT_LIBC)
+  message(FATAL_ERROR "JERRY_LIBC and COMPILER_DEFAULT_LIBC is enabled at the same time!")
 endif()
 
 # Status messages
@@ -105,11 +112,6 @@ set(CMAKE_C_FLAGS_RELEASE "-Os")
 # Architecture-specific compile/link flags
 jerry_add_compile_flags(${FLAGS_COMMON_ARCH})
 jerry_add_flags(CMAKE_EXE_LINKER_FLAGS ${FLAGS_COMMON_ARCH})
-
-# Use jerry libc
-if(JERRY_LIBC AND COMPILER_DEFAULT_LIBC)
-  message(FATAL_ERROR "JERRY_LIBC and COMPILER_DEFAULT_LIBC is enabled at the same time!")
-endif()
 
 # LTO
 if(ENABLE_LTO)


### PR DESCRIPTION
Apple does not support staticaly built applications on OSX, and all
dynamically built apps have to be linked against the System lib
(i.e., `-static` should not be used and `-lSystem` is a must).
As System contains all libc and libm functions, building (and
linking) the minimal jerry-libc and jerry-libm libs makes no sense.
Moreover, if JERRY_LIBC is ON, the compiler will use the jerry-libc
headers but will link the libc functions from System, which causes
heavy confusion and segfaults at run time.

Thus, this patch changes the build system to disable the building
of jerry-libc and jerry-libm, and enables the use of system
libraries when building on OSX.

Fallout: It turned out that jerry-libm is not standard-conforming
in `pow`: `pow(1,INFINITY)` (and sign variants) should return `1`
according to the libm standard. However, the `pow` in jerry-libm
returns `NAN` - seems to be an fdlibm legacy. Interestingly, ES5.1
standard differs from libm standard when in comes to `pow` and also
expects `NaN` in this special case. And unfortunately, the
implementation of `Math.pow` simply passes its arguments to the
libm's `pow` and returns its result, which only works if jerry-libm
is used but not if a (standard-conforming) system libm is used.

As a temporary solution, this patch disables the conformance checks
of the affected cases in the test suites.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu