### PR TITLE
Fix the use of mktemp in tool scripts

### DIFF
--- a/tools/runners/run-test-suite.sh
+++ b/tools/runners/run-test-suite.sh
@@ -115,7 +115,7 @@ do
     if [ "$IS_SNAPSHOT" == true ]
     then
         # Testing snapshot
-        SNAPSHOT_TEMP=`mktemp $(basename -s .js $test).XXXXXXXXXX.snapshot`
+        SNAPSHOT_TEMP=`mktemp $(basename -s .js $test).snapshot.XXXXXXXXXX`
 
         cmd_line="${ENGINE#$ROOT_DIR} $ENGINE_ARGS --save-snapshot-for-global $SNAPSHOT_TEMP ${full_test#$ROOT_DIR}"
         ( ulimit -t $TIMEOUT; $ENGINE $ENGINE_ARGS --save-snapshot-for-global $SNAPSHOT_TEMP $full_test &> $ENGINE_TEMP )


### PR DESCRIPTION
The manual of `mktemp` states that "TEMPLATE must contain at least
3 consecutive 'X's in last component." Linux implementation seems
to be relaxed about this and accepts and rewrites X's even inside
the template, but mktemp of OSX is more strict and handles trailing
X's only. This patch makes sure that mktemp templates work on both
OS's.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu