### PR TITLE
targets/zephyr/Makefile.zephyr: Work around issue with newlib 2.4.0.

### DIFF
--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -80,6 +80,7 @@ EXT_CFLAGS += -Wall -Wno-format-zero-length -Wno-pointer-sign
 EXT_CFLAGS += -Werror=format -Werror=implicit-int -Wno-unused-but-set-variable
 EXT_CFLAGS += -Wno-main -Wno-strict-aliasing -Wno-old-style-declaration
 EXT_CFLAGS += -Wno-error=format=
+EXT_CFLAGS += -D_XOPEN_SOURCE
 
 # Pass2
 -include $(ZEPHYR_BASE)/scripts/Makefile.toolchain.$(ZEPHYR_GCC_VARIANT)


### PR DESCRIPTION
Zephyr SDK 0.8.2 contains newlib 2.4.0 which doesn't provide gettimeofday()
declaration by default, but needs _XOPEN_SOURCE defined for this. While
this is definitely an issue with newlib 2.4.0 (to be fixed in one of the
next releases), defining _XOPEN_SOURCE is quite a harmless workaround.

JerryScript-DCO-1.0-Signed-off-by: Paul Sokolovsky paul.sokolovsky@linaro.org