### PR TITLE
Add target build option to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,3 +226,8 @@ endif()
 if(UNITTESTS)
   add_subdirectory(tests/unit)
 endif()
+
+# External target build
+if(EXTERNAL_BUILD)
+  add_subdirectory(${EXTERNAL_BUILD})
+endif()


### PR DESCRIPTION
Adding EXTERNAL_BUILD option for targets build as
previous EXTERNAL_BUILD_ENTRY_FILE is removed
so that we can build target specific codes calling jerry interfaces.

JerryScript-DCO-1.0-Signed-off-by: SaeHie Park saehie.park@samsung.com