### PR TITLE
Force to use SSE in 32-bit environment instead of the 387 unit

### DIFF
--- a/cmake/toolchain_linux_i686.cmake
+++ b/cmake/toolchain_linux_i686.cmake
@@ -1,0 +1,16 @@
+# Copyright 2016 Samsung Electronics Co., Ltd.
+# Copyright 2016 University of Szeged.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(FLAGS_COMMON_ARCH -mfpmath=sse -msse2)


### PR DESCRIPTION
This patch fixes the failing unittests, which fails in 32-bit mode.
These compiler-options adjusted through the default toolchain file.

JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com