### PR TITLE
Regexp.prototype.exec should generate return array with [[DefineOwnProperty]], not [[Put]]

### DIFF
--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -1434,15 +1434,13 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
           capture_value = ecma_make_string_value (capture_str_p);
         }
 
-        ECMA_TRY_CATCH (put_value,
-                        ecma_op_object_put (result_array_obj_p,
-                                            index_str_p,
-                                            capture_value,
-                                            true),
-                        ret_value);
-        ECMA_FINALIZE (put_value);
+        ecma_property_t *prop_p;
+        prop_p = ecma_create_named_data_property (result_array_obj_p,
+                                                  index_str_p,
+                                                  ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
+        ecma_set_named_data_property_value (prop_p, capture_value);
 
-        ecma_free_value (capture_value);
+        JERRY_ASSERT (!ecma_is_value_object (capture_value));
         ecma_deref_ecma_string (index_str_p);
       }
 

--- a/tests/jerry/regression-test-issue-1078.js
+++ b/tests/jerry/regression-test-issue-1078.js
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-Array.prototype.push(Math.sin);
+Array.prototype.splice(Function.prototype, 1, this);
 Object.freeze(Array.prototype);
-String.prototype.match(String.prototype);
+var res = (new String("Hello")).split(new RegExp());
+assert(res.length == 5);


### PR DESCRIPTION
The spec (ES5-15.10.6.2) explicitly states that it uses [[DefineOwnProperty]], not [[Put]].

Releated issue: https://github.com/Samsung/jerryscript/issues/1078
In this case, the behavior of two operations are different,
because of the indexed property previously defined on Array.prototype.

(And the last line of 'tests/jerry/regression-test-issue-787.js' should not throw TypeError.)