### PR TITLE
fix bug: move jerry_make_api_unavailable into the end of jerry_cleanup

### DIFF
--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -187,9 +187,9 @@ jerry_cleanup (void)
 {
   jerry_assert_api_available ();
 
-  jerry_make_api_unavailable ();
   ecma_finalize ();
   jmem_finalize ();
+  jerry_make_api_unavailable ();
 } /* jerry_cleanup */
 
 /**


### PR DESCRIPTION
In the old jerry_cleanup, it first jerry_make_api_unavailable , then call `ecma_finalize` ->`ecma_gc_run`

During gc, it may call 
```
void
jerry_dispatch_object_free_callback (ecma_external_pointer_t freecb_p, /**< pointer to free callback handler */
                                     ecma_external_pointer_t native_p) /**< native handle, associated
                                                                        *   with freed object */
{
  jerry_make_api_unavailable ();

  ((jerry_object_free_callback_t) freecb_p) ((uintptr_t) native_p);

  jerry_make_api_available ();
} /* jerry_dispatch_object_free_callback */

```
which will **jerry_make_api_available ();** in the end

So in this way, we can't call jerry_init after jerry_cleanup, because 
```
void
jerry_init (jerry_init_flag_t flags) /**< combination of Jerry flags */
{
  if (unlikely (jerry_api_available))
  {
    /* This function cannot be called twice unless jerry_cleanup is called. */
    JERRY_UNREACHABLE ();
  }
.....
```

In the patch, we move `jerry_make_api_unavailable()` to the end of `jerry_cleanup` to make sure the jerry_api_available==false after cleanup