### PR TITLE
Remove unnecessary empty value check code

### DIFF
--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -1410,7 +1410,7 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
       re_set_result_array_properties (result_array_obj_p, input_str_p, re_ctx.num_of_captures / 2, index);
       ecma_deref_ecma_string (input_str_p);
 
-      for (uint32_t i = 0; ecma_is_value_empty (ret_value) && i < re_ctx.num_of_captures; i += 2)
+      for (uint32_t i = 0; i < re_ctx.num_of_captures; i += 2)
       {
         ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (i / 2);
         ecma_value_t capture_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
@@ -1444,14 +1444,7 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
         ecma_deref_ecma_string (index_str_p);
       }
 
-      if (ecma_is_value_empty (ret_value))
-      {
-        ret_value = result_array;
-      }
-      else
-      {
-        ecma_deref_object (result_array_obj_p);
-      }
+      ret_value = result_array;
     }
     else
     {


### PR DESCRIPTION
Related PR : https://github.com/Samsung/jerryscript/pull/1276

Since RegExp.protytype.exec doesn't change the ret_value any more when filling the result array,
I think it is possible to remove some more unncessessary empty value check code.