### PR TITLE
Numbers should be permitted as property name in object literal

### DIFF
--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -153,7 +153,8 @@ opfunc_set_accessor (bool is_getter, /**< is getter accessor */
                      ecma_value_t accessor) /**< accessor value */
 {
   ecma_object_t *object_p = ecma_get_object_from_value (object);
-  ecma_string_t *accessor_name_p = ecma_get_string_from_value (accessor_name);
+  JERRY_ASSERT (ecma_is_value_string (accessor_name) || ecma_is_value_number (accessor_name));
+  ecma_string_t *accessor_name_p = ecma_get_string_from_value (ecma_op_to_string (accessor_name));
   ecma_property_t *property_p = ecma_find_named_property (object_p, accessor_name_p);
 
   if (property_p != NULL && ECMA_PROPERTY_GET_TYPE (property_p) != ECMA_PROPERTY_TYPE_NAMEDACCESSOR)
@@ -198,6 +199,8 @@ opfunc_set_accessor (bool is_getter, /**< is getter accessor */
                                              property_p,
                                              setter_func_p);
   }
+
+  ecma_deref_ecma_string (accessor_name_p);
 } /* opfunc_set_accessor */
 
 /**

--- a/tests/jerry/regression-test-issue-1282.js
+++ b/tests/jerry/regression-test-issue-1282.js
@@ -1,0 +1,33 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var counter = 0;
+
+({ get "0"() { counter += 1; } })[0];
+({ get 0() { counter += 2; } })[0];
+({ get 0.0() { counter += 3; } })[0];
+({ get 0.() { counter += 4; } })[0];
+({ get 1.() { counter += 5; } })[1];
+({ get 5.2322341234123() { counter += 6; } })[5.2322341234123];
+
+assert (counter == 21);
+
+({ set "0"(q) { counter -= 1; } })[0] = "dummy";
+({ set 0(q) { counter -= 2; } })[0] = "dummy";
+({ set 0.0(q) { counter -= 3; } })[0] = "dummy";
+({ set 0.(q) { counter -= 4; } })[0] = "dummy";
+({ set 1.(q) { counter -= 5; } })[1] = "dummy";
+({ set 5.2322341234123(q) { counter -= 6; } })[5.2322341234123] = "dummy";
+
+assert (counter == 0);


### PR DESCRIPTION
Related issue: https://github.com/Samsung/jerryscript/issues/1282

Binary size doesn't change. (at least for linux/release build)