### PR TITLE
[[DefaultValue]] should be called twice when setting object as Array length

### DIFF
--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -198,6 +198,13 @@ ecma_op_array_object_define_own_property (ecma_object_t *obj_p, /**< the array o
     uint32_t new_len_uint32 = ecma_number_to_uint32 (new_len_num);
 
     // d.
+    if (ecma_is_value_object (property_desc_p->value))
+    {
+      ecma_value_t compared_num_val = ecma_op_to_number (property_desc_p->value);
+      new_len_num = ecma_get_number_from_value (compared_num_val);
+      ecma_free_value (compared_num_val);
+    }
+
     if (((ecma_number_t) new_len_uint32) != new_len_num)
     {
       return ecma_raise_range_error (ECMA_ERR_MSG (""));

--- a/tests/jerry/regression-test-issue-1284.js
+++ b/tests/jerry/regression-test-issue-1284.js
@@ -1,0 +1,18 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var count = 0;
+[].length = { valueOf: function() { count++; return 1; } };
+assert(count == 2);
+


### PR DESCRIPTION
Related issue: https://github.com/Samsung/jerryscript/issues/1284

It didn't hurt the sunspider performance after wrapping the code with `ecma_is_value_object` check.