### PR TITLE
Eval called as a bound function should be indirect eval

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -26,6 +26,7 @@
 #include "ecma-objects-general.h"
 #include "ecma-objects-arguments.h"
 #include "ecma-try-catch-macro.h"
+#include "jcontext.h"
 
 #define JERRY_INTERNAL
 #include "jerry-internal.h"
@@ -650,6 +651,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
   else
   {
     JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_BOUND_FUNCTION);
+    JERRY_CONTEXT (is_direct_eval_form_call) = false;
 
     /* 2-3. */
     ecma_property_t *bound_this_prop_p;

--- a/tests/jerry/regression-test-issue-1286.js
+++ b/tests/jerry/regression-test-issue-1286.js
@@ -1,0 +1,25 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var builtinEval = eval;
+var eval = builtinEval.bind(undefined, "context");
+
+var context = "global";
+function checkIfDirectEval() {
+  var context = "function";
+  return (eval() == "function");
+}
+
+assert (!checkIfDirectEval());
+


### PR DESCRIPTION
Related issue: https://github.com/Samsung/jerryscript/issues/1286

is_direct_eval_form_call flag should not be true when executing bound eval function