### PR TITLE
All-in-one build friendly jerry-libm.

### DIFF
--- a/jerry-libm/acos.c
+++ b/jerry-libm/acos.c
@@ -127,3 +127,18 @@ acos (double x)
     return 2.0 * (df + w);
   }
 } /* acos */
+
+#undef one
+#undef pi
+#undef pio2_hi
+#undef pio2_lo
+#undef pS0
+#undef pS1
+#undef pS2
+#undef pS3
+#undef pS4
+#undef pS5
+#undef qS1
+#undef qS2
+#undef qS3
+#undef qS4

--- a/jerry-libm/asin.c
+++ b/jerry-libm/asin.c
@@ -136,3 +136,19 @@ asin (double x)
     return -t;
   }
 } /* asin */
+
+#undef one
+#undef huge
+#undef pio2_hi
+#undef pio2_lo
+#undef pio4_hi
+#undef pS0
+#undef pS1
+#undef pS2
+#undef pS3
+#undef pS4
+#undef pS5
+#undef qS1
+#undef qS2
+#undef qS3
+#undef qS4

--- a/jerry-libm/atan.c
+++ b/jerry-libm/atan.c
@@ -160,3 +160,17 @@ atan (double x)
     return (hx < 0) ? -z : z;
   }
 } /* atan */
+
+#undef aT0
+#undef aT1
+#undef aT2
+#undef aT3
+#undef aT4
+#undef aT5
+#undef aT6
+#undef aT7
+#undef aT8
+#undef aT9
+#undef aT10
+#undef one
+#undef huge

--- a/jerry-libm/atan2.c
+++ b/jerry-libm/atan2.c
@@ -201,3 +201,10 @@ atan2 (double y, double x)
     }
   }
 } /* atan2 */
+
+#undef tiny
+#undef zero
+#undef pi_o_4
+#undef pi_o_2
+#undef pi
+#undef pi_lo

--- a/jerry-libm/ceil.c
+++ b/jerry-libm/ceil.c
@@ -128,3 +128,5 @@ ceil (double x)
   __LO (x) = i1;
   return x;
 } /* ceil */
+
+#undef huge

--- a/jerry-libm/exp.c
+++ b/jerry-libm/exp.c
@@ -205,3 +205,15 @@ exp (double x) /* default IEEE double exp */
     return y * twom1000;
   }
 } /* exp */
+
+#undef one
+#undef huge
+#undef twom1000
+#undef o_threshold
+#undef u_threshold
+#undef invln2
+#undef P1
+#undef P2
+#undef P3
+#undef P4
+#undef P5

--- a/jerry-libm/floor.c
+++ b/jerry-libm/floor.c
@@ -127,3 +127,5 @@ floor (double x)
   __LO (x) = i1;
   return x;
 } /* floor */
+
+#undef huge

--- a/jerry-libm/fmod.c
+++ b/jerry-libm/fmod.c
@@ -232,3 +232,5 @@ fmod (double x, double y)
   }
   return x; /* exact output */
 } /* fmod */
+
+#undef one

--- a/jerry-libm/log.c
+++ b/jerry-libm/log.c
@@ -185,3 +185,15 @@ log (double x)
     }
   }
 } /* log */
+
+#undef zero
+#undef ln2_hi
+#undef ln2_lo
+#undef two54
+#undef Lg1
+#undef Lg2
+#undef Lg3
+#undef Lg4
+#undef Lg5
+#undef Lg6
+#undef Lg7

--- a/jerry-libm/pow.c
+++ b/jerry-libm/pow.c
@@ -73,7 +73,6 @@
  * to produce the hexadecimal values shown.
  */
 
-static const double one = 1.0;
 static const double bp[] =
 {
   1.0,
@@ -91,6 +90,7 @@ static const double dp_l[] =
 };
 
 #define zero     0.0
+#define one      1.0
 #define two      2.0
 #define two53    9007199254740992.0 /* 0x43400000, 0x00000000 */
 #define huge     1.0e300
@@ -445,3 +445,31 @@ pow (double x, double y)
   }
   return s * z;
 } /* pow */
+
+#undef zero
+#undef one
+#undef two
+#undef two53
+#undef huge
+#undef tiny
+#undef L1
+#undef L2
+#undef L3
+#undef L4
+#undef L5
+#undef L6
+#undef P1
+#undef P2
+#undef P3
+#undef P4
+#undef P5
+#undef lg2
+#undef lg2_h
+#undef lg2_l
+#undef ovt
+#undef cp
+#undef cp_h
+#undef cp_l
+#undef ivln2
+#undef ivln2_h
+#undef ivln2_l

--- a/jerry-libm/scalbn.c
+++ b/jerry-libm/scalbn.c
@@ -89,3 +89,8 @@ scalbn (double x, int n)
   __HI (x) = (hx & 0x800fffff) | (k << 20);
   return x * twom54;
 } /* scalbn */
+
+#undef two54
+#undef twom54
+#undef huge
+#undef tiny

--- a/jerry-libm/sqrt.c
+++ b/jerry-libm/sqrt.c
@@ -240,6 +240,9 @@ sqrt (double x)
   return z;
 } /* sqrt */
 
+#undef one
+#undef tiny
+
 /*
 Other methods  (use floating-point arithmetic)
 -------------

--- a/jerry-libm/trig.c
+++ b/jerry-libm/trig.c
@@ -1055,3 +1055,43 @@ tan (double x)
     return __kernel_tan (y[0], y[1], 1 - ((n & 1) << 1)); /*   1 -- n even, -1 -- n odd */
   }
 } /* tan */
+
+#undef zero
+#undef half
+#undef one
+#undef two24
+#undef twon24
+#undef invpio2
+#undef pio2_1
+#undef pio2_1t
+#undef pio2_2
+#undef pio2_2t
+#undef pio2_3
+#undef pio2_3t
+#undef S1
+#undef S2
+#undef S3
+#undef S4
+#undef S5
+#undef S6
+#undef C1
+#undef C2
+#undef C3
+#undef C4
+#undef C5
+#undef C6
+#undef T0
+#undef T1
+#undef T2
+#undef T3
+#undef T4
+#undef T5
+#undef T6
+#undef T7
+#undef T8
+#undef T9
+#undef T10
+#undef T11
+#undef T12
+#undef pio4
+#undef pio4lo


### PR DESCRIPTION
Define constants that would collide in case of all-in-one build of jerry-libm are moved to local const variables.

JerryScript-DCO-1.0-Signed-off-by: István Kádár ikadar@inf.u-szeged.hu