### PR TITLE
Use C99's variable length array instead of alloca()

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -36,8 +36,6 @@
 #include "vm.h"
 #include "vm-stack.h"
 
-#include <alloca.h>
-
 /** \addtogroup vm Virtual machine
  * @{
  *
@@ -2635,9 +2633,7 @@ vm_run_with_alloca (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
                     ecma_length_t arg_list_len, /**< length of arguments list */
                     uint32_t call_stack_size) /**< call stack size */
 {
-  size_t size = call_stack_size * sizeof (ecma_value_t);
-
-  ecma_value_t *stack = (ecma_value_t *) alloca (size);
+  ecma_value_t stack[call_stack_size];
 
   frame_ctx_p->registers_p = stack;
 


### PR DESCRIPTION
"alloc.h" is a non-standard header file, and won't compile on FreeBSD (at least). To make this project more portable, the standard "stdlib.h" should be preferred.

However, since "-std=c99" is enabled globally in "CMakeLists.txt", use C99's "variable length array" is much easier.

Reference:
1. https://en.wikibooks.org/wiki/C_Programming/Platform_Reference/alloc.h
2. https://en.wikipedia.org/wiki/Variable-length_array
3. http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf
4. https://gcc.gnu.org/onlinedocs/gcc/Variable-Length.html