### PR TITLE
Improve the build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,18 +24,17 @@ string(TOUPPER "${PLATFORM}" PLATFORM)
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS )
 
 # Components
-set(JERRY_CORE    ON  CACHE BOOL "Use jerry-core?")
-set(JERRY_LIBC    ON  CACHE BOOL "Use jerry-libc?")
-set(JERRY_LIBM    ON  CACHE BOOL "Use jerry-libm?")
-set(JERRY_CMDLINE ON  CACHE BOOL "Use jerry command line tool?")
-set(UNITTESTS     OFF CACHE BOOL "Use unit tests?")
+set(JERRY_LIBC    ON  CACHE BOOL "Build and use jerry-libc?")
+set(JERRY_LIBM    ON  CACHE BOOL "Build and use jerry-libm?")
+set(JERRY_CMDLINE ON  CACHE BOOL "Build jerry command line tool?")
+set(UNITTESTS     OFF CACHE BOOL "Build unit tests?")
 
 # Optional build settings
-set(PORT_DIR                  "${CMAKE_SOURCE_DIR}/targets/default" CACHE STRING "Should we use default or external port?")
-set(COMPILER_DEFAULT_LIBC     OFF                                   CACHE BOOL   "Enable compiler default libc?")
+set(PORT_DIR                  "${CMAKE_SOURCE_DIR}/targets/default" CACHE STRING "Use default or external port?")
+set(COMPILER_DEFAULT_LIBC     OFF                                   CACHE BOOL   "Use compiler default libc?")
 set(ENABLE_LTO                OFF                                   CACHE BOOL   "Enable LTO build?")
 set(ENABLE_ALL_IN_ONE         ON                                    CACHE BOOL   "Enable all-in-one build?")
-set(ENABLE_STRIP              ON                                    CACHE BOOL   "Discards all symbols from object files?")
+set(ENABLE_STRIP              ON                                    CACHE BOOL   "Enable stripping all symbols from release binary?")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
@@ -50,14 +49,13 @@ if("${PLATFORM}" STREQUAL "DARWIN")
 endif()
 
 if(JERRY_LIBC AND COMPILER_DEFAULT_LIBC)
-  message(FATAL_ERROR "JERRY_LIBC and COMPILER_DEFAULT_LIBC is enabled at the same time!")
+  message(FATAL_ERROR "JERRY_LIBC and COMPILER_DEFAULT_LIBC cannot be enabled at the same time")
 endif()
 
 # Status messages
 message(STATUS "CMAKE_SYSTEM_NAME         " ${CMAKE_SYSTEM_NAME})
 message(STATUS "CMAKE_SYSTEM_PROCESSOR    " ${CMAKE_SYSTEM_PROCESSOR})
 message(STATUS "CMAKE_BUILD_TYPE          " ${CMAKE_BUILD_TYPE})
-message(STATUS "JERRY_CORE                " ${JERRY_CORE})
 message(STATUS "JERRY_LIBC                " ${JERRY_LIBC})
 message(STATUS "JERRY_LIBM                " ${JERRY_LIBM})
 message(STATUS "JERRY_CMDLINE             " ${JERRY_CMDLINE})
@@ -215,11 +213,9 @@ if(JERRY_LIBM)
 endif()
 
 # Jerry's core
-if(JERRY_CORE)
-  add_subdirectory(jerry-core)
-endif()
+add_subdirectory(jerry-core)
 
-# Jerry commandline tool
+# Jerry command line tool
 if(JERRY_CMDLINE)
   add_subdirectory(jerry-main)
 endif()

--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -26,8 +26,8 @@ set(FEATURE_MEM_STRESS_TEST OFF    CACHE BOOL   "Enable mem-stress test?")
 set(FEATURE_MEM_STATS       OFF    CACHE BOOL   "Enable memory statistics?")
 set(FEATURE_PARSER_DUMP     OFF    CACHE BOOL   "Enable parser byte-code dumps?")
 set(FEATURE_REGEXP_DUMP     OFF    CACHE BOOL   "Enable regexp byte-code dumps?")
-set(FEATURE_SNAPSHOT_SAVE   OFF    CACHE BOOL   "Allow to save snapshot files?")
-set(FEATURE_SNAPSHOT_EXEC   OFF    CACHE BOOL   "Allow to execute snapshot files?")
+set(FEATURE_SNAPSHOT_SAVE   OFF    CACHE BOOL   "Enable saving snapshot files?")
+set(FEATURE_SNAPSHOT_EXEC   OFF    CACHE BOOL   "Enable executing snapshot files?")
 set(MEM_HEAP_SIZE_KB        "512"  CACHE STRING "Size of memory heap, in kilobytes")
 
 # Status messages
@@ -157,7 +157,7 @@ if(FEATURE_PROFILE STREQUAL "minimal")
       CONFIG_DISABLE_REGEXP_BUILTIN
       CONFIG_DISABLE_ANNEXB_BUILTIN)
 elseif(NOT FEATURE_PROFILE STREQUAL "full")
-  message(FATAL_ERROR "FEATURE_PROFILE='${FEATURE_PROFILE}' doesn't supported")
+  message(FATAL_ERROR "FEATURE_PROFILE='${FEATURE_PROFILE}' isn't supported")
 endif()
 
 # Jerry heap-section
@@ -224,4 +224,3 @@ target_include_directories(${JERRY_CORE_NAME} PUBLIC ${INCLUDE_CORE})
 if (JERRY_LIBC)
   target_include_directories(${JERRY_CORE_NAME} SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/jerry-libc/include")
 endif()
-

--- a/jerry-libc/CMakeLists.txt
+++ b/jerry-libc/CMakeLists.txt
@@ -27,7 +27,7 @@ elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "armv7l-el")
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "i686")
   set(DEFINES_LIBC ${DEFINES_LIBC} __TARGET_HOST_x86)
 else()
-  message(FATAL_ERROR "Unsupported machine architecture")
+  message(FATAL_ERROR "Machine architecture ${CMAKE_SYSTEM_PROCESSOR} isn't supported")
 endif()
 
 # Include directories

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required (VERSION 2.8.12)
 project (Unittest C)
 
 if(NOT FEATURE_PROFILE STREQUAL "full")
-  message(FATAL_ERROR "FEATURE_PROFILE='${FEATURE_PROFILE}' doesn't supported with UNITTESTS=ON option")
+  message(FATAL_ERROR "FEATURE_PROFILE='${FEATURE_PROFILE}' isn't supported with UNITTESTS=ON")
 endif()
 
 # Unit tests main modules

--- a/tools/build.py
+++ b/tools/build.py
@@ -31,7 +31,7 @@ def default_toolchain():
 
 def add_build_args(parser):
     parser.add_argument('--verbose', '-v', action='store_const', const='ON', default='OFF', help='Increase verbosity')
-    parser.add_argument('--unittests', action='store_const', const='ON', default='OFF', help='Build unittests too')
+    parser.add_argument('--unittests', action='store_const', const='ON', default='OFF', help='Build unittests')
     parser.add_argument('--clean', action='store_true', default=False, help='Clean build')
     parser.add_argument('--builddir', action='store', default=BUILD_DIR, help='Specify output directory (default: %(default)s)')
     parser.add_argument('--strip', choices=['on', 'off'], default='on', help='Strip release binary (default: %(default)s)')
@@ -46,17 +46,16 @@ def add_build_args(parser):
     parser.add_argument('--show-regexp-opcodes', choices=['on', 'off'], default='off', help='Enable regexp byte-code dumps (default: %(default)s)')
     parser.add_argument('--mem-stats', choices=['on', 'off'], default='off', help='Enable memory statistics (default: %(default)s)')
     parser.add_argument('--mem-stress-test', choices=['on', 'off'], default='off', help='Enable mem-stress test (default: %(default)s)')
-    parser.add_argument('--snapshot-save', choices=['on', 'off'], default='on', help='Allow to save snapshot files (default: %(default)s)')
-    parser.add_argument('--snapshot-exec', choices=['on', 'off'], default='on', help='Allow to execute snapshot files (default: %(default)s)')
+    parser.add_argument('--snapshot-save', choices=['on', 'off'], default='on', help='Enable saving snapshot files (default: %(default)s)')
+    parser.add_argument('--snapshot-exec', choices=['on', 'off'], default='on', help='Enable executing snapshot files (default: %(default)s)')
     parser.add_argument('--cmake-param', action='append', default=[], help='Add custom arguments to CMake')
     parser.add_argument('--compile-flag', action='append', default=[], help='Add custom compile flag')
     parser.add_argument('--linker-flag', action='append', default=[], help='Add custom linker flag')
     parser.add_argument('--toolchain', action='store', default=default_toolchain(), help='Add toolchain file (default: %(default)s)')
-    parser.add_argument('--jerry-libc', choices=['on', 'off'], default='on', help='Use jerry-libc (default: %(default)s)')
+    parser.add_argument('--jerry-libc', choices=['on', 'off'], default='on', help='Build and use jerry-libc (default: %(default)s)')
     parser.add_argument('--compiler-default-libc', choices=['on', 'off'], default='off', help='Use compiler-default libc (default: %(default)s)')
-    parser.add_argument('--jerry-core', choices=['on', 'off'], default='on', help='Use jerry-core (default: %(default)s)')
-    parser.add_argument('--jerry-libm', choices=['on', 'off'], default='on', help='Use jerry-libm (default: %(default)s)')
-    parser.add_argument('--jerry-cmdline', choices=['on', 'off'], default='on', help='Use jerry commandline tool (default: %(default)s)')
+    parser.add_argument('--jerry-libm', choices=['on', 'off'], default='on', help='Build and use jerry-libm (default: %(default)s)')
+    parser.add_argument('--jerry-cmdline', choices=['on', 'off'], default='on', help='Build jerry command line tool (default: %(default)s)')
 
 def get_arguments():
     parser = argparse.ArgumentParser()
@@ -68,7 +67,6 @@ def generate_build_options(arguments):
     build_options = []
 
     build_options.append('-DJERRY_LIBC=%s' % arguments.jerry_libc.upper())
-    build_options.append('-DJERRY_CORE=%s' % arguments.jerry_core.upper())
     build_options.append('-DJERRY_LIBM=%s' % arguments.jerry_libm.upper())
     build_options.append('-DJERRY_CMDLINE=%s' % arguments.jerry_cmdline.upper())
     build_options.append('-DCOMPILER_DEFAULT_LIBC=%s' % arguments.compiler_default_libc.upper())


### PR DESCRIPTION
* Remove JERRY_CORE CMake option: the building of the core
  JerryScript library should not be optional.
* Fix wording of comments, status and error messages.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu