### PR TITLE
Fix bug in for-in bytecode replacement

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -789,7 +789,7 @@ parser_parse_for_statement_start (parser_context_t *context_p) /**< context */
       }
       else if (opcode == CBC_PUSH_PROP_LITERAL)
       {
-        opcode = CBC_PUSH_PROP_LITERAL_REFERENCE;
+        opcode = CBC_ASSIGN_PROP_LITERAL;
         context_p->last_cbc_opcode = PARSER_CBC_UNAVAILABLE;
       }
       else if (opcode == CBC_PUSH_PROP_LITERAL_LITERAL)

--- a/tests/jerry/regression-test-issue-1300.js
+++ b/tests/jerry/regression-test-issue-1300.js
@@ -1,0 +1,28 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright 2016 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var array = [ [0] ];
+var obj = { prop : "" };
+var i = 0;
+var count = 0;
+
+(function () {
+      for (array[0][i] in obj)
+          count++;
+})();
+
+assert(array[0][0] == "prop");
+assert(count == 1);
+


### PR DESCRIPTION
Related issue: https://github.com/Samsung/jerryscript/issues/1300

`CBC_PUSH_PROP_LITERAL_REFERENCE` leaves 2 more values on stack, 
and it doesn't assign anything into lhs.
But in this case, the assign operation is necessary, and 2 elements should be poped from the stack.
so I think `CBC_ASSIGN_PROP_LITERAL` should be used in here.