### PR TITLE
Change return value to ecma_value_t for getting internal properties

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -374,7 +374,8 @@ ecma_gc_sweep (ecma_object_t *object_p) /**< object to free */
     bool is_retrieved = ecma_get_external_pointer_value (object_p,
                                                          ECMA_INTERNAL_PROPERTY_FREE_CALLBACK,
                                                          &freecb_p);
-    if (is_retrieved)
+
+    if (is_retrieved && ((jerry_object_free_callback_t) freecb_p) != NULL)
     {
       is_retrieved = ecma_get_external_pointer_value (object_p,
                                                       ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE,

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -486,7 +486,7 @@ ecma_create_property (ecma_object_t *object_p, /**< the object */
  *
  * @return pointer to newly created property
  */
-ecma_property_t *
+ecma_value_t *
 ecma_create_internal_property (ecma_object_t *object_p, /**< the object */
                                ecma_internal_property_id_t property_id) /**< internal property identifier */
 {
@@ -498,7 +498,8 @@ ecma_create_internal_property (ecma_object_t *object_p, /**< the object */
   ecma_property_value_t value;
   value.value = ECMA_NULL_POINTER;
 
-  return ecma_create_property (object_p, NULL, type_and_flags, value);
+  ecma_property_t *property_p = ecma_create_property (object_p, NULL, type_and_flags, value);
+  return &ECMA_PROPERTY_VALUE_PTR (property_p)->value;
 } /* ecma_create_internal_property */
 
 /**
@@ -507,7 +508,7 @@ ecma_create_internal_property (ecma_object_t *object_p, /**< the object */
  * @return pointer to the property, if it is found,
  *         NULL - otherwise.
  */
-ecma_property_t *
+ecma_value_t *
 ecma_find_internal_property (ecma_object_t *object_p, /**< object descriptor */
                              ecma_internal_property_id_t property_id) /**< internal property identifier */
 {
@@ -529,13 +530,15 @@ ecma_find_internal_property (ecma_object_t *object_p, /**< object descriptor */
     if (ECMA_PROPERTY_GET_TYPE (&prop_iter_p->types[0]) == ECMA_PROPERTY_TYPE_INTERNAL
         && ECMA_PROPERTY_GET_INTERNAL_PROPERTY_TYPE (prop_iter_p->types + 0) == property_id)
     {
-      return prop_iter_p->types + 0;
+      ecma_property_pair_t *prop_pair_p = (ecma_property_pair_t *) prop_iter_p;
+      return &prop_pair_p->values[0].value;
     }
 
     if (ECMA_PROPERTY_GET_TYPE (&prop_iter_p->types[1]) == ECMA_PROPERTY_TYPE_INTERNAL
         && ECMA_PROPERTY_GET_INTERNAL_PROPERTY_TYPE (prop_iter_p->types + 1) == property_id)
     {
-      return prop_iter_p->types + 1;
+      ecma_property_pair_t *prop_pair_p = (ecma_property_pair_t *) prop_iter_p;
+      return &prop_pair_p->values[1].value;
     }
 
     prop_iter_p = ECMA_GET_POINTER (ecma_property_header_t,
@@ -553,11 +556,11 @@ ecma_find_internal_property (ecma_object_t *object_p, /**< object descriptor */
  *
  * @return pointer to the property
  */
-ecma_property_t *
+inline ecma_value_t * __attr_always_inline___
 ecma_get_internal_property (ecma_object_t *object_p, /**< object descriptor */
                             ecma_internal_property_id_t property_id) /**< internal property identifier */
 {
-  ecma_property_t *property_p = ecma_find_internal_property (object_p, property_id);
+  ecma_value_t *property_p = ecma_find_internal_property (object_p, property_id);
 
   JERRY_ASSERT (property_p != NULL);
 
@@ -1050,31 +1053,6 @@ ecma_set_named_data_property_value (ecma_property_t *prop_p, /**< property */
 
   ECMA_PROPERTY_VALUE_PTR (prop_p)->value = value;
 } /* ecma_set_named_data_property_value */
-
-/**
- * Get value field of an internal property
- *
- * @return ecma value
- */
-inline ecma_value_t __attr_always_inline___
-ecma_get_internal_property_value (const ecma_property_t *prop_p) /**< property */
-{
-  JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_INTERNAL);
-
-  return ECMA_PROPERTY_VALUE_PTR (prop_p)->value;
-} /* ecma_get_internal_property_value */
-
-/**
- * Set value field of named data property
- */
-inline void __attr_always_inline___
-ecma_set_internal_property_value (ecma_property_t *prop_p, /**< property */
-                                  ecma_value_t value) /**< value to set */
-{
-  JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_INTERNAL);
-
-  ECMA_PROPERTY_VALUE_PTR (prop_p)->value = value;
-} /* ecma_set_internal_property_value */
 
 /**
  * Assign value to named data property

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -266,9 +266,9 @@ extern ecma_property_header_t *ecma_get_property_list (const ecma_object_t *) __
 extern ecma_object_t *ecma_get_lex_env_binding_object (const ecma_object_t *) __attr_pure___;
 extern bool ecma_get_lex_env_provide_this (const ecma_object_t *) __attr_pure___;
 
-extern ecma_property_t *ecma_create_internal_property (ecma_object_t *, ecma_internal_property_id_t);
-extern ecma_property_t *ecma_find_internal_property (ecma_object_t *, ecma_internal_property_id_t);
-extern ecma_property_t *ecma_get_internal_property (ecma_object_t *, ecma_internal_property_id_t);
+extern ecma_value_t *ecma_create_internal_property (ecma_object_t *, ecma_internal_property_id_t);
+extern ecma_value_t *ecma_find_internal_property (ecma_object_t *, ecma_internal_property_id_t);
+extern ecma_value_t *ecma_get_internal_property (ecma_object_t *, ecma_internal_property_id_t);
 
 extern ecma_property_t *
 ecma_create_named_data_property (ecma_object_t *, ecma_string_t *, uint8_t);
@@ -288,9 +288,6 @@ extern void ecma_delete_property (ecma_object_t *, ecma_property_t *);
 extern ecma_value_t ecma_get_named_data_property_value (const ecma_property_t *);
 extern void ecma_set_named_data_property_value (ecma_property_t *, ecma_value_t);
 extern void ecma_named_data_property_assign_value (ecma_object_t *, ecma_property_t *, ecma_value_t);
-
-extern ecma_value_t ecma_get_internal_property_value (const ecma_property_t *);
-extern void ecma_set_internal_property_value (ecma_property_t *, ecma_value_t);
 
 extern ecma_object_t *ecma_get_named_accessor_property_getter (const ecma_property_t *);
 extern ecma_object_t *ecma_get_named_accessor_property_setter (const ecma_property_t *);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
@@ -104,12 +104,12 @@ ecma_builtin_boolean_prototype_object_value_of (ecma_value_t this_arg) /**< this
 
     if (ecma_object_get_class_name (obj_p) == LIT_MAGIC_STRING_BOOLEAN_UL)
     {
-      ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
-                                                                       ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+      ecma_value_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
+                                                                    ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
 
-      JERRY_ASSERT (ecma_is_value_boolean (ecma_get_internal_property_value (prim_value_prop_p)));
+      JERRY_ASSERT (ecma_is_value_boolean (*prim_value_prop_p));
 
-      return ecma_get_internal_property_value (prim_value_prop_p);
+      return *prim_value_prop_p;
     }
   }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -105,19 +105,18 @@ ecma_builtin_date_prototype_to_date_string (ecma_value_t this_arg) /**< this arg
                     ret_value);
 
     ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-    ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
-                                                               ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
-    ecma_number_t *prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
-                                                                       ecma_get_internal_property_value (prim_prop_p));
+    ecma_value_t *date_prop_p = ecma_get_internal_property (obj_p,
+                                                            ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
+    ecma_number_t *date_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t, *date_prop_p);
 
-    if (ecma_number_is_nan (*prim_value_num_p))
+    if (ecma_number_is_nan (*date_num_p))
     {
       ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INVALID_DATE_UL);
       ret_value = ecma_make_string_value (magic_str_p);
     }
     else
     {
-      ret_value = ecma_date_value_to_date_string (*prim_value_num_p);
+      ret_value = ecma_date_value_to_date_string (*date_num_p);
     }
 
     ECMA_FINALIZE (obj_this);
@@ -152,10 +151,9 @@ ecma_builtin_date_prototype_to_time_string (ecma_value_t this_arg) /**< this arg
                     ret_value);
 
     ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-    ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
-                                                               ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
-    ecma_number_t *prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
-                                                                       ecma_get_internal_property_value (prim_prop_p));
+    ecma_value_t *prim_prop_p = ecma_get_internal_property (obj_p,
+                                                            ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
+    ecma_number_t *prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t, *prim_prop_p);
 
     if (ecma_number_is_nan (*prim_value_num_p))
     {
@@ -250,14 +248,11 @@ ecma_builtin_date_prototype_get_time (ecma_value_t this_arg) /**< this argument 
     ecma_object_t *obj_p = ecma_get_object_from_value (this_arg);
     if (ecma_object_get_class_name (obj_p) == LIT_MAGIC_STRING_DATE_UL)
     {
-      ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
-                                                                 ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
+      ecma_value_t *date_prop_p = ecma_get_internal_property (obj_p,
+                                                              ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
 
-      ecma_number_t *prim_value_num_p;
-      prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
-                                                          ecma_get_internal_property_value (prim_prop_p));
-
-      return ecma_make_number_value (*prim_value_num_p);
+      ecma_number_t *date_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t, *date_prop_p);
+      return ecma_make_number_value (*date_num_p);
     }
   }
 
@@ -359,12 +354,11 @@ ecma_builtin_date_prototype_set_time (ecma_value_t this_arg, /**< this argument 
     /* 2. */
     ecma_object_t *obj_p = ecma_get_object_from_value (this_arg);
 
-    ecma_property_t *prim_prop_p = ecma_get_internal_property (obj_p,
-                                                               ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
+    ecma_value_t *date_prop_p = ecma_get_internal_property (obj_p,
+                                                            ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
 
-    ecma_number_t *prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
-                                                                       ecma_get_internal_property_value (prim_prop_p));
-    *prim_value_num_p = value;
+    ecma_number_t *date_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t, *date_prop_p);
+    *date_num_p = value;
 
     /* 3. */
     ret_value = ecma_make_number_value (value);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -546,16 +546,16 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
       prim_value_num = ecma_number_make_nan ();
     }
 
-    ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p,
-                                                                   ECMA_INTERNAL_PROPERTY_CLASS);
-    ecma_set_internal_property_value (class_prop_p, LIT_MAGIC_STRING_DATE_UL);
+    ecma_value_t *class_prop_p = ecma_create_internal_property (obj_p,
+                                                                ECMA_INTERNAL_PROPERTY_CLASS);
+    *class_prop_p = LIT_MAGIC_STRING_DATE_UL;
 
-    ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
-                                                                        ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
+    ecma_value_t *date_prop_p = ecma_create_internal_property (obj_p,
+                                                               ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
 
-    ecma_number_t *prim_value_num_p = ecma_alloc_number ();
-    *prim_value_num_p = prim_value_num;
-    ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_value_num_p);
+    ecma_number_t *date_num_p = ecma_alloc_number ();
+    *date_num_p = prim_value_num;
+    ECMA_SET_INTERNAL_VALUE_POINTER (*date_prop_p, date_num_p);
 
     ret_value = ecma_make_object_value (obj_p);
   }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -245,27 +245,25 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
     ecma_deref_object (prototype_obj_p);
 
     /* 7. */
-    ecma_property_t *target_function_prop_p;
+    ecma_value_t *target_function_prop_p;
     target_function_prop_p = ecma_create_internal_property (function_p,
                                                             ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
     ecma_object_t *this_arg_obj_p = ecma_get_object_from_value (this_arg);
-    ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value, this_arg_obj_p);
+    ECMA_SET_INTERNAL_VALUE_POINTER (*target_function_prop_p, this_arg_obj_p);
 
     /* 8. */
-    ecma_property_t *bound_this_prop_p;
+    ecma_value_t *bound_this_prop_p;
     bound_this_prop_p = ecma_create_internal_property (function_p, ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_THIS);
     const ecma_length_t arg_count = arguments_number;
 
     if (arg_count > 0)
     {
-      ecma_set_internal_property_value (bound_this_prop_p,
-                                        ecma_copy_value_if_not_object (arguments_list_p[0]));
+      *bound_this_prop_p = ecma_copy_value_if_not_object (arguments_list_p[0]);
     }
     else
     {
-      ecma_set_internal_property_value (bound_this_prop_p,
-                                        ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED));
+      *bound_this_prop_p = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
     }
 
     if (arg_count > 1)
@@ -273,9 +271,9 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
       ecma_collection_header_t *bound_args_collection_p;
       bound_args_collection_p = ecma_new_values_collection (&arguments_list_p[1], arg_count - 1, false);
 
-      ecma_property_t *bound_args_prop_p;
+      ecma_value_t *bound_args_prop_p;
       bound_args_prop_p = ecma_create_internal_property (function_p, ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS);
-      ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (bound_args_prop_p)->value, bound_args_collection_p);
+      ECMA_SET_INTERNAL_VALUE_POINTER (*bound_args_prop_p, bound_args_collection_p);
     }
 
     /*

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -899,13 +899,10 @@ ecma_date_set_internal_property (ecma_value_t this_arg, /**< this argument */
 
   ecma_object_t *obj_p = ecma_get_object_from_value (this_arg);
 
-  ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
-                                                                   ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
+  ecma_value_t *date_value_prop_p = ecma_get_internal_property (obj_p,
+                                                                ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
 
-  ecma_number_t *prim_value_num_p;
-  prim_value_num_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
-                                                      ecma_get_internal_property_value (prim_value_prop_p));
-  *prim_value_num_p = value;
+  *ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t, *date_value_prop_p) = value;
 
   return ecma_make_number_value (value);
 } /* ecma_date_set_internal_property */
@@ -1302,14 +1299,13 @@ ecma_date_get_primitive_value (ecma_value_t this_arg) /**< this argument */
   else
   {
     ecma_object_t *obj_p = ecma_get_object_from_value (this_arg);
-    ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
-                                                                     ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
-    JERRY_ASSERT (prim_value_prop_p != NULL);
+    ecma_value_t *date_value_prop_p = ecma_get_internal_property (obj_p,
+                                                                  ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
+    JERRY_ASSERT (date_value_prop_p != NULL);
 
-    ecma_number_t prim_value_num;
-    prim_value_num = *ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t,
-                                                       ecma_get_internal_property_value (prim_value_prop_p));
-    ret_value = ecma_make_number_value (prim_value_num);
+    ecma_number_t date_num = *ECMA_GET_INTERNAL_VALUE_POINTER (ecma_number_t, *date_value_prop_p);
+
+    ret_value = ecma_make_number_value (date_num);
   }
 
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -433,12 +433,12 @@ ecma_builtin_number_prototype_object_value_of (ecma_value_t this_arg) /**< this 
 
     if (ecma_object_get_class_name (obj_p) == LIT_MAGIC_STRING_NUMBER_UL)
     {
-      ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
-                                                                       ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+      ecma_value_t *prim_value_p = ecma_get_internal_property (obj_p,
+                                                               ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
 
-      JERRY_ASSERT (ecma_is_value_number (ecma_get_internal_property_value (prim_value_prop_p)));
+      JERRY_ASSERT (ecma_is_value_number (*prim_value_p));
 
-      return ecma_copy_value (ecma_get_internal_property_value (prim_value_prop_p));
+      return ecma_copy_value (*prim_value_p);
     }
   }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -126,8 +126,8 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
         ecma_object_t *this_obj_p = ecma_get_object_from_value (obj_this);
 
         /* Get bytecode property. */
-        ecma_property_t *bc_prop_p = ecma_get_internal_property (this_obj_p,
-                                                                 ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
+        ecma_value_t *bc_prop_p = ecma_get_internal_property (this_obj_p,
+                                                              ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
 
         /* TODO: We currently have to re-compile the bytecode, because
          * we can't copy it without knowing its length. */
@@ -136,15 +136,15 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
         /* Should always succeed, since we're compiling from a source that has been compiled previously. */
         JERRY_ASSERT (ecma_is_value_empty (bc_comp));
 
-        re_compiled_code_t *old_bc_p = ECMA_GET_INTERNAL_VALUE_POINTER (re_compiled_code_t,
-                                                                        ecma_get_internal_property_value (bc_prop_p));
+        re_compiled_code_t *old_bc_p = ECMA_GET_INTERNAL_VALUE_POINTER (re_compiled_code_t, *bc_prop_p);
+
         if (old_bc_p != NULL)
         {
           /* Free the old bytecode */
           ecma_bytecode_deref ((ecma_compiled_code_t *) old_bc_p);
         }
 
-        ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (bc_prop_p)->value, new_bc_p);
+        ECMA_SET_INTERNAL_VALUE_POINTER (*bc_prop_p, new_bc_p);
 
         re_initialize_props (this_obj_p, pattern_string_p, flags);
 
@@ -198,16 +198,16 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
         ECMA_TRY_CATCH (obj_this, ecma_op_to_object (this_arg), ret_value);
         ecma_object_t *this_obj_p = ecma_get_object_from_value (obj_this);
 
-        ecma_property_t *bc_prop_p = ecma_get_internal_property (this_obj_p,
-                                                                 ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
+        ecma_value_t *bc_prop_p = ecma_get_internal_property (this_obj_p,
+                                                              ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
+
         /* Try to compile bytecode from new source. */
         const re_compiled_code_t *new_bc_p = NULL;
         ECMA_TRY_CATCH (bc_dummy,
                         re_compile_bytecode (&new_bc_p, pattern_string_p, flags),
                         ret_value);
 
-        re_compiled_code_t *old_bc_p = ECMA_GET_INTERNAL_VALUE_POINTER (re_compiled_code_t,
-                                                                        ecma_get_internal_property_value (bc_prop_p));
+        re_compiled_code_t *old_bc_p = ECMA_GET_INTERNAL_VALUE_POINTER (re_compiled_code_t, *bc_prop_p);
 
         if (old_bc_p != NULL)
         {
@@ -215,7 +215,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
           ecma_bytecode_deref ((ecma_compiled_code_t *) old_bc_p);
         }
 
-        ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (bc_prop_p)->value, new_bc_p);
+        ECMA_SET_INTERNAL_VALUE_POINTER (*bc_prop_p, new_bc_p);
         re_initialize_props (this_obj_p, pattern_string_p, flags);
         ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 
@@ -266,11 +266,11 @@ ecma_builtin_regexp_prototype_exec (ecma_value_t this_arg, /**< this argument */
                     ecma_op_to_string (arg),
                     ret_value);
 
-    ecma_property_t *bytecode_prop_p;
     ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-    bytecode_prop_p = ecma_get_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
+    ecma_value_t *bytecode_prop_p = ecma_get_internal_property (obj_p,
+                                                                ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
 
-    void *bytecode_p = ECMA_GET_INTERNAL_VALUE_POINTER (void, ecma_get_internal_property_value (bytecode_prop_p));
+    void *bytecode_p = ECMA_GET_INTERNAL_VALUE_POINTER (void, *bytecode_prop_p);
 
     if (bytecode_p == NULL)
     {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -76,10 +76,10 @@ ecma_builtin_string_prototype_object_to_string (ecma_value_t this_arg) /**< this
 
     if (ecma_object_get_class_name (obj_p) == LIT_MAGIC_STRING_STRING_UL)
     {
-      ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
-                                                                       ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+      ecma_value_t *prim_value_p = ecma_get_internal_property (obj_p,
+                                                               ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
 
-      return ecma_copy_value (ecma_get_internal_property_value (prim_value_prop_p));
+      return ecma_copy_value (*prim_value_p);
     }
   }
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -143,10 +143,9 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
     {
       ecma_string_t *prim_prop_str_value_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
 
-      ecma_property_t *prim_value_prop_p;
-      prim_value_prop_p = ecma_create_internal_property (obj_p,
-                                                         ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
-      ecma_set_internal_property_value (prim_value_prop_p, ecma_make_string_value (prim_prop_str_value_p));
+      ecma_value_t *prim_value_p = ecma_create_internal_property (obj_p,
+                                                                  ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+      *prim_value_p = ecma_make_string_value (prim_prop_str_value_p);
       break;
     }
 #endif /* !CONFIG_DISABLE_STRING_BUILTIN */
@@ -154,10 +153,9 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
 #ifndef CONFIG_DISABLE_NUMBER_BUILTIN
     case ECMA_BUILTIN_ID_NUMBER_PROTOTYPE:
     {
-      ecma_property_t *prim_value_prop_p;
-      prim_value_prop_p = ecma_create_internal_property (obj_p,
-                                                         ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
-      ecma_set_internal_property_value (prim_value_prop_p, ecma_make_integer_value (0));
+      ecma_value_t *prim_value_p = ecma_create_internal_property (obj_p,
+                                                                  ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+      *prim_value_p = ecma_make_integer_value (0);
       break;
     }
 #endif /* !CONFIG_DISABLE_NUMBER_BUILTIN */
@@ -165,10 +163,9 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
 #ifndef CONFIG_DISABLE_BOOLEAN_BUILTIN
     case ECMA_BUILTIN_ID_BOOLEAN_PROTOTYPE:
     {
-      ecma_property_t *prim_value_prop_p;
-      prim_value_prop_p = ecma_create_internal_property (obj_p,
-                                                         ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
-      ecma_set_internal_property_value (prim_value_prop_p, ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE));
+      ecma_value_t *prim_value_p = ecma_create_internal_property (obj_p,
+                                                                  ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+      *prim_value_p = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
       break;
     }
 #endif /* !CONFIG_DISABLE_BOOLEAN_BUILTIN */
@@ -179,10 +176,9 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_number_t *prim_prop_num_value_p = ecma_alloc_number ();
       *prim_prop_num_value_p = ecma_number_make_nan ();
 
-      ecma_property_t *prim_value_prop_p;
-      prim_value_prop_p = ecma_create_internal_property (obj_p,
-                                                         ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
-      ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (prim_value_prop_p)->value, prim_prop_num_value_p);
+      ecma_value_t *prim_value_p = ecma_create_internal_property (obj_p,
+                                                                  ECMA_INTERNAL_PROPERTY_DATE_FLOAT);
+      ECMA_SET_INTERNAL_VALUE_POINTER (*prim_value_p, prim_prop_num_value_p);
       break;
     }
 #endif /* !CONFIG_DISABLE_DATE_BUILTIN */
@@ -190,10 +186,9 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
 #ifndef CONFIG_DISABLE_REGEXP_BUILTIN
     case ECMA_BUILTIN_ID_REGEXP_PROTOTYPE:
     {
-      ecma_property_t *bytecode_prop_p;
-      bytecode_prop_p = ecma_create_internal_property (obj_p,
-                                                       ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
-      ecma_set_internal_property_value (bytecode_prop_p, ECMA_NULL_POINTER);
+      ecma_value_t *bytecode_prop_p = ecma_create_internal_property (obj_p,
+                                                                     ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
+      *bytecode_prop_p = ECMA_NULL_POINTER;
       break;
     }
 #endif /* !CONFIG_DISABLE_REGEXP_BUILTIN */
@@ -409,8 +404,8 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
   else
   {
     uint32_t bit_for_index = (uint32_t) 1u << (index - 32);
-    ecma_property_t *mask_prop_p = ecma_find_internal_property (object_p,
-                                                                ECMA_INTERNAL_PROPERTY_INSTANTIATED_MASK_32_63);
+    ecma_value_t *mask_prop_p = ecma_find_internal_property (object_p,
+                                                             ECMA_INTERNAL_PROPERTY_INSTANTIATED_MASK_32_63);
 
     uint32_t instantiated_bitset;
 
@@ -421,7 +416,7 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
     }
     else
     {
-      instantiated_bitset = ecma_get_internal_property_value (mask_prop_p);
+      instantiated_bitset = *mask_prop_p;
 
       if (instantiated_bitset & bit_for_index)
       {
@@ -430,9 +425,7 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
       }
     }
 
-    instantiated_bitset |= bit_for_index;
-
-    ecma_set_internal_property_value (mask_prop_p, instantiated_bitset);
+    *mask_prop_p = (instantiated_bitset | bit_for_index);
   }
 
   ecma_value_t value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
@@ -597,8 +590,8 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
 
       if (index == 32)
       {
-        ecma_property_t *mask_prop_p = ecma_find_internal_property (object_p,
-                                                                    ECMA_INTERNAL_PROPERTY_INSTANTIATED_MASK_32_63);
+        ecma_value_t *mask_prop_p = ecma_find_internal_property (object_p,
+                                                                 ECMA_INTERNAL_PROPERTY_INSTANTIATED_MASK_32_63);
 
         if (mask_prop_p == NULL)
         {
@@ -606,7 +599,7 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
         }
         else
         {
-          instantiated_bitset = ecma_get_internal_property_value (mask_prop_p);
+          instantiated_bitset = *mask_prop_p;
         }
       }
 

--- a/jerry-core/ecma/operations/ecma-boolean-object.c
+++ b/jerry-core/ecma/operations/ecma-boolean-object.c
@@ -52,15 +52,13 @@ ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boo
   ecma_object_t *obj_p = ecma_create_object (prototype_obj_p, false, true, ECMA_OBJECT_TYPE_GENERAL);
   ecma_deref_object (prototype_obj_p);
 
-  ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  ECMA_PROPERTY_VALUE_PTR (class_prop_p)->value = LIT_MAGIC_STRING_BOOLEAN_UL;
+  ecma_value_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
+  *class_prop_p = LIT_MAGIC_STRING_BOOLEAN_UL;
 
-  ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
-                                                                      ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+  ecma_value_t *prim_value_p = ecma_create_internal_property (obj_p,
+                                                              ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
 
-  ecma_value_t prim_value = ecma_make_boolean_value (boolean_value);
-
-  ecma_set_internal_property_value (prim_value_prop_p, prim_value);
+  *prim_value_p = ecma_make_boolean_value (boolean_value);
 
   return ecma_make_object_value (obj_p);
 } /* ecma_op_create_boolean_object */

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -98,9 +98,9 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
 
   ecma_deref_object (prototype_obj_p);
 
-  ecma_property_t *class_prop_p = ecma_create_internal_property (new_error_obj_p,
-                                                                 ECMA_INTERNAL_PROPERTY_CLASS);
-  ECMA_PROPERTY_VALUE_PTR (class_prop_p)->value = LIT_MAGIC_STRING_ERROR_UL;
+  ecma_value_t *class_prop_p = ecma_create_internal_property (new_error_obj_p,
+                                                              ECMA_INTERNAL_PROPERTY_CLASS);
+  *class_prop_p = LIT_MAGIC_STRING_ERROR_UL;
 
   return new_error_obj_p;
 } /* ecma_new_standard_error */

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -519,13 +519,11 @@ ecma_op_function_has_instance (ecma_object_t *func_obj_p, /**< Function object *
     JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_BOUND_FUNCTION);
 
     /* 1. */
-    ecma_property_t *target_function_prop_p;
+    ecma_value_t *target_function_prop_p;
     target_function_prop_p = ecma_get_internal_property (func_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
-    ecma_object_t *target_func_obj_p;
-    target_func_obj_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
-                                                         ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
+    ecma_object_t *target_func_obj_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t, *target_function_prop_p);
 
     /* 3. */
     ret_value = ecma_op_object_has_instance (target_func_obj_p, value);
@@ -654,27 +652,22 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
     JERRY_CONTEXT (is_direct_eval_form_call) = false;
 
     /* 2-3. */
-    ecma_property_t *bound_this_prop_p;
-    ecma_property_t *target_function_prop_p;
-
-    bound_this_prop_p = ecma_get_internal_property (func_obj_p, ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_THIS);
+    ecma_value_t *target_function_prop_p;
     target_function_prop_p = ecma_get_internal_property (func_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
-    ecma_object_t *target_func_obj_p;
-    target_func_obj_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
-                                                         ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
+    ecma_object_t *target_func_obj_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t, *target_function_prop_p);
 
     /* 4. */
-    ecma_property_t *bound_args_prop_p;
-    ecma_value_t bound_this_value = ECMA_PROPERTY_VALUE_PTR (bound_this_prop_p)->value;
-    bound_args_prop_p = ecma_find_internal_property (func_obj_p, ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS);
+    ecma_value_t *bound_args_prop_p = ecma_find_internal_property (func_obj_p,
+                                                                   ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS);
+    ecma_value_t bound_this_value = *ecma_get_internal_property (func_obj_p,
+                                                                 ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_THIS);
 
     if (bound_args_prop_p != NULL)
     {
       ecma_collection_header_t *bound_arg_list_p;
-      bound_arg_list_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_header_t,
-                                                          ECMA_PROPERTY_VALUE_PTR (bound_args_prop_p)->value);
+      bound_arg_list_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_header_t, *bound_args_prop_p);
 
       JERRY_ASSERT (bound_arg_list_p->unit_number > 0);
 
@@ -843,13 +836,11 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
     JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_BOUND_FUNCTION);
 
     /* 1. */
-    ecma_property_t *target_function_prop_p;
+    ecma_value_t *target_function_prop_p;
     target_function_prop_p = ecma_get_internal_property (func_obj_p,
                                                          ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION);
 
-    ecma_object_t *target_func_obj_p;
-    target_func_obj_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
-                                                         ECMA_PROPERTY_VALUE_PTR (target_function_prop_p)->value);
+    ecma_object_t *target_func_obj_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t, *target_function_prop_p);
 
     /* 2. */
     if (!ecma_is_constructor (ecma_make_object_value (target_func_obj_p)))
@@ -859,14 +850,13 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
     else
     {
       /* 4. */
-      ecma_property_t *bound_args_prop_p;
+      ecma_value_t *bound_args_prop_p;
       bound_args_prop_p = ecma_find_internal_property (func_obj_p, ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS);
 
       if (bound_args_prop_p != NULL)
       {
         ecma_collection_header_t *bound_arg_list_p;
-        bound_arg_list_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_header_t,
-                                                            ECMA_PROPERTY_VALUE_PTR (bound_args_prop_p)->value);
+        bound_arg_list_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_header_t, *bound_args_prop_p);
 
         JERRY_ASSERT (bound_arg_list_p->unit_number > 0);
 

--- a/jerry-core/ecma/operations/ecma-number-object.c
+++ b/jerry-core/ecma/operations/ecma-number-object.c
@@ -60,14 +60,14 @@ ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Numb
                                              ECMA_OBJECT_TYPE_GENERAL);
   ecma_deref_object (prototype_obj_p);
 
-  ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  ECMA_PROPERTY_VALUE_PTR (class_prop_p)->value = LIT_MAGIC_STRING_NUMBER_UL;
+  ecma_value_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
+  *class_prop_p = LIT_MAGIC_STRING_NUMBER_UL;
 
-  ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
-                                                                      ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+  ecma_value_t *prim_value_p = ecma_create_internal_property (obj_p,
+                                                              ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
 
   /* Pass reference (no need to free conv_to_num_completion). */
-  ecma_set_internal_property_value (prim_value_prop_p, conv_to_num_completion);
+  *prim_value_p = conv_to_num_completion;
 
   return ecma_make_object_value (obj_p);
 } /* ecma_op_create_number_object */

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -940,8 +940,8 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
       }
       else
       {
-        ecma_property_t *class_name_prop_p = ecma_find_internal_property (obj_p,
-                                                                          ECMA_INTERNAL_PROPERTY_CLASS);
+        ecma_value_t *class_name_prop_p = ecma_find_internal_property (obj_p,
+                                                                       ECMA_INTERNAL_PROPERTY_CLASS);
 
         if (class_name_prop_p == NULL)
         {
@@ -949,7 +949,7 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
         }
         else
         {
-          return ECMA_PROPERTY_VALUE_PTR (class_name_prop_p)->value;
+          return *class_name_prop_p;
         }
       }
     }

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -231,13 +231,12 @@ ecma_op_create_regexp_object_from_bytecode (re_compiled_code_t *bytecode_p) /**<
   ecma_deref_object (re_prototype_obj_p);
 
   /* Set the internal [[Class]] property */
-  ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  ECMA_PROPERTY_VALUE_PTR (class_prop_p)->value = LIT_MAGIC_STRING_REGEXP_UL;
+  ecma_value_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
+  *class_prop_p = LIT_MAGIC_STRING_REGEXP_UL;
 
   /* Set bytecode internal property. */
-  ecma_property_t *bytecode_prop_p;
-  bytecode_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
-  ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (bytecode_prop_p)->value, bytecode_p);
+  ecma_value_t *bytecode_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
+  ECMA_SET_INTERNAL_VALUE_POINTER (*bytecode_prop_p, bytecode_p);
   ecma_bytecode_ref ((ecma_compiled_code_t *) bytecode_p);
 
   /* Initialize RegExp object properties */
@@ -283,20 +282,20 @@ ecma_op_create_regexp_object (ecma_string_t *pattern_p, /**< input pattern */
   ecma_deref_object (re_prototype_obj_p);
 
   /* Set the internal [[Class]] property */
-  ecma_property_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
-  ECMA_PROPERTY_VALUE_PTR (class_prop_p)->value = LIT_MAGIC_STRING_REGEXP_UL;
+  ecma_value_t *class_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_CLASS);
+  *class_prop_p = LIT_MAGIC_STRING_REGEXP_UL;
 
   re_initialize_props (obj_p, pattern_p, flags);
 
   /* Set bytecode internal property. */
-  ecma_property_t *bytecode_prop_p;
-  bytecode_prop_p = ecma_create_internal_property (obj_p, ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
+  ecma_value_t *bytecode_prop_p = ecma_create_internal_property (obj_p,
+                                                                 ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
 
   /* Compile bytecode. */
   const re_compiled_code_t *bc_p = NULL;
   ECMA_TRY_CATCH (empty, re_compile_bytecode (&bc_p, pattern_p, flags), ret_value);
 
-  ECMA_SET_INTERNAL_VALUE_POINTER (ECMA_PROPERTY_VALUE_PTR (bytecode_prop_p)->value, bc_p);
+  ECMA_SET_INTERNAL_VALUE_POINTER (*bytecode_prop_p, bc_p);
   ret_value = ecma_make_object_value (obj_p);
 
   ECMA_FINALIZE (empty);
@@ -1241,10 +1240,9 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
 
   JERRY_ASSERT (ecma_object_get_class_name (regexp_object_p) == LIT_MAGIC_STRING_REGEXP_UL);
 
-  ecma_property_t *bytecode_prop_p = ecma_get_internal_property (regexp_object_p,
-                                                                 ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
-  re_compiled_code_t *bc_p = ECMA_GET_INTERNAL_VALUE_POINTER (re_compiled_code_t,
-                                                              ECMA_PROPERTY_VALUE_PTR (bytecode_prop_p)->value);
+  ecma_value_t *bytecode_prop_p = ecma_get_internal_property (regexp_object_p,
+                                                              ECMA_INTERNAL_PROPERTY_REGEXP_BYTECODE);
+  re_compiled_code_t *bc_p = ECMA_GET_INTERNAL_VALUE_POINTER (re_compiled_code_t, *bytecode_prop_p);
 
   if (bc_p == NULL)
   {

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -94,9 +94,9 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
    * See also: ecma_object_get_class_name
    */
 
-  ecma_property_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
-                                                                      ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
-  ecma_set_internal_property_value (prim_value_prop_p, ecma_make_string_value (prim_prop_str_value_p));
+  ecma_value_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
+                                                                   ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+  *prim_value_prop_p = ecma_make_string_value (prim_prop_str_value_p);
 
   // 15.5.5.1
   ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
@@ -168,10 +168,9 @@ ecma_op_string_object_get_own_property (ecma_object_t *obj_p, /**< a String obje
   }
 
   // 4.
-  ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
-                                                                   ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
-  ecma_string_t *prim_value_str_p;
-  prim_value_str_p = ecma_get_string_from_value (ecma_get_internal_property_value (prim_value_prop_p));
+  ecma_value_t *prim_value_p = ecma_get_internal_property (obj_p,
+                                                           ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+  ecma_string_t *prim_value_str_p = ecma_get_string_from_value (*prim_value_p);
 
   // 6.
   ecma_length_t length = ecma_string_get_length (prim_value_str_p);
@@ -235,10 +234,9 @@ ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p, /**< a String obj
   ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? main_collection_p : non_enum_collection_p;
   JERRY_UNUSED (for_non_enumerable_p);
 
-  ecma_property_t *prim_value_prop_p = ecma_get_internal_property (obj_p,
-                                                                   ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
-  ecma_string_t *prim_value_str_p;
-  prim_value_str_p = ecma_get_string_from_value (ecma_get_internal_property_value (prim_value_prop_p));
+  ecma_value_t *prim_value_p = ecma_get_internal_property (obj_p,
+                                                           ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+  ecma_string_t *prim_value_str_p = ecma_get_string_from_value (*prim_value_p);
 
   ecma_length_t length = ecma_string_get_length (prim_value_str_p);
 

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -1706,21 +1706,9 @@ jerry_set_object_native_handle (const jerry_value_t obj_val, /**< object to set 
                                          ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE,
                                          handle_p);
 
-  if (freecb_p != NULL)
-  {
-    ecma_create_external_pointer_property (object_p,
-                                           ECMA_INTERNAL_PROPERTY_FREE_CALLBACK,
-                                           (uintptr_t) freecb_p);
-  }
-  else
-  {
-    ecma_property_t *prop_p = ecma_find_internal_property (object_p,
-                                                           ECMA_INTERNAL_PROPERTY_FREE_CALLBACK);
-    if (prop_p != NULL)
-    {
-      ecma_delete_property (object_p, prop_p);
-    }
-  }
+  ecma_create_external_pointer_property (object_p,
+                                         ECMA_INTERNAL_PROPERTY_FREE_CALLBACK,
+                                         (uintptr_t) freecb_p);
 } /* jerry_set_object_native_handle */
 
 /**


### PR DESCRIPTION
Start reworking the property handling.

This patch has a negligible perf change (+0.18%), but reduces binary size by 600 bytes: 157304 -> 156744.