### PR TITLE
Disallow failures of Travis CI jobs on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,3 @@ matrix:
       env: OPTS="--jerry-tests --jerry-test-suite"
     - os: osx
       env: OPTS=--unittests
-  allow_failures:
-    - os: osx


### PR DESCRIPTION
Related issue: #1296 

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu