### PR TITLE
Fix warnings reported on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
   endif()
   jerry_add_compile_warnings(logical-op)
 else()
-  jerry_add_compile_flags(-Wno-nested-anon-types)
+  jerry_add_compile_flags(-Wno-nested-anon-types -Wno-static-in-inline)
 endif()
 
 if(DEFINED EXTERNAL_COMPILE_FLAGS)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -106,17 +106,17 @@ ecma_date_days_in_year (ecma_number_t year) /**< year value */
     return year; /* year is NaN */
   }
 
-  if (fmod (floor (year), 4))
+  if (fmod (floor (year), 4) != ECMA_NUMBER_ZERO)
   {
     return (ecma_number_t) 365;
   }
 
-  if (fmod (floor (year), 100))
+  if (fmod (floor (year), 100) != ECMA_NUMBER_ZERO)
   {
     return (ecma_number_t) 366;
   }
 
-  if (fmod (floor (year), 400))
+  if (fmod (floor (year), 400) != ECMA_NUMBER_ZERO)
   {
     return (ecma_number_t) 365;
   }

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -734,7 +734,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
 
         while (*bc_p == RE_OP_ALTERNATIVE)
         {
-          JERRY_TRACE_MSG (", jump: %d");
+          JERRY_TRACE_MSG (", jump: %d", offset);
           bc_p++;
           offset = re_get_value (&bc_p);
           bc_p += offset;

--- a/jerry-core/jerry-port.h
+++ b/jerry-core/jerry-port.h
@@ -80,7 +80,7 @@ void jerry_port_fatal (jerry_fatal_code_t code);
  *
  * Example: a libc-based port may implement this with vprintf().
  */
-void jerry_port_console (const char *format, ...);
+void jerry_port_console (const char *format, ...) __attribute__ ((format (printf, 1, 2)));
 
 /**
  * Jerry log levels. The levels are in severity order
@@ -110,7 +110,7 @@ typedef enum
  * Example: a libc-based port may implement this with vfprintf(stderr) or
  * vfprintf(logfile), or both, depending on log level.
  */
-void jerry_port_log (jerry_log_level_t level, const char *format, ...);
+void jerry_port_log (jerry_log_level_t level, const char *format, ...) __attribute__ ((format (printf, 2, 3)));
 
 /*
  * Date Port API

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -348,7 +348,7 @@ lit_read_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer with cha
   lit_utf8_byte_t c = buf_p[0];
   if ((c & LIT_UTF8_1_BYTE_MASK) == LIT_UTF8_1_BYTE_MARKER)
   {
-    *code_point = (lit_code_point_t) (c & LIT_UTF8_LAST_7_BITS_MASK);
+    *code_point = (ecma_char_t) (c & LIT_UTF8_LAST_7_BITS_MASK);
     return 1;
   }
 

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -270,7 +270,7 @@ main (int argc,
         return JERRY_STANDALONE_EXIT_CODE_FAIL;
       }
 
-      jerry_port_default_set_log_level (argv[i][0] - '0');
+      jerry_port_default_set_log_level ((jerry_log_level_t) (argv[i][0] - '0'));
     }
     else if (!strcmp ("--abort-on-fail", argv[i]))
     {


### PR DESCRIPTION
OS X build regularly reports some 39 warnings falling in 3 major
categories:

* "static function '...' is used in an inline function with
  external linkage [-Wstatic-in-inline]": Some semantics around
  `inline` have changed between C89 and C99, and gcc and clang seem
  to disagree on how strict they should be about them. Solution
  chosen is to use `-Wnostatic-in-inline` command line option for
  clang.

* "implicit conversion turns floating-point number into integer:
  'double' to 'bool' [-Wfloat-conversion]": `if (fmod (..., ...))`
  was used at different places, which is not nice anyway, thus the
  return value is compared explicitly against `ECMA_NUMBER_ZERO`.

* "format string is not a string literal [-Wformat-nonliteral]":
  Console and log port I/O functions have a printf-like interface,
  and the default implementations actually pass both format string
  and the remaining arguments to a vfprintf. However, clang is
  strict about the format string parameter of vfprintf and expects
  a literal there. By annotating the port I/O functions with
  `__attribute__ ((format (printf, ..., ...)))`, clang will check
  the format string being a literal string earlier, when the port
  functions are called, and will not complain within them when
  vfprintf is called.
  (Actually, this has revealed an incorrect format string, which
  has been fixed as well.)

(There were also some single conversion errors not listed above.)

The patch was tested on OS X (where all warnings disappeared), but
it should help clang compilation on other OS's as well.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu