### PR TITLE
SplitMatch operation should not set its return array element with [[Put]]

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1564,7 +1564,14 @@ ecma_builtin_helper_split_match (ecma_value_t input_string, /**< first argument 
         ecma_object_t *match_array_p = ecma_get_object_from_value (match_array);
         ecma_string_t *zero_str_p = ecma_new_ecma_string_from_number (ECMA_NUMBER_ZERO);
 
-        ecma_op_object_put (match_array_p, zero_str_p, ecma_make_string_value (separator_str_p), true);
+        ecma_value_t put_comp = ecma_builtin_helper_def_prop (match_array_p,
+                                                              zero_str_p,
+                                                              ecma_make_string_value (separator_str_p),
+                                                              true,
+                                                              true,
+                                                              true,
+                                                              true);
+        JERRY_ASSERT (ecma_is_value_true (put_comp));
 
         ecma_string_t *magic_index_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
         ecma_property_t *index_prop_p = ecma_create_named_data_property (match_array_p,

--- a/tests/jerry/regression-test-issue-1076.js
+++ b/tests/jerry/regression-test-issue-1076.js
@@ -1,0 +1,18 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright 2016 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try { Array.prototype.unshift(1)  } catch($){}
+try { Object.freeze(this.Array.prototype)()  } catch($){}
+try { new String(1).split("")  } catch($){}


### PR DESCRIPTION
Related issue: #1076 

I used `ecma_builtin_helper_def_prop` instead of `ecma_create_named_data_property` and `ecma_set_named_data_property_value` because the length of the result array should be set correctly.