### PR TITLE
vm_op_set_value should be able to throw error when ecma_op_to_string throws

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -143,7 +143,7 @@ vm_op_set_value (ecma_value_t object, /**< base object */
     ecma_value_t to_string = ecma_op_to_string (property);
     ecma_fast_free_value (property);
 
-    if (ECMA_IS_VALUE_ERROR (property))
+    if (ECMA_IS_VALUE_ERROR (to_string))
     {
       ecma_free_value (object);
       return to_string;

--- a/tests/jerry/regression-test-issue-1309.js
+++ b/tests/jerry/regression-test-issue-1309.js
@@ -1,0 +1,31 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright 2016 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var errorMessage = "toStringThrows"
+
+var toStringThrows = {
+  toString : function() {
+    throw new Error(errorMessage);
+  }
+}
+
+try {
+  var obj = {};
+  obj[toStringThrows] = 3;
+  assert(false);
+} catch (e) {
+  assert(e.message == errorMessage);
+}
+


### PR DESCRIPTION
Related issue: https://github.com/Samsung/jerryscript/issues/1309