### PR TITLE
Remove problems with gettimeofday, newlibc and zephyr SDK

### DIFF
--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -84,7 +84,7 @@ EXT_CFLAGS += -Wall -Wno-format-zero-length -Wno-pointer-sign
 EXT_CFLAGS += -Werror=format -Werror=implicit-int -Wno-unused-but-set-variable
 EXT_CFLAGS += -Wno-main -Wno-strict-aliasing -Wno-old-style-declaration
 EXT_CFLAGS += -Wno-error=format=
-EXT_CFLAGS += -D_XOPEN_SOURCE
+EXT_CFLAGS += -D_XOPEN_SOURCE=700
 
 # Pass2
 -include $(ZEPHYR_BASE)/scripts/Makefile.toolchain.$(ZEPHYR_GCC_VARIANT)
@@ -94,9 +94,8 @@ CC = $(CROSS_COMPILE)gcc
 ZEPHYR_LIBC_INC = $(subst -I,,$(TOOLCHAIN_CFLAGS))
 LIB_INCLUDE_DIR += -L $(CURDIR)/$(OUTPUT)
 
-# TODO: Order of includes seems to have changed and time_t seems to be defined differently. Temporary disable the conversion and sign-conversion until we find what is happening
-# this will generate warnings on the default date port.
-EXT_CFLAGS += -Wno-error=conversion -Wno-error=sign-conversion
+# TODO: There is a warning when compiling in some architectures related to __sputc_r
+EXT_CFLAGS += -Wno-error=conversion
 EXT_CFLAGS += $(LIB_INCLUDE_DIR)
 EXT_CFLAGS += $(TOOLCHAIN_CFLAGS)
 


### PR DESCRIPTION
Fix Zephyr build

With the changes to the zephyr sdk, gettimeofday is being guarded
by XOPEN_SOURCE_EXTENDED which requires at least 700 on XOPEN_SOURCE to be active

This little patch also helps on removing most of the warnings we had before
related to that issue.

More info on this feature:
http://man7.org/linux/man-pages/man7/feature_test_macros.7.html

Another option was to enable _GNU_SOURCE for this port.

There are still some harmless warnings related to __sputc_r for which we still require
the convertion warning.

Tested on qemu_cortex_m3, qemu_x86, arduino_101 and frdm_k64f.
Zephyr Sdk 0.8.2, Zephyr 1.5.0-rc4 & Zephyr ec39b216

JerryScript-DCO-1.0-Signed-off-by: Sergio Martinez sergio.martinez.rodriguez@intel.com