### PR TITLE
Add missing jerry-libm include path to jerry-core target.

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -231,3 +231,7 @@ target_include_directories(${JERRY_CORE_NAME} PUBLIC ${INCLUDE_CORE})
 if (JERRY_LIBC)
   target_include_directories(${JERRY_CORE_NAME} SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/jerry-libc/include")
 endif()
+
+if (JERRY_LIBM)
+  target_include_directories(${JERRY_CORE_NAME} SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/jerry-libm/include")
+endif()


### PR DESCRIPTION
Add the 'jerry-libm/include' path to specified include directories to jerry-core target in case of enabled jerry-libm build.