### PR TITLE
Improve error messages

### DIFF
--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -639,8 +639,9 @@ parser_set_continues_to_current_position (parser_context_t *context_p, /**< cont
   }
 } /* parser_set_continues_to_current_position */
 
+#if JERRY_ENABLE_ERROR_MESSAGES
 /**
- * Returns with the striong representation of the error
+ * Returns with the string representation of the error
  */
 const char *
 parser_error_to_string (parser_error_t error) /**< error code */
@@ -925,13 +926,12 @@ parser_error_to_string (parser_error_t error) /**< error code */
     }
     default:
     {
-      break;
+      JERRY_ASSERT (error == PARSER_ERR_NO_ERROR);
+      return "No error.";
     }
   }
-
-  JERRY_ASSERT (error == PARSER_ERR_NO_ERROR);
-  return "No error.";
 } /* parser_error_to_string */
+#endif /* JERRY_ENABLE_ERROR_MESSAGES */
 
 /**
  * @}

--- a/jerry-core/parser/js/js-parser.h
+++ b/jerry-core/parser/js/js-parser.h
@@ -126,7 +126,7 @@ typedef struct
   parser_error_t error;                               /**< error code */
   parser_line_counter_t line;                         /**< line where the error occured */
   parser_line_counter_t column;                       /**< column where the error occured */
-} parser_error_location;
+} parser_error_location_t;
 
 /* Note: source must be a valid UTF-8 string */
 extern ecma_value_t parser_parse_script (const uint8_t *, size_t, bool, ecma_compiled_code_t **);

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -85,7 +85,7 @@ assert_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< f
   }
   else
   {
-    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Script error: assertion failed\n");
+    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Script Error: assertion failed\n");
     exit (JERRY_STANDALONE_EXIT_CODE_FAIL);
   }
 } /* assert_handler */
@@ -144,7 +144,7 @@ print_unhandled_exception (jerry_value_t error_value)
   }
   err_str_buf[err_str_size] = 0;
 
-  jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Script Error: unhandled exception: %s\n", err_str_buf);
+  jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Script Error: %s\n", err_str_buf);
   jerry_release_value (err_str_val);
 } /* print_unhandled_exception */
 

--- a/tests/unit/test-api.c
+++ b/tests/unit/test-api.c
@@ -724,6 +724,28 @@ main (void)
 
   TEST_ASSERT (test_api_is_free_callback_was_called);
 
+  // Test: parser error location
+  jerry_init (JERRY_INIT_SHOW_OPCODES);
+
+  const char *parser_err_src_p = "b = 'hello';\nvar a = (;";
+  parsed_code_val = jerry_parse ((jerry_char_t *) parser_err_src_p,
+                                 strlen (parser_err_src_p),
+                                 false);
+  TEST_ASSERT (jerry_value_has_error_flag (parsed_code_val));
+  jerry_value_clear_error_flag (&parsed_code_val);
+  jerry_value_t err_str_val = jerry_value_to_string (parsed_code_val);
+  jerry_size_t err_str_size = jerry_get_string_size (err_str_val);
+  jerry_char_t err_str_buf[256];
+  sz = jerry_string_to_char_buffer (err_str_val, err_str_buf, err_str_size);
+  err_str_buf[sz] = 0;
+
+  jerry_release_value (err_str_val);
+  jerry_release_value (parsed_code_val);
+
+  TEST_ASSERT (!strcmp ((char *) err_str_buf,
+                        "SyntaxError: Primary expression expected. [line: 2, column: 10]"));
+  jerry_cleanup ();
+
   // External Magic String
   jerry_init (JERRY_INIT_SHOW_OPCODES);
 

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -62,8 +62,8 @@ class Options:
 
 # Test options for unittests
 jerry_unittests_options = [
-                           Options('unittests', ['--unittests']),
-                           Options('unittests-debug', ['--unittests', '--debug']),
+                           Options('unittests', ['--unittests', '--error-messages=on']),
+                           Options('unittests-debug', ['--unittests', '--debug', '--error-messages=on']),
                           ]
 
 # Test options for jerry-tests


### PR DESCRIPTION
 * Print location on parser errors.
 * Do not print messages on parse error if FEATURE_ERROR_MESSAGES is not set.
 * Minor style fixes

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com