### PR TITLE
Add tolerant mode to Signed-off-by check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 script: "python tools/run-tests.py $OPTS"
 
 env:
-  - OPTS="--check-signed-off --check-cppcheck --check-vera"
+  - OPTS="--check-signed-off-travis --check-cppcheck --check-vera"
   - OPTS="--jerry-tests --jerry-test-suite"
   - OPTS="--jerry-tests --jerry-test-suite --toolchain=cmake/toolchain_linux_armv7l.cmake" TIMEOUT=300
   - OPTS=--buildoption-test

--- a/tools/check-signed-off.sh
+++ b/tools/check-signed-off.sh
@@ -15,6 +15,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Usage
+function print_usage
+{
+ echo "Usage: $0 [--help] [--tolerant]"
+}
+
+function print_help
+{
+ echo "$0: Check Signed-off-by message of the latest commit"
+ echo ""
+ print_usage
+ echo ""
+ echo "Optional arguments:"
+ echo "  --help            print this help message"
+ echo "  --tolerant        check the existence of the message only but don't"
+ echo "                    require the name and email address to match the author"
+ echo "                    of the commit"
+ echo ""
+ echo "The last line of every commit message must follow the form of:"
+ echo "'JerryScript-DCO-1.0-Signed-off-by: NAME EMAIL', where NAME and EMAIL must"
+ echo "match the name and email address of the author of the commit (unless in"
+ echo "tolerant mode)."
+}
+
+# Processing command line
+TOLERANT="no"
+while [ "$#" -gt 0 ]
+do
+ if [ "$1" == "--help" ]
+ then
+  print_help
+  exit 0
+ elif [ "$1" == "--tolerant" ]
+ then
+  TOLERANT="yes"
+  shift
+ else
+  print_usage
+  exit 1
+ fi
+done
+
+# Determining latest commit
 parent_hashes=(`git show -s --format=%p HEAD | head -1`)
 
 if [ "${#parent_hashes[@]}" -eq 1 ]
@@ -28,16 +71,27 @@ else
  exit 1
 fi
 
-author_name=`git show -s --format=%an $commit_hash`
-author_email=`git show -s --format=%ae $commit_hash`
-required_signed_off_by_line="JerryScript-DCO-1.0-Signed-off-by: $author_name $author_email"
+# Checking the last line
 actual_signed_off_by_line=`git show -s --format=%B $commit_hash | sed '/^$/d' | tr -d '\015' | tail -n 1`
 
-if [ "$actual_signed_off_by_line" != "$required_signed_off_by_line" ]
+if [ "$TOLERANT" == "no" ]
 then
- echo -e "\e[1;33mSigned-off-by message is incorrect. The following line should be at the end of the $commit_hash commit's message: '$required_signed_off_by_line'. \e[0m"
+ author_name=`git show -s --format=%an $commit_hash`
+ author_email=`git show -s --format=%ae $commit_hash`
+ required_signed_off_by_line="JerryScript-DCO-1.0-Signed-off-by: $author_name $author_email"
 
- exit 1
+ if [ "$actual_signed_off_by_line" != "$required_signed_off_by_line" ]
+ then
+  echo -e "\e[1;33mSigned-off-by message is incorrect. The following line should be at the end of the $commit_hash commit's message: '$required_signed_off_by_line'. \e[0m"
+  exit 1
+ fi
+else
+  echo -e "\e[1;33mWarning! The name and email address of the author of the $commit_hash commit is not checked in tolerant mode! \e[0m"
+  if echo "$actual_signed_off_by_line" | grep -q -v '^JerryScript-DCO-1.0-Signed-off-by:'
+  then
+   echo -e "\e[1;33mSigned-off-by message is incorrect. The following line should be at the end of the $commit_hash commit's message: '$required_signed_off_by_line'. \e[0m"
+   exit 1
+  fi
 fi
 
 exit 0


### PR DESCRIPTION
In tolerant mode, only the existence of the Signed-off-by line is
checked but the name and address is not matched against the author
of the commit.

The tools/run-check.py script is extended to allow calling the
check script in tolerant mode and also to detect whether it is
being run by Travis CI.

The Travis CI config has been modified to check PRs in strict mode
but use tolerant mode for merges to master. This should enable the
use of the Merge button on the GitHub web interface. (The PR is
strictly checked when a contributor opens it but when a committer
merges it via the web interface and GitHub rewrites author details
from the contributor's profile, master will not turn red either.)

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu