### PR TITLE
Add git commit hash to jerry version info

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -112,33 +112,6 @@ endif()
 # Valgrind
 set(INCLUDE_THIRD_PARTY_VALGRIND "${CMAKE_SOURCE_DIR}/third-party/valgrind")
 
-# Definitions
-# Get version information from git
-if(IS_DIRECTORY "${CMAKE_SOURCE_DIR}/.git")
-  execute_process(COMMAND git symbolic-ref -q HEAD
-                  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                  OUTPUT_VARIABLE JERRY_GIT_BRANCH
-                  OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process(COMMAND git rev-parse HEAD
-                  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                  OUTPUT_VARIABLE JERRY_GIT_COMMIT
-                  OUTPUT_STRIP_TRAILING_WHITESPACE)
-else()
-  set(JERRY_GIT_BRANCH "UNDEFINED")
-  set(JERRY_GIT_COMMIT "UNDEFINED")
-endif()
-
-# Get build date
-execute_process(COMMAND date +%d/%m/%Y
-                OUTPUT_VARIABLE JERRY_BUILD_DATE
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-set(DEFINES_JERRY
-    ${DEFINES_JERRY}
-    JERRY_BUILD_DATE="${JERRY_BUILD_DATE}"
-    JERRY_COMMIT_HASH="${JERRY_GIT_COMMIT}"
-    JERRY_BRANCH_NAME="${JERRY_GIT_BRANCH}")
-
 # build mode specific compile/link flags
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_NDEBUG)

--- a/jerry-main/CMakeLists.txt
+++ b/jerry-main/CMakeLists.txt
@@ -21,7 +21,7 @@ project (${JERRY_NAME} C)
 # Jerry standalone
 set(SOURCE_JERRY_STANDALONE_MAIN main-unix.c)
 
-# Generage map file
+# Generate map file
 if("${PLATFORM}" STREQUAL "DARWIN")
   set(MAP_FILE_FLAGS "-Xlinker -map")
 else()
@@ -35,6 +35,19 @@ set(LINKER_FLAGS_COMMON "${LINKER_FLAGS_COMMON} ${MAP_FILE_FLAGS}")
 if(NOT ("${PLATFORM}" STREQUAL "DARWIN"))
   set(LINKER_FLAGS_STATIC "-static")
 endif()
+
+# Get version information from git
+if(IS_DIRECTORY "${CMAKE_SOURCE_DIR}/.git")
+  execute_process(COMMAND git rev-parse --short HEAD
+                  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                  OUTPUT_VARIABLE JERRY_COMMIT_HASH
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(JERRY_COMMIT_HASH " (${JERRY_COMMIT_HASH})")
+else()
+  set(JERRY_COMMIT_HASH "")
+endif()
+
+set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_COMMIT_HASH="${JERRY_COMMIT_HASH}")
 
 add_executable(${JERRY_NAME} ${SOURCE_JERRY_STANDALONE_MAIN})
 set_property(TARGET ${JERRY_NAME}

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -193,7 +193,7 @@ main (int argc,
     }
     else if (!strcmp ("-v", argv[i]) || !strcmp ("--version", argv[i]))
     {
-      jerry_port_console ("Version: \t%d.%d\n\n", JERRY_API_MAJOR_VERSION, JERRY_API_MINOR_VERSION);
+      jerry_port_console ("Version: %d.%d%s\n", JERRY_API_MAJOR_VERSION, JERRY_API_MINOR_VERSION, JERRY_COMMIT_HASH);
       return JERRY_STANDALONE_EXIT_CODE_OK;
     }
     else if (!strcmp ("--mem-stats", argv[i]))


### PR DESCRIPTION
Previously, jerry-core was built with various build identification
info (build date, git commit hash, git branch name), which was both
available from string constants of the library and also exposed by
jerry-main via the `--version` command line option. As of late,
jerry-core identifies itself only with API version number macros,
but sometimes it could be helpful to get access to the git commit
hash as well, even if that info does not become part of the API.

This patch moves the git commit hash retrieval logic from the build
scripts of jerry-core to jerry-main, and changes `--version` handler
to print the hash as well.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu