### PR TITLE
Make tools/settings.py lighter

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -102,15 +102,15 @@ def generate_build_options(arguments):
 def configure_output_dir(arguments):
     global BUILD_DIR
 
-    if os.path.isabs(arguments.builddir):
+    if path.isabs(arguments.builddir):
         BUILD_DIR = arguments.builddir
     else:
         BUILD_DIR = path.join(PROJECT_DIR, arguments.builddir)
 
-    if arguments.clean and os.path.exists(BUILD_DIR):
+    if arguments.clean and path.exists(BUILD_DIR):
         shutil.rmtree(BUILD_DIR)
 
-    if not os.path.exists(BUILD_DIR):
+    if not path.exists(BUILD_DIR):
         makedirs(BUILD_DIR)
 
 def configure_build(arguments):

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -16,7 +16,8 @@
 # limitations under the License.
 
 import argparse
-from subprocess import CalledProcessError
+import subprocess
+import sys
 from settings import *
 
 OUTPUT_DIR = path.join(PROJECT_DIR, 'build', 'tests')
@@ -39,7 +40,7 @@ if len(sys.argv) == 1:
 
 script_args = parser.parse_args()
 
-if os.path.isabs(script_args.outdir):
+if path.isabs(script_args.outdir):
     OUTPUT_DIR = script_args.outdir
 else:
     OUTPUT_DIR = path.join(PROJECT_DIR, script_args.outdir)
@@ -50,7 +51,7 @@ class Options:
     test_args = []
 
     def __init__(self, name = '', build_args = [], test_args = []):
-        self.out_dir = os.path.join(OUTPUT_DIR, name)
+        self.out_dir = path.join(OUTPUT_DIR, name)
         self.build_args = build_args
         self.build_args.append('--builddir=%s' % self.out_dir)
         self.test_args = test_args
@@ -108,10 +109,18 @@ def create_binary(buildoptions):
 
     try:
         script_output = subprocess.check_output(build_cmd)
-    except CalledProcessError as e:
+    except subprocess.CalledProcessError as e:
         return e.returncode
 
     return 0
+
+def run_check(runnable):
+    try:
+        ret = subprocess.check_call(runnable)
+    except subprocess.CalledProcessError as e:
+        return e.returncode
+
+    return ret
 
 def run_jerry_tests():
     ret_build = ret_test = 0

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -15,10 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import subprocess
-import sys
-from subprocess import CalledProcessError
 from os import path
 
 TOOLS_DIR = path.dirname(path.abspath(__file__))
@@ -33,11 +29,3 @@ SIGNED_OFF_SCRIPT = path.join(TOOLS_DIR, 'check-signed-off.sh')
 VERA_SCRIPT = path.join(TOOLS_DIR, 'check-vera.sh')
 TEST_RUNNER_SCRIPT = path.join(TOOLS_DIR, 'runners/run-test-suite.sh')
 UNITTEST_RUNNER_SCRIPT = path.join(TOOLS_DIR, 'runners/run-unittests.sh')
-
-def run_check(runnable):
-    try:
-        ret = subprocess.check_call(runnable)
-    except CalledProcessError as e:
-        return e.returncode
-
-    return ret


### PR DESCRIPTION
It should not import things it does not use and it should define
settings data only (i.e., definition of functions should not happen
there).

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu