### PR TITLE
Make jerry-main's link options configurable

### DIFF
--- a/jerry-main/CMakeLists.txt
+++ b/jerry-main/CMakeLists.txt
@@ -17,23 +17,34 @@ cmake_minimum_required (VERSION 2.8.12)
 set(JERRY_NAME jerry)
 project (${JERRY_NAME} C)
 
+# Optional build settings
+set(ENABLE_LINK_MAP    OFF CACHE BOOL "Enable generating a link map file?")
+set(ENABLE_STATIC_LINK ON  CACHE BOOL "Enable static linking?")
+
+if("${PLATFORM}" STREQUAL "DARWIN")
+  set(ENABLE_STATIC_LINK "OFF")
+endif()
+
+# Status messages
+message(STATUS "ENABLE_LINK_MAP           " ${ENABLE_LINK_MAP})
+message(STATUS "ENABLE_STATIC_LINK        " ${ENABLE_STATIC_LINK})
+
 # Sources
 # Jerry standalone
 set(SOURCE_JERRY_STANDALONE_MAIN main-unix.c)
 
 # Generate map file
-if("${PLATFORM}" STREQUAL "DARWIN")
-  set(MAP_FILE_FLAGS "-Xlinker -map")
-else()
-  set(MAP_FILE_FLAGS "-Xlinker -Map")
+if(ENABLE_LINK_MAP)
+  if("${PLATFORM}" STREQUAL "DARWIN")
+    set(LINKER_FLAGS_COMMON "${LINKER_FLAGS_COMMON} -Xlinker -map -Xlinker jerry.map")
+  else()
+    set(LINKER_FLAGS_COMMON "${LINKER_FLAGS_COMMON} -Xlinker -Map -Xlinker jerry.map")
+  endif()
 endif()
 
-set(MAP_FILE_FLAGS "${MAP_FILE_FLAGS} -Xlinker jerry.map")
-set(LINKER_FLAGS_COMMON "${LINKER_FLAGS_COMMON} ${MAP_FILE_FLAGS}")
-
 # Disable static build
-if(NOT ("${PLATFORM}" STREQUAL "DARWIN"))
-  set(LINKER_FLAGS_STATIC "-static")
+if(ENABLE_STATIC_LINK)
+  set(LINKER_FLAGS_COMMON "-static ${LINKER_FLAGS_COMMON}")
 endif()
 
 # Get version information from git
@@ -51,7 +62,7 @@ set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_COMMIT_HASH="${JERRY_COMMIT_HASH}")
 
 add_executable(${JERRY_NAME} ${SOURCE_JERRY_STANDALONE_MAIN})
 set_property(TARGET ${JERRY_NAME}
-             PROPERTY LINK_FLAGS "${LINKER_FLAGS_STATIC} ${LINKER_FLAGS_COMMON}")
+             PROPERTY LINK_FLAGS "${LINKER_FLAGS_COMMON}")
 target_compile_definitions(${JERRY_NAME} PRIVATE ${DEFINES_JERRY})
 target_include_directories(${JERRY_NAME} PRIVATE ${PORT_DIR})
 link_directories(${CMAKE_BINARY_DIR})

--- a/tools/build.py
+++ b/tools/build.py
@@ -57,6 +57,8 @@ def add_build_args(parser):
     parser.add_argument('--compiler-default-libc', choices=['on', 'off'], default='off', help='Use compiler-default libc (default: %(default)s)')
     parser.add_argument('--jerry-libm', choices=['on', 'off'], default='on', help='Build and use jerry-libm (default: %(default)s)')
     parser.add_argument('--jerry-cmdline', choices=['on', 'off'], default='on', help='Build jerry command line tool (default: %(default)s)')
+    parser.add_argument('--static-link', choices=['on', 'off'], default='on', help='Enable static linking of jerry command line tool (default: %(default)s)')
+    parser.add_argument('--link-map', choices=['on', 'off'], default='off', help='Enable the generation of a link map file for jerry command line tool (default: %(default)s)')
 
 def get_arguments():
     parser = argparse.ArgumentParser()
@@ -88,6 +90,8 @@ def generate_build_options(arguments):
     build_options.append('-DENABLE_LTO=%s' % arguments.lto.upper())
     build_options.append('-DENABLE_STRIP=%s' % arguments.strip.upper())
     build_options.append('-DUNITTESTS=%s' % arguments.unittests)
+    build_options.append('-DENABLE_STATIC_LINK=%s' % arguments.static_link.upper())
+    build_options.append('-DENABLE_LINK_MAP=%s' % arguments.link_map.upper())
 
     build_options.extend(arguments.cmake_param)
 


### PR DESCRIPTION
Until now,
* the link map of jerry-main has always been generated, even though
  it is not used that often;
* static linking has always been forced except for the OSX target.

This patch adds configuration options for these features.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu