### PR TITLE
Remove several ecma_op_object_get_[own_]property calls.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -79,6 +79,7 @@ typedef enum
   ECMA_SIMPLE_VALUE_TRUE, /**< boolean true */
   ECMA_SIMPLE_VALUE_UNDEFINED, /**< undefined value */
   ECMA_SIMPLE_VALUE_NULL, /**< null value */
+  ECMA_SIMPLE_VALUE_NOT_FOUND, /**< a special value returned by ecma_op_object_find */
   ECMA_SIMPLE_VALUE_REGISTER_REF, /**< register reference, a special "base" value for vm */
   ECMA_SIMPLE_VALUE__COUNT /** count of simple ecma values */
 } ecma_simple_value_t;

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -222,6 +222,18 @@ ecma_is_value_false (ecma_value_t value) /**< ecma value */
 } /* ecma_is_value_false */
 
 /**
+ * Check if the value is not found.
+ *
+ * @return true - if the value contains ecma-not-found simple value,
+ *         false - otherwise.
+ */
+inline bool __attr_pure___ __attr_always_inline___
+ecma_is_value_found (ecma_value_t value) /**< ecma value */
+{
+  return value != ecma_make_simple_value (ECMA_SIMPLE_VALUE_NOT_FOUND);
+} /* ecma_is_value_found */
+
+/**
  * Check if the value is array hole.
  *
  * @return true - if the value contains ecma-array-hole simple value,

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -120,6 +120,7 @@ extern bool ecma_is_value_null (ecma_value_t) __attr_pure___;
 extern bool ecma_is_value_boolean (ecma_value_t) __attr_pure___;
 extern bool ecma_is_value_true (ecma_value_t) __attr_pure___;
 extern bool ecma_is_value_false (ecma_value_t) __attr_pure___;
+extern bool ecma_is_value_found (ecma_value_t) __attr_pure___;
 extern bool ecma_is_value_array_hole (ecma_value_t) __attr_pure___;
 
 extern bool ecma_is_value_integer_number (ecma_value_t) __attr_pure___;

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -210,8 +210,6 @@ ecma_lcache_invalidate (ecma_object_t *object_p, /**< object */
   {
     if (entry_p->object_cp != ECMA_NULL_POINTER && entry_p->prop_p == prop_p)
     {
-      JERRY_ASSERT (ECMA_GET_NON_NULL_POINTER (ecma_string_t,
-                                               entry_p->prop_name_cp) == prop_name_p);
       JERRY_ASSERT (entry_p->object_cp == object_cp);
 
       ecma_lcache_invalidate_entry (entry_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -353,16 +353,15 @@ ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, /**< array */
       ecma_string_t *array_index_string_p = ecma_new_ecma_string_from_uint32 (array_index);
 
       /* 5.b.iii.2 */
-      if (ecma_op_object_get_property (ecma_get_object_from_value (value),
-                                       array_index_string_p) != NULL)
-      {
-        ecma_string_t *new_array_index_string_p = ecma_new_ecma_string_from_uint32 (*length_p + array_index);
+      ECMA_TRY_CATCH (get_value,
+                      ecma_op_object_find (ecma_get_object_from_value (value),
+                                           array_index_string_p),
+                      ret_value);
 
+      if (ecma_is_value_found (get_value))
+      {
         /* 5.b.iii.3.a */
-        ECMA_TRY_CATCH (get_value,
-                        ecma_op_object_get (ecma_get_object_from_value (value),
-                                            array_index_string_p),
-                        ret_value);
+        ecma_string_t *new_array_index_string_p = ecma_new_ecma_string_from_uint32 (*length_p + array_index);
 
         /* 5.b.iii.3.b */
         /* This will always be a simple value since 'is_throw' is false, so no need to free. */
@@ -375,10 +374,10 @@ ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, /**< array */
                                                               false); /* Failure handling */
 
         JERRY_ASSERT (ecma_is_value_true (put_comp));
-
-        ECMA_FINALIZE (get_value);
         ecma_deref_ecma_string (new_array_index_string_p);
       }
+
+      ECMA_FINALIZE (get_value);
 
       ecma_deref_ecma_string (array_index_string_p);
     }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
@@ -151,9 +151,7 @@ ecma_builtin_object_prototype_object_has_own_property (ecma_value_t this_arg, /*
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_val);
 
   /* 3. */
-  ecma_property_t *property_p = ecma_op_object_get_own_property (obj_p, property_name_string_p);
-
-  if (property_p != NULL)
+  if (ecma_op_object_has_own_property (obj_p, property_name_string_p))
   {
     return_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
   }
@@ -161,6 +159,7 @@ ecma_builtin_object_prototype_object_has_own_property (ecma_value_t this_arg, /*
   {
     return_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_FALSE);
   }
+
   ECMA_FINALIZE (obj_val);
 
   ECMA_FINALIZE (to_string_val);

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -622,7 +622,7 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
 
       ecma_string_t *name_p = ecma_get_magic_string (curr_property_p->magic_string_id);
 
-      if (!was_instantiated || ecma_op_object_get_own_property (object_p, name_p) != NULL)
+      if (!was_instantiated || ecma_op_object_has_own_property (object_p, name_p))
       {
         ecma_append_to_values_collection (for_non_enumerable_p,
                                           ecma_make_string_value (name_p),

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -582,17 +582,17 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
     // 3.
     ecma_string_t *enumerable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_ENUMERABLE);
 
-    if (ecma_op_object_get_property (obj_p, enumerable_magic_string_p) != NULL)
-    {
-      ECMA_TRY_CATCH (enumerable_prop_value,
-                      ecma_op_object_get (obj_p, enumerable_magic_string_p),
-                      ret_value);
+    ECMA_TRY_CATCH (enumerable_prop_value,
+                    ecma_op_object_find (obj_p, enumerable_magic_string_p),
+                    ret_value);
 
+    if (ecma_is_value_found (enumerable_prop_value))
+    {
       prop_desc.is_enumerable_defined = true;
       prop_desc.is_enumerable = ecma_op_to_boolean (enumerable_prop_value);
-
-      ECMA_FINALIZE (enumerable_prop_value);
     }
+
+    ECMA_FINALIZE (enumerable_prop_value);
 
     ecma_deref_ecma_string (enumerable_magic_string_p);
 
@@ -603,17 +603,17 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       // 4.
       ecma_string_t *configurable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CONFIGURABLE);
 
-      if (ecma_op_object_get_property (obj_p, configurable_magic_string_p) != NULL)
-      {
-        ECMA_TRY_CATCH (configurable_prop_value,
-                        ecma_op_object_get (obj_p, configurable_magic_string_p),
-                        ret_value);
+      ECMA_TRY_CATCH (configurable_prop_value,
+                      ecma_op_object_find (obj_p, configurable_magic_string_p),
+                      ret_value);
 
+      if (ecma_is_value_found (configurable_prop_value))
+      {
         prop_desc.is_configurable_defined = true;
         prop_desc.is_configurable = ecma_op_to_boolean (configurable_prop_value);
-
-        ECMA_FINALIZE (configurable_prop_value);
       }
+
+      ECMA_FINALIZE (configurable_prop_value);
 
       ecma_deref_ecma_string (configurable_magic_string_p);
     }
@@ -625,17 +625,17 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       // 5.
       ecma_string_t *value_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_VALUE);
 
-      if (ecma_op_object_get_property (obj_p, value_magic_string_p) != NULL)
-      {
-        ECMA_TRY_CATCH (value_prop_value,
-                        ecma_op_object_get (obj_p, value_magic_string_p),
-                        ret_value);
+      ECMA_TRY_CATCH (value_prop_value,
+                      ecma_op_object_find (obj_p, value_magic_string_p),
+                      ret_value);
 
+      if (ecma_is_value_found (value_prop_value))
+      {
         prop_desc.is_value_defined = true;
         prop_desc.value = ecma_copy_value (value_prop_value);
-
-        ECMA_FINALIZE (value_prop_value);
       }
+
+      ECMA_FINALIZE (value_prop_value);
 
       ecma_deref_ecma_string (value_magic_string_p);
     }
@@ -647,17 +647,17 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       // 6.
       ecma_string_t *writable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_WRITABLE);
 
-      if (ecma_op_object_get_property (obj_p, writable_magic_string_p) != NULL)
-      {
-        ECMA_TRY_CATCH (writable_prop_value,
-                        ecma_op_object_get (obj_p, writable_magic_string_p),
-                        ret_value);
+      ECMA_TRY_CATCH (writable_prop_value,
+                      ecma_op_object_find (obj_p, writable_magic_string_p),
+                      ret_value);
 
+      if (ecma_is_value_found (writable_prop_value))
+      {
         prop_desc.is_writable_defined = true;
         prop_desc.is_writable = ecma_op_to_boolean (writable_prop_value);
-
-        ECMA_FINALIZE (writable_prop_value);
       }
+
+      ECMA_FINALIZE (writable_prop_value);
 
       ecma_deref_ecma_string (writable_magic_string_p);
     }
@@ -669,12 +669,12 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       // 7.
       ecma_string_t *get_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GET);
 
-      if (ecma_op_object_get_property (obj_p, get_magic_string_p) != NULL)
-      {
-        ECMA_TRY_CATCH (get_prop_value,
-                        ecma_op_object_get (obj_p, get_magic_string_p),
-                        ret_value);
+      ECMA_TRY_CATCH (get_prop_value,
+                      ecma_op_object_find (obj_p, get_magic_string_p),
+                      ret_value);
 
+      if (ecma_is_value_found (get_prop_value))
+      {
         if (!ecma_op_is_callable (get_prop_value)
             && !ecma_is_value_undefined (get_prop_value))
         {
@@ -698,9 +698,9 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
             prop_desc.get_p = get_p;
           }
         }
-
-        ECMA_FINALIZE (get_prop_value);
       }
+
+      ECMA_FINALIZE (get_prop_value);
 
       ecma_deref_ecma_string (get_magic_string_p);
     }
@@ -713,12 +713,12 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
 
       ecma_string_t *set_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_SET);
 
-      if (ecma_op_object_get_property (obj_p, set_magic_string_p) != NULL)
-      {
-        ECMA_TRY_CATCH (set_prop_value,
-                        ecma_op_object_get (obj_p, set_magic_string_p),
-                        ret_value);
+      ECMA_TRY_CATCH (set_prop_value,
+                      ecma_op_object_find (obj_p, set_magic_string_p),
+                      ret_value);
 
+      if (ecma_is_value_found (set_prop_value))
+      {
         if (!ecma_op_is_callable (set_prop_value)
             && !ecma_is_value_undefined (set_prop_value))
         {
@@ -742,9 +742,9 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
             prop_desc.set_p = set_p;
           }
         }
-
-        ECMA_FINALIZE (set_prop_value);
       }
+
+      ECMA_FINALIZE (set_prop_value);
 
       ecma_deref_ecma_string (set_magic_string_p);
     }

--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -104,7 +104,7 @@ ecma_op_has_binding (ecma_object_t *lex_env_p, /**< lexical environment */
 
     ecma_object_t *binding_obj_p = ecma_get_lex_env_binding_object (lex_env_p);
 
-    return (ecma_op_object_get_property (binding_obj_p, name_p) != NULL);
+    return ecma_op_object_has_property (binding_obj_p, name_p);
   }
 } /* ecma_op_has_binding */
 
@@ -270,19 +270,21 @@ ecma_op_get_binding_value (ecma_object_t *lex_env_p, /**< lexical environment */
 
     ecma_object_t *binding_obj_p = ecma_get_lex_env_binding_object (lex_env_p);
 
-    if (ecma_op_object_get_property (binding_obj_p, name_p) == NULL)
+    ecma_value_t result = ecma_op_object_find (binding_obj_p, name_p);
+
+    if (!ecma_is_value_found (result))
     {
       if (is_strict)
       {
-        return ecma_raise_reference_error (ECMA_ERR_MSG (""));
+        result = ecma_raise_reference_error (ECMA_ERR_MSG (""));
       }
       else
       {
-        return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+        result = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
       }
     }
 
-    return ecma_op_object_get (binding_obj_p, name_p);
+    return result;
   }
 } /* ecma_op_get_binding_value */
 

--- a/jerry-core/ecma/operations/ecma-objects-arguments.h
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.h
@@ -23,10 +23,8 @@ extern void
 ecma_op_create_arguments_object (ecma_object_t *, ecma_object_t *, const ecma_value_t *,
                                  ecma_length_t, const ecma_compiled_code_t *);
 
-extern ecma_value_t
-ecma_op_arguments_object_get (ecma_object_t *, ecma_string_t *);
-extern ecma_property_t *
-ecma_op_arguments_object_get_own_property (ecma_object_t *, ecma_string_t *);
+extern void
+ecma_arguments_update_mapped_arg_value (ecma_object_t *, ecma_string_t *, ecma_property_t *);
 extern ecma_value_t
 ecma_op_arguments_object_delete (ecma_object_t *, ecma_string_t *, bool);
 extern ecma_value_t

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -130,60 +130,6 @@ ecma_op_create_object_object_noarg_and_set_prototype (ecma_object_t *object_prot
 } /* ecma_op_create_object_object_noarg_and_set_prototype */
 
 /**
- * [[Get]] ecma general object's operation
- *
- * See also:
- *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
- *          ECMA-262 v5, 8.12.3
- *
- * @return ecma value
- *         Returned value must be freed with ecma_free_value
- */
-ecma_value_t
-ecma_op_general_object_get (ecma_object_t *obj_p, /**< the object */
-                            ecma_string_t *property_name_p) /**< property name */
-{
-  JERRY_ASSERT (obj_p != NULL
-                && !ecma_is_lexical_environment (obj_p));
-  JERRY_ASSERT (property_name_p != NULL);
-
-  // 1.
-  const ecma_property_t *prop_p = ecma_op_object_get_property (obj_p, property_name_p);
-
-  // 2.
-  if (prop_p == NULL)
-  {
-    return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
-  }
-
-  // 3.
-  if (ECMA_PROPERTY_GET_TYPE (prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA)
-  {
-    return ecma_copy_value (ecma_get_named_data_property_value (prop_p));
-  }
-  else
-  {
-    // 4.
-    ecma_object_t *getter_p = ecma_get_named_accessor_property_getter (prop_p);
-
-    // 5.
-    if (getter_p == NULL)
-    {
-      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
-    }
-    else
-    {
-      return ecma_op_function_call (getter_p,
-                                    ecma_make_object_value (obj_p),
-                                    NULL,
-                                    0);
-    }
-  }
-
-  JERRY_UNREACHABLE ();
-} /* ecma_op_general_object_get */
-
-/**
  * [[GetOwnProperty]] ecma general object's operation
  *
  * See also:
@@ -203,47 +149,6 @@ ecma_op_general_object_get_own_property (ecma_object_t *obj_p, /**< the object *
 
   return ecma_find_named_property (obj_p, property_name_p);
 } /* ecma_op_general_object_get_own_property */
-
-/**
- * [[GetProperty]] ecma general object's operation
- *
- * See also:
- *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 8
- *          ECMA-262 v5, 8.12.2
- *
- * @return pointer to a property - if it exists,
- *         NULL (i.e. ecma-undefined) - otherwise.
- */
-ecma_property_t *
-ecma_op_general_object_get_property (ecma_object_t *obj_p, /**< the object */
-                                     ecma_string_t *property_name_p) /**< property name */
-{
-  JERRY_ASSERT (obj_p != NULL
-                && !ecma_is_lexical_environment (obj_p));
-  JERRY_ASSERT (property_name_p != NULL);
-
-  // 1.
-  ecma_property_t *prop_p = ecma_op_object_get_own_property (obj_p, property_name_p);
-
-  // 2.
-  if (prop_p != NULL)
-  {
-    return prop_p;
-  }
-
-  // 3.
-  ecma_object_t *prototype_p = ecma_get_object_prototype (obj_p);
-
-  // 4., 5.
-  if (prototype_p != NULL)
-  {
-    return ecma_op_object_get_property (prototype_p, property_name_p);
-  }
-  else
-  {
-    return NULL;
-  }
-} /* ecma_op_general_object_get_property */
 
 /**
  * [[Put]] ecma general object's operation

--- a/jerry-core/ecma/operations/ecma-objects-general.h
+++ b/jerry-core/ecma/operations/ecma-objects-general.h
@@ -31,9 +31,7 @@ extern ecma_object_t *ecma_op_create_object_object_noarg (void);
 extern ecma_value_t ecma_op_create_object_object_arg (ecma_value_t);
 extern ecma_object_t *ecma_op_create_object_object_noarg_and_set_prototype (ecma_object_t *);
 
-extern ecma_value_t ecma_op_general_object_get (ecma_object_t *, ecma_string_t *);
 extern ecma_property_t *ecma_op_general_object_get_own_property (ecma_object_t *, ecma_string_t *);
-extern ecma_property_t *ecma_op_general_object_get_property (ecma_object_t *, ecma_string_t *);
 extern ecma_value_t ecma_op_general_object_put (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
 extern ecma_value_t ecma_op_general_object_delete (ecma_object_t *, ecma_string_t *, bool);
 extern ecma_value_t ecma_op_general_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -26,9 +26,14 @@
  * @{
  */
 
-extern ecma_value_t ecma_op_object_get (ecma_object_t *, ecma_string_t *);
 extern ecma_property_t *ecma_op_object_get_own_property (ecma_object_t *, ecma_string_t *);
 extern ecma_property_t *ecma_op_object_get_property (ecma_object_t *, ecma_string_t *);
+extern bool ecma_op_object_has_own_property (ecma_object_t *, ecma_string_t *);
+extern bool ecma_op_object_has_property (ecma_object_t *, ecma_string_t *);
+extern ecma_value_t ecma_op_object_find_own (ecma_object_t *, ecma_string_t *);
+extern ecma_value_t ecma_op_object_find (ecma_object_t *, ecma_string_t *);
+extern ecma_value_t ecma_op_object_get_own_data_prop (ecma_object_t *, ecma_string_t *);
+extern ecma_value_t ecma_op_object_get (ecma_object_t *, ecma_string_t *);
 extern ecma_value_t ecma_op_object_put (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
 extern ecma_value_t ecma_op_object_delete (ecma_object_t *, ecma_string_t *, bool);
 extern ecma_value_t ecma_op_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);

--- a/jerry-core/ecma/operations/ecma-reference.c
+++ b/jerry-core/ecma/operations/ecma-reference.c
@@ -105,26 +105,11 @@ ecma_op_resolve_reference_value (ecma_object_t *lex_env_p, /**< starting lexical
 
       ecma_object_t *binding_obj_p = ecma_get_lex_env_binding_object (lex_env_p);
 
-      ecma_property_t *property_p = ecma_op_object_get_property (binding_obj_p, name_p);
+      ecma_value_t prop_value = ecma_op_object_find (binding_obj_p, name_p);
 
-      if (likely (property_p != NULL))
+      if (ecma_is_value_found (prop_value))
       {
-        if (ECMA_PROPERTY_GET_TYPE (property_p) == ECMA_PROPERTY_TYPE_NAMEDDATA)
-        {
-          return ecma_fast_copy_value (ecma_get_named_data_property_value (property_p));
-        }
-
-        ecma_object_t *getter_p = ecma_get_named_accessor_property_getter (property_p);
-
-        if (getter_p == NULL)
-        {
-          return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
-        }
-
-        return ecma_op_function_call (getter_p,
-                                      ecma_make_object_value (binding_obj_p),
-                                      NULL,
-                                      0);
+        return prop_value;
       }
     }
 

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -1311,11 +1311,9 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
   if (input_buffer_p && (re_ctx.flags & RE_FLAG_GLOBAL))
   {
     ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
-    ecma_property_t *lastindex_prop_p = ecma_op_object_get_property (regexp_object_p, magic_str_p);
+    ecma_value_t lastindex_value = ecma_op_object_get_own_data_prop (regexp_object_p, magic_str_p);
 
-    ECMA_OP_TO_NUMBER_TRY_CATCH (lastindex_num,
-                                 ecma_get_named_data_property_value (lastindex_prop_p),
-                                 ret_value)
+    ECMA_OP_TO_NUMBER_TRY_CATCH (lastindex_num, lastindex_value, ret_value)
 
     index = ecma_number_to_int32 (lastindex_num);
 
@@ -1330,6 +1328,8 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
     }
 
     ECMA_OP_TO_NUMBER_FINALIZE (lastindex_num);
+
+    ecma_fast_free_value (lastindex_value);
 
     ecma_deref_ecma_string (magic_str_p);
   }

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -1084,10 +1084,10 @@ jerry_has_property (const jerry_value_t obj_val, /**< object value */
     return false;
   }
 
-  ecma_property_t *prop_p = ecma_op_object_get_property (ecma_get_object_from_value (obj_val),
-                                                         ecma_get_string_from_value (prop_name_val));
+  bool has_property = ecma_op_object_has_property (ecma_get_object_from_value (obj_val),
+                                                   ecma_get_string_from_value (prop_name_val));
 
-  return ecma_make_boolean_value (prop_p != NULL);
+  return ecma_make_boolean_value (has_property);
 } /* jerry_has_property */
 
 /**
@@ -1108,10 +1108,10 @@ jerry_has_own_property (const jerry_value_t obj_val, /**< object value */
     return false;
   }
 
-  ecma_property_t *prop_p = ecma_op_object_get_own_property (ecma_get_object_from_value (obj_val),
-                                                             ecma_get_string_from_value (prop_name_val));
+  bool has_property = ecma_op_object_has_own_property (ecma_get_object_from_value (obj_val),
+                                                       ecma_get_string_from_value (prop_name_val));
 
-  return ecma_make_boolean_value (prop_p != NULL);
+  return ecma_make_boolean_value (has_property);
 } /* jerry_has_own_property */
 
 

--- a/jerry-core/vm/opcodes-ecma-relational.c
+++ b/jerry-core/vm/opcodes-ecma-relational.c
@@ -228,7 +228,7 @@ opfunc_in (ecma_value_t left_value, /**< left value */
     ecma_string_t *left_value_prop_name_p = ecma_get_string_from_value (str_left_value);
     ecma_object_t *right_value_obj_p = ecma_get_object_from_value (right_value);
 
-    if (ecma_op_object_get_property (right_value_obj_p, left_value_prop_name_p) != NULL)
+    if (ecma_op_object_has_property (right_value_obj_p, left_value_prop_name_p))
     {
       ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
     }

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -2169,8 +2169,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
             lit_utf8_byte_t *data_ptr = chunk_p->data;
             ecma_string_t *prop_name_p = ecma_get_string_from_value (*(ecma_value_t *) data_ptr);
 
-            if (ecma_op_object_get_property (ecma_get_object_from_value (stack_top_p[-3]),
-                                             prop_name_p) == NULL)
+            if (!ecma_op_object_has_property (ecma_get_object_from_value (stack_top_p[-3]),
+                                              prop_name_p))
             {
               stack_top_p[-2] = chunk_p->next_chunk_cp;
               ecma_deref_ecma_string (prop_name_p);


### PR DESCRIPTION
The ecma_op_object_get_[own_]property calls should be phased out from
the project eventually and virtual properties should be introduced instead.

Negligible perf improvement (+0.282%) and 200 byte binary size reduction (157080->156824)
