### PR TITLE
Enable `make install`

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -208,3 +208,6 @@ endif()
 if (JERRY_LIBM)
   target_include_directories(${JERRY_CORE_NAME} SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/jerry-libm/include")
 endif()
+
+install(TARGETS ${JERRY_CORE_NAME} DESTINATION lib)
+install(FILES jerry-api.h jerry-port.h DESTINATION include)

--- a/jerry-libc/CMakeLists.txt
+++ b/jerry-libc/CMakeLists.txt
@@ -47,3 +47,6 @@ add_library(${JERRY_LIBC_NAME} STATIC ${SOURCE_LIBC} ${TARGET_SPECIFIC_LIBC_SOUR
 target_compile_definitions(${JERRY_LIBC_NAME} PRIVATE ${DEFINES_LIBC})
 target_include_directories(${JERRY_LIBC_NAME} PRIVATE ${INCLUDE_LIBC})
 target_include_directories(${JERRY_LIBC_NAME} SYSTEM PUBLIC "${CMAKE_SOURCE_DIR}/jerry-libc/include")
+
+install(TARGETS ${JERRY_LIBC_NAME} DESTINATION lib)
+install(DIRECTORY ${INCLUDE_LIBC}/include/ DESTINATION include/jerry-libc)

--- a/jerry-libm/CMakeLists.txt
+++ b/jerry-libm/CMakeLists.txt
@@ -37,3 +37,6 @@ set_property(TARGET ${JERRY_LIBM_NAME}
 
 target_include_directories(${JERRY_LIBM_NAME} PRIVATE ${INCLUDE_LIBM})
 target_include_directories(${JERRY_LIBM_NAME} INTERFACE ${INCLUDE_LIBM})
+
+install(TARGETS ${JERRY_LIBM_NAME} DESTINATION lib)
+install(DIRECTORY ${INCLUDE_LIBM}/ DESTINATION include/jerry-libm)

--- a/jerry-main/CMakeLists.txt
+++ b/jerry-main/CMakeLists.txt
@@ -80,3 +80,5 @@ endif()
 set(JERRY_LIBS ${JERRY_LIBS} ${IMPORTED_LIB})
 
 target_link_libraries(${JERRY_NAME} ${JERRY_LIBS})
+
+install(TARGETS ${JERRY_NAME} DESTINATION bin)


### PR DESCRIPTION
With the new build system, the conventional `cmake && make` already
works. However, the last step, i.e., `make install` was still
missing (didn't work). This patch adds the `install()` commands to
CMakeLists that are required to generate the `install` target in
the Makefile.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu