### PR TITLE
Fix getter's this value

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -227,7 +227,8 @@ ecma_op_object_has_property (ecma_object_t *object_p, /**< the object */
  *         Returned value must be freed with ecma_free_value
  */
 ecma_value_t
-ecma_op_object_find_own (ecma_object_t *object_p, /**< the object */
+ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
+                         ecma_object_t *object_p, /**< target object */
                          ecma_string_t *property_name_p) /**< property name */
 {
   JERRY_ASSERT (object_p != NULL
@@ -241,7 +242,7 @@ ecma_op_object_find_own (ecma_object_t *object_p, /**< the object */
     ecma_value_t *map_prop_p = ecma_get_internal_property (object_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
     ecma_object_t *map_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t, *map_prop_p);
 
-    ecma_value_t arg_name = ecma_op_object_find_own (map_p, property_name_p);
+    ecma_value_t arg_name = ecma_op_object_find_own (*map_prop_p, map_p, property_name_p);
 
     if (ecma_is_value_found (arg_name))
     {
@@ -333,7 +334,7 @@ ecma_op_object_find_own (ecma_object_t *object_p, /**< the object */
     return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
   }
 
-  return ecma_op_function_call (getter_p, ecma_make_object_value (object_p), NULL, 0);
+  return ecma_op_function_call (getter_p, base_value, NULL, 0);
 } /* ecma_op_object_find_own */
 
 /**
@@ -352,9 +353,10 @@ ecma_op_object_find (ecma_object_t *object_p, /**< the object */
   /* Circular reference is possible in JavaScript and testing it is complicated. */
   int max_depth = 128;
 
+  ecma_value_t base_value = ecma_make_object_value (object_p);
   do
   {
-    ecma_value_t value = ecma_op_object_find_own (object_p, property_name_p);
+    ecma_value_t value = ecma_op_object_find_own (base_value, object_p, property_name_p);
 
     if (ecma_is_value_found (value))
     {
@@ -455,7 +457,7 @@ ecma_op_object_put (ecma_object_t *object_p, /**< the object */
     ecma_value_t *map_prop_p = ecma_get_internal_property (object_p, ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP);
     ecma_object_t *map_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t, *map_prop_p);
 
-    ecma_value_t arg_name = ecma_op_object_find_own (map_p, property_name_p);
+    ecma_value_t arg_name = ecma_op_object_find_own (*map_prop_p, map_p, property_name_p);
 
     if (ecma_is_value_found (arg_name))
     {

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -30,7 +30,7 @@ extern ecma_property_t *ecma_op_object_get_own_property (ecma_object_t *, ecma_s
 extern ecma_property_t *ecma_op_object_get_property (ecma_object_t *, ecma_string_t *);
 extern bool ecma_op_object_has_own_property (ecma_object_t *, ecma_string_t *);
 extern bool ecma_op_object_has_property (ecma_object_t *, ecma_string_t *);
-extern ecma_value_t ecma_op_object_find_own (ecma_object_t *, ecma_string_t *);
+extern ecma_value_t ecma_op_object_find_own (ecma_value_t, ecma_object_t *, ecma_string_t *);
 extern ecma_value_t ecma_op_object_find (ecma_object_t *, ecma_string_t *);
 extern ecma_value_t ecma_op_object_get_own_data_prop (ecma_object_t *, ecma_string_t *);
 extern ecma_value_t ecma_op_object_get (ecma_object_t *, ecma_string_t *);

--- a/tests/jerry/getter-setter-this-value.js
+++ b/tests/jerry/getter-setter-this-value.js
@@ -1,0 +1,34 @@
+// Copyright 2016 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function Box(data) {
+  this._data = data;
+}
+
+var box = new Box('=');
+
+Object.defineProperty(Box.prototype, 'data', {
+  get: function () {
+    assert(this === box);
+    return this._data;
+  },
+  set: function (data) {
+    assert(this === box);
+    this._data = data;
+  }
+});
+
+assert(box.data === '=');
+box.data = '+';
+assert(box.data === '+');


### PR DESCRIPTION
According to ECMA-262 section 8.7.1, the **this** value of _getter_ should be _base_. However, since commit da02a37a02b15f724f2155991fbbffaf394790d3 it is not properly set.
 
For the following test case, 

```javascript
if (typeof print === 'undefined') {
    print = console.log;
}

function Box() {
    this._data = '=';
    Object.defineProperty(this, 'data1', {
        get: function () {
            return this._data;
        },
        set: function (data) {
            this._data = data;
        }
    });
}

Object.defineProperty(Box.prototype, 'data2', {
    get: function () {
        if (typeof this._data === 'undefined') {
            throw new Error('getter oops');
        }
        return this._data;
    },
    set: function (data) {
        if (typeof this._data === 'undefined') {
            throw new Error('setter oops');
        }
        this._data = data;
    }
});

Object.defineProperties(Box.prototype, {
    'data3': {
        get: function () {
            return this._data;
        },
        set: function (data) {
            this._data = data;
        }
    }
});

var box = new Box();

Object.defineProperty(box, 'data4', {
    get: function () {
        return this._data;
    },
    set: function (data) {
        this._data = data;
    }
});

try {
    print(box.data1, box.data2, box.data3, box.data4);
} catch (e) {
    print(e);
}

try {
    box.data2 = '+';
    print(box.data1, box.data2, box.data3, box.data4);
} catch (e) {
    print(e);
}

```

the correct output should be:
 
```
= = = =
+ + + +
```

This patch is a quick fix,  a more reasonable way is to implement ECMA's `GetBase(V)` operation IMO.

Reference:
- http://www.ecma-international.org/ecma-262/5.1/#sec-8.7.1