### PR TITLE
Remove obsolete dependencies from install scripts

### DIFF
--- a/tools/apt-get-install-deps.sh
+++ b/tools/apt-get-install-deps.sh
@@ -17,6 +17,6 @@
 
 sudo apt-get update -q
 sudo apt-get install -q -y \
-    make cmake ninja-build \
-    gcc gcc-arm-none-eabi \
+    make cmake \
+    gcc \
     cppcheck vera++ python

--- a/tools/brew-install-deps.sh
+++ b/tools/brew-install-deps.sh
@@ -18,7 +18,7 @@
 brew update
 
 PKGS="
-    cmake ninja
+    cmake
     cppcheck vera++
     "
 


### PR DESCRIPTION
The new build script does not support ninja anymore, and we haven't
been building bare-metal arm targets for long. This patch removes
now-obsolete dependencies from install scripts.

This can also help to reduce the load on Travis CI (as it keeps
installing dependencies for each build job over and over again).

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu