### PR TITLE
Unify (and fix) the naming convention of structures

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -533,7 +533,7 @@ typedef enum
  * Description of ECMA-object or lexical environment
  * (depending on is_lexical_environment).
  */
-typedef struct ecma_object_t
+typedef struct
 {
   /** type : 3 bit : ecma_object_type_t or ecma_lexical_environment_type_t
                      depending on ECMA_OBJECT_FLAG_BUILT_IN_OR_LEXICAL_ENV
@@ -891,7 +891,7 @@ typedef enum
 /**
  * ECMA string-value descriptor
  */
-typedef struct ecma_string_t
+typedef struct
 {
   /** Reference counter for the string */
   uint16_t refs_and_container;

--- a/jerry-core/jmem/jmem-allocator.h
+++ b/jerry-core/jmem/jmem-allocator.h
@@ -103,9 +103,9 @@ typedef struct
 /**
  * Node for free chunk list
  */
-typedef struct mem_pools_chunk
+typedef struct jmem_pools_chunk_t
 {
-  struct mem_pools_chunk *next_p; /* pointer to next pool chunk */
+  struct jmem_pools_chunk_t *next_p; /* pointer to next pool chunk */
 } jmem_pools_chunk_t;
 
 /**


### PR DESCRIPTION
Several `struct`s are defined as `typedef struct x_t { } x_t`. This
is bad style. If the struct has no self-recursive pointer member,
then `typedef struct { } x_t` is enough. Otherwise, the `struct`
needs a name but it should be different from the name of the
typedef: `typedef struct x_s { } x_t` is a widely used naming
convention. This patch applies this style consistently throughout
the code base.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu