### PR TITLE
Fixing ecma_builtin_number_prototype_helper_round.

### DIFF
--- a/tests/jerry/number-prototype-to-fixed.js
+++ b/tests/jerry/number-prototype-to-fixed.js
@@ -37,6 +37,10 @@ assert((-0.0).toFixed(1) === "-0.0");
 assert((123456789012345678901.0).toFixed(20) === "123456789012345680000.00000000000000000000");
 assert((123.56).toFixed(NaN) === "124");
 assert((123.56).toFixed(-0.9) === "124");
+assert((0.095).toFixed(2) === "0.10");
+//assert((0.995).toFixed(2) === "0.99");
+//assert((9.995).toFixed(2) === "9.99");
+assert((99.995).toFixed(2) === "100.00");
 
 try {
     Number.prototype.toExponential.call(new Object());


### PR DESCRIPTION
"ecma_builtin_number_prototype_helper_round" is used by following
functions:
* ecma_builtin_number_prototype_object_to_fixed
* ecma_builtin_number_prototype_object_to_exponential
* ecma_builtin_number_prototype_object_to_precision

The current implementation does not support currying numbers and will
produce illegal digit for some test cases. For example, the result of
"0.95.toFixed(1)" is "0.:".

This patch fixs the issue, however the implementation of "toFixed" is
still problematic, at least not meet section 15.7.4.5 8.a of the
specification. The related test case is:

* assert((0.995).toFixed(2) === "0.99");
* assert((9.995).toFixed(2) === "9.99");

Reference:
* http://www.ecma-international.org/ecma-262/5.1/#sec-15.7.4.5

JerryScript-DCO-1.0-Signed-off-by: Yanhui Shen