### PR TITLE
Combine the vm_run_with_inline_stack and  vm_run_with_alloca

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -2616,43 +2616,6 @@ vm_execute (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
   return completion_value;
 } /* vm_execute */
 
-#define INLINE_STACK_SIZE 16
-
-/**
- * Run the code with inline stack.
- *
- * @return ecma value
- */
-static ecma_value_t __attr_noinline___
-vm_run_with_inline_stack (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
-                          const ecma_value_t *arg_p, /**< arguments list */
-                          ecma_length_t arg_list_len) /**< length of arguments list */
-{
-  ecma_value_t inline_stack[INLINE_STACK_SIZE];
-
-  frame_ctx_p->registers_p = inline_stack;
-
-  return vm_execute (frame_ctx_p, arg_p, arg_list_len);
-} /* vm_run_with_inline_stack */
-
-/**
- * Run the code with inline stack.
- *
- * @return ecma value
- */
-static ecma_value_t __attr_noinline___
-vm_run_with_alloca (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
-                    const ecma_value_t *arg_p, /**< arguments list */
-                    ecma_length_t arg_list_len, /**< length of arguments list */
-                    uint32_t call_stack_size) /**< call stack size */
-{
-  ecma_value_t stack[call_stack_size];
-
-  frame_ctx_p->registers_p = stack;
-
-  return vm_execute (frame_ctx_p, arg_p, arg_list_len);
-} /* vm_run_with_alloca */
-
 /**
  * Run the code.
  *
@@ -2700,19 +2663,10 @@ vm_run (const ecma_compiled_code_t *bytecode_header_p, /**< byte-code data heade
   frame_ctx.is_eval_code = is_eval_code;
   frame_ctx.call_operation = VM_NO_EXEC_OP;
 
-  if (call_stack_size <= INLINE_STACK_SIZE)
-  {
-    return vm_run_with_inline_stack (&frame_ctx,
-                                     arg_list_p,
-                                     arg_list_len);
-  }
-  else
-  {
-    return vm_run_with_alloca (&frame_ctx,
-                               arg_list_p,
-                               arg_list_len,
-                               call_stack_size);
-  }
+  ecma_value_t stack[call_stack_size];
+  frame_ctx.registers_p = stack;
+
+  return vm_execute (&frame_ctx, arg_list_p, arg_list_len);
 } /* vm_run */
 
 /**


### PR DESCRIPTION
Since both _inline_stack and _alloca **use the space of stack**, why don't we combine those 2 branch together? 

Before, when call_stack_size<INLINE_STACK_SIZE, we allocate an array with fixed length INLINE_STACK_SIZE, it also leads the waste of stack. 

But when I run run-perf-test, I cant see the changes of RSS.  @LaszloLango Could you help me measure the performance in your internal tool? Especially the "stack" size