### PR TITLE
Fix compiler error about between type and format string

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -113,7 +113,7 @@ ecma_builtin_global_object_print (ecma_value_t this_arg, /**< this argument */
                                                               0,
                                                               JERRY_BITSINBYTE);
 
-        jerry_port_console ("\\u%02x%02x", byte_high, byte_low);
+        jerry_port_console ("\\u%02x%02x", (unsigned int) byte_high, (unsigned int) byte_low);
       }
     }
 

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -415,7 +415,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         }
 
         ecma_char_t ch = lit_utf8_read_next (&str_curr_p);
-        JERRY_TRACE_MSG ("Period matching '.' to %d: ", (uint32_t) ch);
+        JERRY_TRACE_MSG ("Period matching '.' to %u: ", (unsigned int) ch);
 
         if (lit_char_is_line_terminator (ch))
         {
@@ -608,8 +608,9 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         {
           ecma_char_t ch1 = re_canonicalize (re_get_char (&bc_p), is_ignorecase);
           ecma_char_t ch2 = re_canonicalize (re_get_char (&bc_p), is_ignorecase);
-          JERRY_TRACE_MSG ("num_of_ranges=%d, ch1=%d, ch2=%d, curr_ch=%d; ",
-                           num_of_ranges, ch1, ch2, curr_ch);
+          JERRY_TRACE_MSG ("num_of_ranges=%u, ch1=%u, ch2=%u, curr_ch=%u; ",
+                           (unsigned int) num_of_ranges, (unsigned int) ch1,
+                           (unsigned int) ch2, (unsigned int) curr_ch);
 
           if (curr_ch >= ch1 && curr_ch <= ch2)
           {
@@ -644,7 +645,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         uint32_t backref_idx;
 
         backref_idx = re_get_value (&bc_p);
-        JERRY_TRACE_MSG ("Execute RE_OP_BACKREFERENCE (idx: %d): ", backref_idx);
+        JERRY_TRACE_MSG ("Execute RE_OP_BACKREFERENCE (idx: %u): ", (unsigned int) backref_idx);
         backref_idx *= 2;  /* backref n -> saved indices [n*2, n*2+1] */
         JERRY_ASSERT (backref_idx >= 2 && backref_idx + 1 < re_ctx_p->num_of_captures);
 
@@ -729,7 +730,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
 
         while (*bc_p == RE_OP_ALTERNATIVE)
         {
-          JERRY_TRACE_MSG (", jump: %d", offset);
+          JERRY_TRACE_MSG (", jump: %u", (unsigned int) offset);
           bc_p++;
           offset = re_get_value (&bc_p);
           bc_p += offset;
@@ -1148,7 +1149,7 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
       }
       default:
       {
-        JERRY_TRACE_MSG ("UNKNOWN opcode (%d)!\n", (uint32_t) op);
+        JERRY_TRACE_MSG ("UNKNOWN opcode (%u)!\n", (unsigned int) op);
         return ecma_raise_common_error (ECMA_ERR_MSG (""));
       }
     }

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -237,7 +237,7 @@ re_parse_alternative (re_compiler_ctx_t *re_ctx_p, /**< RegExp compiler context 
       case RE_TOK_START_CAPTURE_GROUP:
       {
         idx = re_ctx_p->num_of_captures++;
-        JERRY_TRACE_MSG ("Compile a capture group start (idx: %d)\n", idx);
+        JERRY_TRACE_MSG ("Compile a capture group start (idx: %u)\n", (unsigned int) idx);
 
         ret_value = re_parse_alternative (re_ctx_p, false);
 
@@ -251,7 +251,7 @@ re_parse_alternative (re_compiler_ctx_t *re_ctx_p, /**< RegExp compiler context 
       case RE_TOK_START_NON_CAPTURE_GROUP:
       {
         idx = re_ctx_p->num_of_non_captures++;
-        JERRY_TRACE_MSG ("Compile a non-capture group start (idx: %d)\n", idx);
+        JERRY_TRACE_MSG ("Compile a non-capture group start (idx: %u)\n", (unsigned int) idx);
 
         ret_value = re_parse_alternative (re_ctx_p, false);
 
@@ -264,8 +264,9 @@ re_parse_alternative (re_compiler_ctx_t *re_ctx_p, /**< RegExp compiler context 
       }
       case RE_TOK_CHAR:
       {
-        JERRY_TRACE_MSG ("Compile character token: %c, qmin: %d, qmax: %d\n",
-                         re_ctx_p->current_token.value, re_ctx_p->current_token.qmin, re_ctx_p->current_token.qmax);
+        JERRY_TRACE_MSG ("Compile character token: %c, qmin: %u, qmax: %u\n",
+                         (char) re_ctx_p->current_token.value, (unsigned int) re_ctx_p->current_token.qmin,
+                         (unsigned int) re_ctx_p->current_token.qmax);
 
         re_append_opcode (bc_ctx_p, RE_OP_CHAR);
         re_append_char (bc_ctx_p, re_canonicalize ((ecma_char_t) re_ctx_p->current_token.value,
@@ -364,7 +365,7 @@ re_parse_alternative (re_compiler_ctx_t *re_ctx_p, /**< RegExp compiler context 
           re_ctx_p->highest_backref = backref;
         }
 
-        JERRY_TRACE_MSG ("Compile a backreference: %d\n", backref);
+        JERRY_TRACE_MSG ("Compile a backreference: %u\n", (unsigned int) backref);
         re_append_opcode (bc_ctx_p, RE_OP_BACKREFERENCE);
         re_append_u32 (bc_ctx_p, backref);
 


### PR DESCRIPTION
IoT.js just integrated with jerryscript updated, and the build for Nuttx was failed. So my colleague opened an issue https://github.com/Samsung/iotjs/issues/398

While re-enabling build, I found out several messages regarding type conversion because of platform depenency like below.

```bash
/home/chokobole/Workspace/iotjs/iotjs/deps/jerry/jerry-core/ecma/operations/ecma-regexp-object.c:615:11: error: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' [-Werror=format=]
           JERRY_TRACE_MSG ("num_of_ranges=%d, ch1=%d, ch2=%d, curr_ch=%d; ",
```

~~To workaround errors, I used standard format string macro defined at inttypes.h, but I don't know if there have better solutions.~~


**FIX**

*Accepting @zherczeg and @akosthekiss 's opinion, I just simply casted around the type according to format string.*
