### PR TITLE
Switch cppcheck to C99 mode

### DIFF
--- a/tools/check-cppcheck.sh
+++ b/tools/check-cppcheck.sh
@@ -35,9 +35,11 @@ do
 done
 
 cppcheck -j$CPPCHECK_JOBS --force \
- --language=c++ --std=c++11 \
+ --language=c --std=c99 \
  --enable=warning,style,performance,portability,information \
+ --quiet --template="{file}:{line}: {severity}({id}): {message}" \
  --error-exitcode=1 \
  --exitcode-suppressions=tools/cppcheck/suppressions-list \
+ --suppressions-list=tools/cppcheck/suppressions-list \
  "${INCLUDE_DIRS[@]}" \
  jerry-core targets/default jerry-libc jerry-libm *.c *h tests/unit

--- a/tools/cppcheck/suppressions-list
+++ b/tools/cppcheck/suppressions-list
@@ -1,10 +1,3 @@
-operatorEqVarError
-noConstructor
-duplicateExpression
 wrongmathcall:tests/unit/test-libm.inc.h
 variableScope:jerry-libm/*.c
 invalidPointerCast:jerry-libm/*.c
-unreadVariable:jerry-libm/*.c
-
-// FIXME: false positive in cppcheck 1.61 (will disappear once distro ships with 1.69)
-variableScope:jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c


### PR DESCRIPTION
From the beginning, we have been configuring cppcheck to check its
input as C++ source. However, the transition to C99 happened a
while ago. This patch switches cppcheck into C99 mode.

Some related changes:
* Progress reporting of cppcheck just clutters the output and makes
  warnings hard to discover. Thus, this patch puts cppcheck into a
  quieter mode where it prints anything only if a non-suppressed
  warning is found.
* The default warning format of cppcheck is a bit different from
  usual compiler error/warning format. This patch configures
  cppcheck to use a more familiar warning template.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu