### PR TITLE
Generalize the zephyr build system

### DIFF
--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -47,6 +47,11 @@ endif
 
 INTERM     = build/$(BOARD)/obj-$(BOARD)
 OUTPUT     = build/$(BOARD)
+DOTCONFIG  = $(OUTPUT)/zephyr/.config
+
+include $(DOTCONFIG)
+override ARCH = $(subst ",,$(CONFIG_ARCH))
+# (this comment is to close the mismatched quote) "
 
 -include $(ZEPHYR_BASE)/boards/$(BOARD_NAME)/Makefile.board
 -include $(ZEPHYR_BASE)/scripts/Makefile.toolchain.$(ZEPHYR_GCC_VARIANT)
@@ -56,29 +61,42 @@ EXT_CFLAGS += -fno-stack-protector -fno-strict-overflow -ffreestanding
 EXT_CFLAGS += -fno-reorder-functions -fno-defer-pop -fdata-sections
 EXT_CFLAGS += -ffunction-sections -fno-inline-functions
 
-ifeq ($(BOARD),qemu_x86)
-CONFIG_TOOLCHAIN_VARIANT = x86
+ifeq ($(ARCH),x86)
+
 CPU = i686
+ifeq ($(CONFIG_X86_IAMCU),y)
+EXT_CFLAGS += -march=lakemont -mtune=lakemont -miamcu -msoft-float
+else
 EXT_CFLAGS += -march=pentium
+endif
 EXT_CFLAGS += -mpreferred-stack-boundary=2 -mno-sse
-else ifeq ($(BOARD),qemu_cortex_m3)
-CONFIG_TOOLCHAIN_VARIANT = arm
-CPU = arm7-m
-EXT_CFLAGS += -march=armv7-m -mthumb -mcpu=cortex-m3 -mabi=aapcs
-else ifeq ($(BOARD),frdm_k64f)
-CONFIG_TOOLCHAIN_VARIANT = arm
-CPU = arm7e-m
-EXT_CFLAGS += -march=armv7e-m -mthumb -mcpu=cortex-m4 -mabi=aapcs -mfloat-abi=hard -mfpu=fpv4-sp-d16
-else ifeq ($(BOARD),em_starterkit)
+
+else ifeq ($(ARCH),arm)
+
+ifeq ($(CONFIG_CPU_CORTEX_M4),y)
+CPU = armv7e-m
+EXT_CFLAGS += -march=$(CPU) -mthumb -mcpu=cortex-m4 -mabi=aapcs
+else
+CPU = armv7-m
+EXT_CFLAGS += -march=$(CPU) -mthumb -mcpu=cortex-m3 -mabi=aapcs
+endif
+ifeq ($(CONFIG_FP_SOFTABI), y)
+EXT_CFLAGS += -mfloat-abi=softfp -mfpu=fpv4-sp-d16
+endif
+ifeq ($(CONFIG_FP_HARDABI), y)
+EXT_CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
+endif
+
+else ifeq ($(ARCH),arc)
+
 # TODO: Tested only to build, untested to boot
-CONFIG_TOOLCHAIN_VARIANT = arc
 CPU = arc
 EXT_CFLAGS += -mARCv2EM -mav2em -mno-sdata
+
 else
-CONFIG_TOOLCHAIN_VARIANT = iamcu
-CPU = i686
-EXT_CFLAGS += -march=lakemont -mtune=lakemont -miamcu -msoft-float
-EXT_CFLAGS += -mpreferred-stack-boundary=2 -mno-sse
+
+CPU = $(error ARCH=$(ARCH) is not supported)
+
 endif
 
 EXT_CFLAGS += -Wall -Wno-format-zero-length -Wno-pointer-sign
@@ -110,6 +128,9 @@ BUILD_CONFIG = O="$(OUTPUT)/zephyr" V=$(V) USER_LIBS="$(LIBS)" USER_LIB_INCLUDE_
 
 .PHONY: all
 all: jerry zephyr
+
+$(DOTCONFIG):
+	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) initconfig
 
 $(EXTERNAL_LIB):
 ifdef V


### PR DESCRIPTION
I was trying to run JerryScript on a new board and it annoyed me having to modify the makefiles for each and every new board.

With these chances JerryScript for Zephyr can be compiled out-of-the-box on a much wider variety of Zephyr platforms.

There are 21 platforms in $ZEPHYR_BASE/boards. Without these patches 4 build, with the patches it rises to 13 (and there are no regressions).