### PR TITLE
Update jerry-libc unreachable asserts

### DIFF
--- a/jerry-libc/jerry-libc-printf.c
+++ b/jerry-libc/jerry-libc-printf.c
@@ -253,7 +253,7 @@ libc_printf_write_d_i (FILE *stream, /**< stream pointer */
 
     case LIBC_PRINTF_ARG_LENGTH_TYPE_HIGHL:
     {
-      assert (!"unsupported length field L");
+      assert (false && "unsupported length field L");
     }
   }
 
@@ -355,13 +355,13 @@ libc_printf_write_u_o_x_X (FILE *stream, /**< stream pointer */
 
     case LIBC_PRINTF_ARG_LENGTH_TYPE_HIGHL:
     {
-      assert (!"unsupported length field L");
+      assert (false && "unsupported length field L");
       return;
     }
 
     default:
     {
-      assert (!"unexpected length field");
+      assert (false && "unexpected length field");
       return;
     }
   }
@@ -422,7 +422,7 @@ libc_printf_write_u_o_x_X (FILE *stream, /**< stream pointer */
 
     default:
     {
-      assert (!"unexpected type field");
+      assert (false && "unexpected type field");
       return;
     }
   }
@@ -522,7 +522,7 @@ vfprintf (FILE *stream, /**< stream pointer */
 
       if (*format_iter_p == '*')
       {
-        assert (!"unsupported width field *");
+        assert (false && "unsupported width field *");
       }
 
       // If there is a number, recognize it as field width
@@ -535,7 +535,7 @@ vfprintf (FILE *stream, /**< stream pointer */
 
       if (*format_iter_p == '.')
       {
-        assert (!"unsupported precision field");
+        assert (false && "unsupported precision field");
       }
 
       switch (*format_iter_p)
@@ -628,7 +628,7 @@ vfprintf (FILE *stream, /**< stream pointer */
         case 'a':
         case 'A':
         {
-          assert (!"unsupported double type field");
+          assert (false && "unsupported double type field");
           break;
         }
 
@@ -636,7 +636,7 @@ vfprintf (FILE *stream, /**< stream pointer */
         {
           if (length & LIBC_PRINTF_ARG_LENGTH_TYPE_L)
           {
-            assert (!"unsupported length field L");
+            assert (false && "unsupported length field L");
           }
           else
           {
@@ -659,7 +659,7 @@ vfprintf (FILE *stream, /**< stream pointer */
         {
           if (length & LIBC_PRINTF_ARG_LENGTH_TYPE_L)
           {
-            assert (!"unsupported length field L");
+            assert (false && "unsupported length field L");
           }
           else
           {
@@ -699,7 +699,7 @@ vfprintf (FILE *stream, /**< stream pointer */
 
         case 'n':
         {
-          assert (!"unsupported type field n");
+          assert (false && "unsupported type field n");
         }
       }
     }

--- a/jerry-libc/target/posix/jerry-libc-target.c
+++ b/jerry-libc/target/posix/jerry-libc-target.c
@@ -134,13 +134,13 @@ fopen (const char *path, /**< file path */
       create_if_not_exist = true;
       if (mode[1] == '+')
       {
-        assert (!"unsupported mode a+");
+        assert (false && "unsupported mode a+");
       }
       break;
     }
     default:
     {
-      assert (!"unsupported mode");
+      assert (false && "unsupported mode");
     }
   }
 


### PR DESCRIPTION
Newer compilers (especially clang) warn (and fail) on
`assert (!"message");` constructs typically used to assert on
unreachable code paths (multiple occurrences in jerry-libc). A more
up-to-date approach is to use `assert (false && "message");`. This
patch applies the pattern to all relevant asserts in jerry-libc.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu