### PR TITLE
target: zephyr: Include toolchain headers using -isystem

### DIFF
--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -96,10 +96,9 @@ CC = $(CROSS_COMPILE)gcc
 ZEPHYR_LIBC_INC = $(subst -I,,$(TOOLCHAIN_CFLAGS))
 LIB_INCLUDE_DIR += -L $(CURDIR)/$(OUTPUT)
 
-# TODO: There is a warning when compiling in some architectures related to __sputc_r
 EXT_CFLAGS += -Wno-error=conversion
 EXT_CFLAGS += $(LIB_INCLUDE_DIR)
-EXT_CFLAGS += $(TOOLCHAIN_CFLAGS)
+EXT_CFLAGS += $(subst -I,-isystem,$(TOOLCHAIN_CFLAGS))
 
 EXTERNAL_LIB = $(INTERM)/lib/libjerry-core.a
 ZEPHYR_BIN = $(OUTPUT)/zephyr/zephyr.strip


### PR DESCRIPTION
Currently the zephyr port fails to build with some cross-toolsets because
warnings from the system headers are being treated as errors. Using
-isystem for any includes in TOOLCHAIN_CFLAGS allows us to crank up the
warning levels without worrying about newlib headers breaking the build.

JerryScript-DCO-1.0-Signed-off-by: Daniel Thompson daniel.thompson@linaro.org