### PR TITLE
Undef VALGRIND_*_SPACE macros at the end of sources

### DIFF
--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -690,6 +690,13 @@ jmem_heap_stat_free_iter ()
 } /* jmem_heap_stat_free_iter */
 #endif /* JMEM_STATS */
 
+#undef VALGRIND_NOACCESS_SPACE
+#undef VALGRIND_UNDEFINED_SPACE
+#undef VALGRIND_DEFINED_SPACE
+#undef VALGRIND_FREYA_CHECK_MEMPOOL_REQUEST
+#undef VALGRIND_FREYA_MALLOCLIKE_SPACE
+#undef VALGRIND_FREYA_FREELIKE_SPACE
+
 /**
  * @}
  * @}

--- a/jerry-core/jmem/jmem-poolman.c
+++ b/jerry-core/jmem/jmem-poolman.c
@@ -337,6 +337,12 @@ jmem_pools_stat_dealloc (void)
 } /* jmem_pools_stat_dealloc */
 #endif /* JMEM_STATS */
 
+#undef VALGRIND_NOACCESS_SPACE
+#undef VALGRIND_UNDEFINED_SPACE
+#undef VALGRIND_DEFINED_SPACE
+#undef VALGRIND_FREYA_MALLOCLIKE_SPACE
+#undef VALGRIND_FREYA_FREELIKE_SPACE
+
 /**
  * @}
  * @}


### PR DESCRIPTION
Defining the same macros in multiple source files can cause macro
re-definition warnings or errors in all-in-one builds.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu