### PR TITLE
Drop `-gdwarf-4` from compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ endif()
 jerry_add_compile_flags(-fno-stack-protector)
 
 # Debug information
-jerry_add_compile_flags(-g -gdwarf-4)
+jerry_add_compile_flags(-g)
 
 jerry_add_compile_warnings(all extra format-nonliteral init-self conversion sign-conversion format-security missing-declarations)
 jerry_add_compile_flags(-Wno-stack-protector -Wno-attributes)


### PR DESCRIPTION
`-g` is enough (most modern compilers use DWARF4 as default, at
least, e.g., GCC has switched from DWARF2 in 4.8), more future
proof (if a compiler moves to a newer version, it wont get forced
to a fixed older version), and less restrictive (some compilers
handle the "standard" `-g` only but don't understand its variants).

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu