### PR TITLE
[zephyr] Removed factory setting deprecated on zephyr

### DIFF
--- a/targets/zephyr/Makefile
+++ b/targets/zephyr/Makefile
@@ -20,7 +20,7 @@ $(error Missing zephyr base)
 endif
 
 # For testing without real hardware use qemu_x86 instead of arduino_101
-BOARD ?= arduino_101_factory
+BOARD ?= arduino_101
 
 O ?= $(PROJECT_BASE)/outdir
 

--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -18,7 +18,7 @@ ifeq ($(.DEFAULT_GOAL),)
   $(warning no default goal is set)
 endif
 
-BOARD ?= arduino_101_factory
+BOARD ?= arduino_101
 BOARD_NAME ?= arduino_101
 
 ifeq ($(BOARD),qemu_x86)

--- a/targets/zephyr/README.md
+++ b/targets/zephyr/README.md
@@ -69,19 +69,19 @@ make -f ./targets/zephyr/Makefile.zephyr BOARD=qemu_cortex_m3 qemu
 ```
 # assume you are in harmony folder
 cd jerryscript
-make -f ./targets/zephyr/Makefile.zephyr BOARD=arduino_101_factory
+make -f ./targets/zephyr/Makefile.zephyr BOARD=arduino_101
 ```
 
 This will generate the following libraries:
 ```
-./build/arduino_101_factory/librelease-cp_minimal.jerry-core.a
-./build/arduino_101_factory/librelease-cp_minimal.jerry-libm.lib.a
-./build/arduino_101_factory/librelease.external-cp_minimal-entry.a
+./build/arduino_101/librelease-cp_minimal.jerry-core.a
+./build/arduino_101/librelease-cp_minimal.jerry-libm.lib.a
+./build/arduino_101/librelease.external-cp_minimal-entry.a
 ```
 
 The final Zephyr image will be located here:
 ```
-./build/arduino_101_factory/zephyr/zephyr.strip
+./build/arduino_101/zephyr/zephyr.strip
 ```
 
 #### 5. Flashing
@@ -106,7 +106,7 @@ You can follow the Zephyr instructions to flash using the dfu-util command
 or use this helper:
 
 ```
-make -f ./targets/zephyr/Makefile.zephyr BOARD=arduino_101_factory dfu-x86
+make -f ./targets/zephyr/Makefile.zephyr BOARD=arduino_101 dfu-x86
 ```
 
 Make sure you have the factory bootloader in your device to use this method or it will not flash.
@@ -118,7 +118,7 @@ There is a helper function to flash using the JTAG and Flywatter2
 ![alt tag](docs/arduino_101.jpg?raw=true "Example")
 
 ```
-make -f ./targets/zephyr/Makefile.zephyr BOARD=arduino_101_factory flash
+make -f ./targets/zephyr/Makefile.zephyr BOARD=arduino_101 flash
 ```
 
 <warning> Careful if you flash the BOARD arduino_101, you will lose the bootloader


### PR DESCRIPTION
The new zephyr build system doesn't support the arduino_101_factory
board.

This change restores the default BOARD to arduino_101 which
is the current recommended method.

If you are in an older SDK / Zephyr you can still use.

`make -f ./targets/zephyr/Makefile.zephyr BOARD=arduino_101_factory`

JerryScript-DCO-1.0-Signed-off-by: Sergio Martinez sergio.martinez.rodriguez@intel.com