### PR TITLE
Change string length into a virtual property.

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -86,6 +86,22 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
   {
     if (type == ECMA_OBJECT_TYPE_STRING)
     {
+      if (ecma_string_is_length (property_name_p))
+      {
+        if (options & ECMA_PROPERTY_GET_VALUE)
+        {
+          ecma_value_t *prim_value_p = ecma_get_internal_property (object_p,
+                                                                   ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+
+          ecma_string_t *prim_value_str_p = ecma_get_string_from_value (*prim_value_p);
+          ecma_length_t length = ecma_string_get_length (prim_value_str_p);
+
+          property_ref_p->virtual_value = ecma_make_uint32_value (length);
+        }
+
+        return ECMA_PROPERTY_TYPE_VIRTUAL;
+      }
+
       uint32_t index;
 
       if (ecma_string_get_array_index (property_name_p, &index))
@@ -316,6 +332,17 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
   {
     if (type == ECMA_OBJECT_TYPE_STRING)
     {
+      if (ecma_string_is_length (property_name_p))
+      {
+        ecma_value_t *prim_value_p = ecma_get_internal_property (object_p,
+                                                                 ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
+
+        ecma_string_t *prim_value_str_p = ecma_get_string_from_value (*prim_value_p);
+        ecma_length_t length = ecma_string_get_length (prim_value_str_p);
+
+        return ecma_make_uint32_value (length);
+      }
+
       uint32_t index;
 
       if (ecma_string_get_array_index (property_name_p, &index))

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -49,12 +49,9 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
 
   ecma_string_t *prim_prop_str_value_p;
 
-  ecma_number_t length_value;
-
   if (arguments_list_len == 0)
   {
     prim_prop_str_value_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING__EMPTY);
-    length_value = ECMA_NUMBER_ZERO;
   }
   else
   {
@@ -70,9 +67,6 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
       JERRY_ASSERT (ecma_is_value_string (to_str_arg_value));
 
       prim_prop_str_value_p = ecma_get_string_from_value (to_str_arg_value);
-
-      ecma_length_t string_len = ecma_string_get_length (prim_prop_str_value_p);
-      length_value = ((ecma_number_t) (uint32_t) string_len);
     }
   }
 
@@ -97,16 +91,6 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
   ecma_value_t *prim_value_prop_p = ecma_create_internal_property (obj_p,
                                                                    ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
   *prim_value_prop_p = ecma_make_string_value (prim_prop_str_value_p);
-
-  // 15.5.5.1
-  ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
-  ecma_property_value_t *length_prop_value_p = ecma_create_named_data_property (obj_p,
-                                                                                length_magic_string_p,
-                                                                                ECMA_PROPERTY_FIXED,
-                                                                                NULL);
-  ecma_deref_ecma_string (length_magic_string_p);
-
-  length_prop_value_p->value = ecma_make_number_value (length_value);
 
   return ecma_make_object_value (obj_p);
 } /* ecma_op_create_string_object */
@@ -136,8 +120,7 @@ ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p, /**< a String obj
 
   ecma_collection_header_t *for_enumerable_p = main_collection_p;
 
-  ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? main_collection_p : non_enum_collection_p;
-  JERRY_UNUSED (for_non_enumerable_p);
+  ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? non_enum_collection_p : main_collection_p;
 
   ecma_value_t *prim_value_p = ecma_get_internal_property (obj_p,
                                                            ECMA_INTERNAL_PROPERTY_ECMA_VALUE);
@@ -154,6 +137,10 @@ ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p, /**< a String obj
 
     ecma_deref_ecma_string (name_p);
   }
+
+  ecma_string_t *length_str_p = ecma_new_ecma_length_string ();
+  ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (length_str_p), true);
+  ecma_deref_ecma_string (length_str_p);
 } /* ecma_op_string_list_lazy_property_names */
 
 /**


### PR DESCRIPTION
Slight improvement:

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 0.939 -> 0.937 : +0.192% | 
3d-raytrace.js | 1.097 -> 1.107 : -0.879% | 
access-binary-trees.js | 0.568 -> 0.563 : +0.836% | 
access-fannkuch.js | 2.359 -> 2.397 : -1.598% | 
access-nbody.js | 1.079 -> 1.081 : -0.162% | 
bitops-3bit-bits-in-byte.js | 0.593 -> 0.585 : +1.218% | 
bitops-bits-in-byte.js | 0.872 -> 0.872 : +0.093% | 
bitops-bitwise-and.js | 1.087 -> 1.086 : +0.114% | 
bitops-nsieve-bits.js | 1.758 -> 1.769 : -0.630% | 
controlflow-recursive.js | 0.396 -> 0.398 : -0.377% | 
crypto-aes.js | 1.090 -> 1.087 : +0.296% | 
crypto-md5.js | 0.732 -> 0.713 : +2.543% | 
crypto-sha1.js | 0.700 -> 0.689 : +1.579% | 
date-format-tofte.js | 0.851 -> 0.848 : +0.333% | 
date-format-xparb.js | 0.451 -> 0.434 : +3.785% | 
math-cordic.js | 1.341 -> 1.342 : -0.039% | 
math-partial-sums.js | 0.749 -> 0.743 : +0.766% | 
math-spectral-norm.js | 0.602 -> 0.598 : +0.553% | 
string-base64.js | 1.914 -> 1.812 : +5.321% | 
string-fasta.js | 1.398 -> 1.344 : +3.812% | 
Geometric mean: | +0.903% | 

Binary sizes (bytes)
old:152868
new:152756
