### PR TITLE
Rework arguments object.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -197,9 +197,6 @@ typedef uintptr_t ecma_external_pointer_t;
  */
 typedef enum
 {
-  ECMA_INTERNAL_PROPERTY_SCOPE, /**< [[Scope]] */
-  ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP, /**< [[ParametersMap]] */
-
   ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE, /**< native handle associated with an object */
   ECMA_INTERNAL_PROPERTY_FREE_CALLBACK, /**< object's native free callback */
 
@@ -605,6 +602,15 @@ typedef struct
       ecma_value_t scope_cp; /**< function scope */
       ecma_value_t bytecode_cp; /**< function byte code */
     } function;
+
+    /*
+     * Description of arguments objects.
+     */
+    struct
+    {
+      ecma_value_t lex_env_cp; /**< lexical environment */
+      uint32_t length; /**< length of names */
+    } arguments;
 
     ecma_external_pointer_t external_function; /**< external function */
   } u;

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -783,8 +783,6 @@ ecma_free_internal_property (ecma_property_t *property_p) /**< the property */
       break;
     }
 
-    case ECMA_INTERNAL_PROPERTY_SCOPE: /* a lexical environment */
-    case ECMA_INTERNAL_PROPERTY_PARAMETERS_MAP: /* an object */
     case ECMA_INTERNAL_PROPERTY_INSTANTIATED_MASK_32_63: /* an integer (bit-mask) */
     case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION:
     {

--- a/jerry-core/ecma/operations/ecma-objects-arguments.h
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.h
@@ -23,8 +23,6 @@ extern void
 ecma_op_create_arguments_object (ecma_object_t *, ecma_object_t *, const ecma_value_t *,
                                  ecma_length_t, const ecma_compiled_code_t *);
 
-extern void
-ecma_arguments_update_mapped_arg_value (ecma_object_t *, ecma_string_t *, ecma_property_t *);
 extern ecma_value_t
 ecma_op_arguments_object_delete (ecma_object_t *, ecma_string_t *, bool);
 extern ecma_value_t


### PR DESCRIPTION
14% memory improvement on crypto-aes.js. No performance change (arguments is not used by sunspider tests).

Binary size reduced 153004 -> 152708, but perhaps this is just a bounce back after the internal property rework patch.