### PR TITLE
build: Adopt outputexports

### DIFF
--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -19,11 +19,7 @@ ifeq ($(.DEFAULT_GOAL),)
 endif
 
 BOARD ?= arduino_101
-BOARD_NAME ?= arduino_101
-
-ifeq ($(BOARD),qemu_x86)
-BOARD_NAME = qemu_x86
-endif
+export BOARD
 
 TARGET_ZEPHYR ?= ./targets/zephyr
 TARGET_ZEPHYR_SRC_DIR = $(TARGET_ZEPHYR)/src
@@ -47,89 +43,32 @@ endif
 
 INTERM     = build/$(BOARD)/obj-$(BOARD)
 OUTPUT     = build/$(BOARD)/zephyr
-DOTCONFIG  = $(OUTPUT)/.config
 
-include $(DOTCONFIG)
-override ARCH = $(subst ",,$(CONFIG_ARCH))
-# (this comment is to close the mismatched quote) "
-
--include $(ZEPHYR_BASE)/boards/$(BOARD_NAME)/Makefile.board
--include $(ZEPHYR_BASE)/scripts/Makefile.toolchain.$(ZEPHYR_GCC_VARIANT)
+include $(OUTPUT)/Makefile.export
 
 EXT_CFLAGS := -fno-asynchronous-unwind-tables -fno-omit-frame-pointer
 EXT_CFLAGS += -fno-stack-protector -fno-strict-overflow -ffreestanding
 EXT_CFLAGS += -fno-reorder-functions -fno-defer-pop -fdata-sections
 EXT_CFLAGS += -ffunction-sections -fno-inline-functions
 
-ifeq ($(ARCH),x86)
-
-CPU = i686
-ifeq ($(CONFIG_X86_IAMCU),y)
-EXT_CFLAGS += -march=lakemont -mtune=lakemont -miamcu -msoft-float
-else
-EXT_CFLAGS += -march=pentium
-endif
-EXT_CFLAGS += -mpreferred-stack-boundary=2 -mno-sse
-
-else ifeq ($(ARCH),arm)
-
-ifeq ($(CONFIG_CPU_CORTEX_M4),y)
-CPU = armv7e-m
-EXT_CFLAGS += -march=$(CPU) -mthumb -mcpu=cortex-m4 -mabi=aapcs
-else
-CPU = armv7-m
-EXT_CFLAGS += -march=$(CPU) -mthumb -mcpu=cortex-m3 -mabi=aapcs
-endif
-ifeq ($(CONFIG_FP_SOFTABI), y)
-EXT_CFLAGS += -mfloat-abi=softfp -mfpu=fpv4-sp-d16
-endif
-ifeq ($(CONFIG_FP_HARDABI), y)
-EXT_CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
-endif
-
-else ifeq ($(ARCH),arc)
-
-# TODO: Tested only to build, untested to boot
-CPU = arc
-EXT_CFLAGS += -mARCv2EM -mav2em -mno-sdata
-
-else
-
-CPU = $(error ARCH=$(ARCH) is not supported)
-
-endif
+EXT_CFLAGS += $(KBUILD_CFLAGS) $(NOSTDINC_FLAGS) $(subst -I,-isystem,$(ZEPHYRINCLUDE))
 
 EXT_CFLAGS += -Wall -Wno-format-zero-length -Wno-pointer-sign
 EXT_CFLAGS += -Werror=format -Werror=implicit-int -Wno-unused-but-set-variable
 EXT_CFLAGS += -Wno-main -Wno-strict-aliasing -Wno-old-style-declaration
 EXT_CFLAGS += -Wno-error=format=
 EXT_CFLAGS += -D_XOPEN_SOURCE=700
-EXT_CFLAGS += -nostdlib
-
-# Pass2
--include $(ZEPHYR_BASE)/scripts/Makefile.toolchain.$(ZEPHYR_GCC_VARIANT)
-
-CC = $(CROSS_COMPILE)gcc
-
-ZEPHYR_LIBC_INC = $(subst -I,,$(TOOLCHAIN_CFLAGS))
-LIB_INCLUDE_DIR += -L $(CURDIR)/$(OUTPUT)/..
 
 EXT_CFLAGS += -Wno-error=conversion
-EXT_CFLAGS += $(LIB_INCLUDE_DIR)
-EXT_CFLAGS += $(subst -I,-isystem,$(TOOLCHAIN_CFLAGS))
 
 EXTERNAL_LIB = $(INTERM)/lib/libjerry-core.a
-ZEPHYR_BIN = $(OUTPUT)/zephyr.strip
 
 LIBS = jerry-core
 
 BUILD_CONFIG = O="$(OUTPUT)" V=$(V) USER_LIBS="$(LIBS)" USER_LIB_INCLUDE_DIR="-L $(CURDIR)/$(INTERM)/lib" TARGET_ZEPHYR=$(TARGET_ZEPHYR)
 
 .PHONY: all
-all: jerry zephyr
-
-$(DOTCONFIG):
-	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) initconfig
+all: zephyr
 
 $(EXTERNAL_LIB):
 ifdef V
@@ -147,7 +86,6 @@ endif
 	 -DMEM_HEAP_SIZE_KB=$(JERRYHEAP) \
 	 -DEXTERNAL_CMAKE_C_COMPILER=$(CC) \
 	 -DEXTERNAL_CMAKE_C_COMPILER_ID=GNU \
-	 -DEXTERNAL_CMAKE_SYSTEM_PROCESSOR=$(CPU) \
 	 -DJERRY_CMDLINE=OFF \
 	 -DEXTERNAL_COMPILE_FLAGS="$(EXT_CFLAGS)" \
 	 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain_external.cmake \
@@ -158,7 +96,13 @@ endif
 
 	make -C $(INTERM) $(TYPE)$(VARIETY) V=1
 
-$(ZEPHYR_BIN):
+$(OUTPUT)/Makefile.export: $(OUTPUT)/include/config/auto.conf
+	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) outputexports
+
+$(OUTPUT)/include/config/auto.conf:
+	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) initconfig
+
+zephyr: jerry
 ifdef V
 	@echo "- ZEPHYR -------------------------------------------------------"
 endif
@@ -170,17 +114,22 @@ endif
 jerry: $(EXTERNAL_LIB)
 	@touch $(EXTERNAL_LIB)
 
-zephyr:	$(EXTERNAL_LIB) $(ZEPHYR_BIN)
-	@touch $(ZEPHYR_BIN)
+GENERIC_TARGETS = qemu qemugdb flash debug debugserver
+KCONFIG_TARGETS = \
+	initconfig config nconfig menuconfig xconfig gconfig \
+	oldconfig silentoldconfig defconfig savedefconfig \
+	allnoconfig allyesconfig alldefconfig randconfig \
+	listnewconfig olddefconfig
+CLEAN_TARGETS = pristine mrproper
 
-qemu:	$(EXTERNAL_LIB) $(ZEPHYR_BIN)
-	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) qemu
+$(GENERIC_TARGETS): jerry
+$(CLEAN_TARGETS): clean
 
-flash:	$(EXTERNAL_LIB) $(OUTPUT)/zephyr.strip
-	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) flash
-
-debugserver:
-	make -f $(TARGET_ZEPHYR)/Makefile BOARD=$(BOARD_NAME) debugserver
+$(GENERIC_TARGETS) $(KCONFIG_TARGETS) $(CLEAN_TARGETS):
+ifdef V
+	@echo "- ZEPHYR -------------------------------------------------------"
+endif
+	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) $@
 
 dfu-x86: all
 	@- dfu-util -a x86_app -D build/$(BOARD)/zephyr/zephyr.bin; \
@@ -205,20 +154,15 @@ showconfig:
 	@echo "CROSS_COMPILE    = $(CROSS_COMPILE) "
 	@echo "TOOLCHAIN_LIBS   = $(TOOLCHAIN_LIBS) "
 	@echo "LIBS             = $(LIBS) "
-	@echo "LIB_INCLUDE_DIR  = $(LIB_INCLUDE_DIR) "
 	@echo "BUILD_CONFIG     = $(BUILD_CONFIG) "
-	@echo "ZEPHYR_LIBC_INC  = $(ZEPHYR_LIBC_INC) "
 	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) showconfig
 
 clean:
-	@echo "Clearing Jerryscript"
-	@rm -rf $(OUTPUT)
-	@rm -rf $(INTERM)
-	@rm -f $(TARGET_ZEPHYR_SRC_DIR)/*.o
-	@echo "Clearing Zephyr"
-	make -f $(TARGET_ZEPHYR)/Makefile clean
-	make -f $(TARGET_ZEPHYR)/Makefile pristine
-
-mrproper:
-	make -f $(TARGET_ZEPHYR)/Makefile mrproper
-
+ifdef V
+	@echo "- CLEANING JERRY SCRIPT ----------------------------------------"
+endif
+	rm -rf $(INTERM) $(TARGET_ZEPHYR_SRC_DIR)/*.o
+ifdef V
+	@echo "- CLEANING ZEPHYR ----------------------------------------------"
+endif
+	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) clean


### PR DESCRIPTION
This patch simplifies the integration with the zephyr build system
whilst at the same time enriching the set of build targets to allow
zephyr to be configured using its kbuild features.

It works by exploiting "make outputexports", a feature of the zephyr
build system that makes the zephyr compiler configuration available to
other build systems in an easily accessible manner.

Whilst looking at the build we also correct the implementation of clean
so that it no longer destroys any custom zephyr configuration. Like any
other zephyr application one must use "make pristine" to remove the
config too.

JerryScript-DCO-1.0-Signed-off-by: Daniel Thompson daniel.thompson@linaro.org