### PR TITLE
Improve Js2C converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ tags
 ID
 
 # targets
-jerry_targetjs.h
+jerry-targetjs.h
 targets/mbedk64f/libjerry
 targets/mbedk64f/build
 targets/mbedk64f/yotta_modules

--- a/targets/esp8266/Makefile
+++ b/targets/esp8266/Makefile
@@ -95,7 +95,7 @@ LINKFLAGS_eagle.app.v6 =				\
 DEPENDS_eagle.app.v6 =					\
 	$(LD_FILE)					\
 	$(LDDIR)/eagle.rom.addr.v6.ld			\
-	./source/jerry_targetjs.h			\
+	./source/jerry-targetjs.h			\
 	./libs/libjerrylibm.a				\
 	./libs/libjerrycore.a				\
 	./libs/libjerryentry.a

--- a/targets/esp8266/Makefile.esp8266
+++ b/targets/esp8266/Makefile.esp8266
@@ -34,7 +34,7 @@ ESP_CFLAGS := -D__TARGET_ESP8266 -D__attr_always_inline___=
 MFORCE32 = `xtensa-lx106-elf-gcc --help=target | grep mforce-l32`
 
 ifneq ($(MFORCE32),)
-    # Your compiler supports the -mforce-l32 flag which means that 
+    # Your compiler supports the -mforce-l32 flag which means that
     # constants can be placed in ROM to free additional RAM
     ESP_CFLAGS += -DJERRY_CONST_DATA="__attribute__((aligned(4))) __attribute__((section(\".irom.text\")))"
 endif

--- a/targets/esp8266/user/user_main.c
+++ b/targets/esp8266/user/user_main.c
@@ -43,7 +43,7 @@ void show_free_mem(int idx) {
 
 //-----------------------------------------------------------------------------
 
-#include "jerry_targetjs.h"
+#include "jerry-targetjs.h"
 
 
 static int jerry_task_init(void) {

--- a/targets/mbed/readme.md
+++ b/targets/mbed/readme.md
@@ -43,7 +43,7 @@ Basically, you can create a new target in this way (If the mbed OS support your 
   You can run this rule with the following command: 
   - `make -f targets/mbed/Makefile.mbed board=$(TARGET) jerry`
 
-2. The next rule is the `js2c`. This rule calls a `js2c.py` python script from the `jerryscript/targets/tools` and creates the JavaScript builtin file into the `targets/mbed/source/` folder. This file is the `jerry_targetjs.h`. You can run this rule with the follwoing command:
+2. The next rule is the `js2c`. This rule calls a `js2c.py` python script from the `jerryscript/targets/tools` and creates the JavaScript builtin file into the `targets/mbed/source/` folder. This file is the `jerry-targetjs.h`. You can run this rule with the follwoing command:
 
   - `make -f targets/mbed/Makefile.mbed board=$(TARGET) js2c`
 

--- a/targets/mbed/source/main.cpp
+++ b/targets/mbed/source/main.cpp
@@ -19,7 +19,7 @@
 #include "jerry-core/jerry-api.h"
 #include "jerry_run.h"
 
-#include "jerry_targetjs.h"
+#include "jerry-targetjs.h"
 
 static Serial pc (USBTX, USBRX); //tx, rx
 

--- a/targets/mbedos5/.gitignore
+++ b/targets/mbedos5/.gitignore
@@ -5,4 +5,4 @@ mbed-events
 mbed_settings.py
 js/pins.js
 source/pins.cpp
-source/jerry_targetjs.h
+source/jerry-targetjs.h

--- a/targets/mbedos5/Makefile
+++ b/targets/mbedos5/Makefile
@@ -52,13 +52,13 @@ MBED_CLI_FLAGS += -D "CONFIG_MEM_HEAP_AREA_SIZE=(1024*$(HEAPSIZE))"
 MBED_CLI_FLAGS += -t GCC_ARM
 
 .PHONY: all js2c getlibs rebuild library
-all: source/jerry_targetjs.h source/pins.cpp .mbed ../../.mbedignore
+all: source/jerry-targetjs.h source/pins.cpp .mbed ../../.mbedignore
 	mbed target $(BOARD)
 	mbed compile $(MBED_CLI_FLAGS)
 
 library: .mbed ../../.mbedignore
 	# delete encoded js code if it exists
-	rm -f source/jerry_targetjs.h
+	rm -f source/jerry-targetjs.h
 	mbed target $(BOARD)
 	mbed compile $(MBED_CLI_FLAGS) --library
 
@@ -68,13 +68,13 @@ clean:
 js2c: js/main.js js/flash_leds.js
 	python ../tools/js2c.py --ignore pins.js
 
-source/pins.cpp: 
+source/pins.cpp:
 	python tools/generate_pins.py ${BOARD}
 
 ifeq ($(NO_JS),0)
-source/jerry_targetjs.h: js2c
+source/jerry-targetjs.h: js2c
 else
-source/jerry_targetjs.h: ;
+source/jerry-targetjs.h: ;
 endif
 
 getlibs: .mbed

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/launcher.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/launcher.cpp
@@ -25,14 +25,14 @@
 #include "jerryscript-mbed-launcher/launcher.h"
 #include "jerryscript-mbed-launcher/setup.h"
 
-#include "jerry_targetjs.h"
+#include "jerry-targetjs.h"
 
 DECLARE_JS_CODES;
 
 /**
  * load_javascript
  *
- * Parse and run javascript files specified in jerry_targetjs.h
+ * Parse and run javascript files specified in jerry-targetjs.h
  */
 static int load_javascript() {
     for (int src = 0; js_codes[src].source; src++) {


### PR DESCRIPTION
 * Rename 'jerry_targetjs.h' to 'jerry-targetjs.h',
   because we use dashes in file names instead of underscores.
 * Made destination and js souce directory configurable.
 * Updated esp8266 target to the recent changes.
 * Updated mbed and mbedos5 target to the recent changes.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com