### PR TITLE
target: zephyr: Cause pristine to remove entire build directory

### DIFF
--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -120,7 +120,7 @@ KCONFIG_TARGETS = \
 	oldconfig silentoldconfig defconfig savedefconfig \
 	allnoconfig allyesconfig alldefconfig randconfig \
 	listnewconfig olddefconfig
-CLEAN_TARGETS = pristine mrproper
+CLEAN_TARGETS = mrproper
 
 $(GENERIC_TARGETS): jerry
 $(CLEAN_TARGETS): clean
@@ -166,3 +166,9 @@ ifdef V
 	@echo "- CLEANING ZEPHYR ----------------------------------------------"
 endif
 	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) clean
+
+pristine: clean
+ifdef V
+	@echo "- CLEANING BUILD DIRECTORY -------------------------------------"
+endif
+	rm -rf build/


### PR DESCRIPTION
For a normal zephyr application the pristine target simply runs
"rm -rf outdir". However the JerryScript build overrides the output
directory [O=$(OUTPUT)] so Zephyr's implementation pristine is not able
to to a full aggressive clean up for all boards.

For this reason it is better for the JerryScript build wrapper to have
its own implementation of pristine.

JerryScript-DCO-1.0-Signed-off-by: Daniel Thompson daniel.thompson@linaro.org