### PR TITLE
Webpage-related fixes

### DIFF
--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -68,13 +68,13 @@ typedef enum
  * of the parameter list.
  *
  * This function is only called with messages coming from the jerry engine as
- * the result of some abnormal operation or describing its internal operations 
+ * the result of some abnormal operation or describing its internal operations
  * (e.g., data structure dumps or tracing info).
  *
  * It should be the port that decides whether error and debug messages are logged to
  * the console, or saved to a database or to a file.
- * 
- * Example: a libc-based port may implement this with vfprintf(stderr) or 
+ *
+ * Example: a libc-based port may implement this with vfprintf(stderr) or
  * vfprintf(logfile), or both, depending on log level.
  */
 void jerry_port_log (jerry_log_level_t level, const char *fmt, ...);

--- a/tools/update-webpage.sh
+++ b/tools/update-webpage.sh
@@ -28,6 +28,7 @@ API_REFERENCE_MD="02.API-REFERENCE.md"
 API_EXAMPLES_MD="03.API-EXAMPLE.md"
 INTERNALS_MD="04.INTERNALS.md"
 PORT_API_MD="05.PORT-API.md"
+REFERENCE_COUNTING_MD="06.REFERENCE-COUNTING.md"
 
 declare -A titles
 
@@ -36,6 +37,7 @@ titles[$API_REFERENCE_MD]="API Reference"
 titles[$API_EXAMPLES_MD]="API Examples"
 titles[$INTERNALS_MD]="Internals"
 titles[$PORT_API_MD]="Port API"
+titles[$REFERENCE_COUNTING_MD]="Reference counting"
 
 for docfile in $docs_dir/*.md; do
   docfile_base=`basename $docfile`
@@ -77,8 +79,8 @@ for docfile in $docs_dir/*.md; do
   ' $docfile                                             >> $gh_pages_dir/$docfile_base
 
   # fix image links
-  sed -i -r -e 's/^!\[.*\]\(/&{{ site.baseurl }}\//' $gh_pages_dir/$docfile_base
-  sed -i -r -e 's/^!\[.*\]\(\{\{ site\.baseurl \}\}\/img.*$/&{: class="thumbnail center-block img-responsive" }/' $gh_pages_dir/$docfile_base
+  sed -i -r -e 's/^!\[.*\]\(/&{{ site.github.url }}\//' $gh_pages_dir/$docfile_base
+  sed -i -r -e 's/^!\[.*\]\(\{\{ site\.github\.url \}\}\/img.*$/&{: class="thumbnail center-block img-responsive" }/' $gh_pages_dir/$docfile_base
 
   # replace span tags to div
   sed -i 's/<span class=/<div class=/g' $gh_pages_dir/$docfile_base


### PR DESCRIPTION
 * Fix webpage-generator script
   - Generate 'site.github.url' instead of 'site.baseurl' (#1248)
   - Include 'Reference counting' documentation
 * Remove trailing whitespaces from 05.PORT-API.md

JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com