### PR TITLE
All strings whose are valid array indicies always use the UINT32_IN_DESC format.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -845,6 +845,11 @@ typedef double ecma_number_t;
 #define ECMA_MAX_CHARS_IN_STRINGIFIED_UINT32 10
 
 /**
+ * String is not a valid array index.
+ */
+#define ECMA_STRING_NOT_ARRAY_INDEX UINT32_MAX
+
+/**
  * Description of a collection's header.
  */
 typedef struct

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -969,18 +969,18 @@ ecma_delete_array_properties (ecma_object_t *object_p, /**< object */
         ecma_string_t *property_name_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
                                                                     prop_pair_p->names_cp[i]);
 
-        uint32_t index;
-        if (ecma_string_get_array_index (property_name_p, &index))
-        {
-          if (index < old_length && index >= new_length)
-          {
-            new_length = index + 1;
+        uint32_t index = ecma_string_get_array_index (property_name_p);
 
-            if (new_length == old_length)
-            {
-              /* Early return. */
-              return new_length;
-            }
+        if (index < old_length && index >= new_length)
+        {
+          JERRY_ASSERT (index != ECMA_STRING_NOT_ARRAY_INDEX);
+
+          new_length = index + 1;
+
+          if (new_length == old_length)
+          {
+            /* Early return. */
+            return new_length;
           }
         }
       }
@@ -1015,23 +1015,23 @@ ecma_delete_array_properties (ecma_object_t *object_p, /**< object */
         ecma_string_t *property_name_p = ECMA_GET_NON_NULL_POINTER (ecma_string_t,
                                                                     prop_pair_p->names_cp[i]);
 
-        uint32_t index;
-        if (ecma_string_get_array_index (property_name_p, &index))
+        uint32_t index = ecma_string_get_array_index (property_name_p);
+
+        if (index < old_length && index >= new_length)
         {
-          if (index < old_length && index >= new_length)
+          JERRY_ASSERT (index != ECMA_STRING_NOT_ARRAY_INDEX);
+
+          ecma_free_property (object_p, property_name_p, current_prop_p->types + i);
+
+          if (has_hashmap)
           {
-            ecma_free_property (object_p, property_name_p, current_prop_p->types + i);
-
-            if (has_hashmap)
-            {
-              ecma_property_hashmap_delete (object_p, property_name_p, current_prop_p->types + i);
-            }
-
-            JERRY_ASSERT (current_prop_p->types[i] == ECMA_PROPERTY_TYPE_DELETED);
-
-            ecma_deref_ecma_string (property_name_p);
-            prop_pair_p->names_cp[i] = ECMA_NULL_POINTER;
+            ecma_property_hashmap_delete (object_p, property_name_p, current_prop_p->types + i);
           }
+
+          JERRY_ASSERT (current_prop_p->types[i] == ECMA_PROPERTY_TYPE_DELETED);
+
+          ecma_deref_ecma_string (property_name_p);
+          prop_pair_p->names_cp[i] = ECMA_NULL_POINTER;
         }
       }
     }

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -174,7 +174,7 @@ extern ecma_string_t *ecma_concat_ecma_strings (ecma_string_t *, ecma_string_t *
 extern void ecma_ref_ecma_string (ecma_string_t *);
 extern void ecma_deref_ecma_string (ecma_string_t *);
 extern ecma_number_t ecma_string_to_number (const ecma_string_t *);
-extern bool ecma_string_get_array_index (const ecma_string_t *, uint32_t *);
+extern uint32_t ecma_string_get_array_index (const ecma_string_t *);
 
 extern lit_utf8_size_t __attr_return_value_should_be_checked___
 ecma_string_copy_to_utf8_buffer (const ecma_string_t *, lit_utf8_byte_t *, lit_utf8_size_t);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -1229,9 +1229,8 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
   {
     ecma_string_t *property_name_p = ecma_get_string_from_value (*iter.current_value_p);
 
-    uint32_t index;
-    bool is_index = ecma_string_get_array_index (property_name_p, &index);
-    JERRY_ASSERT (is_index);
+    uint32_t index = ecma_string_get_array_index (property_name_p);
+    JERRY_ASSERT (index != ECMA_STRING_NOT_ARRAY_INDEX);
 
     if (index < len)
     {
@@ -1249,9 +1248,8 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
   {
     ecma_string_t *property_name_p = ecma_get_string_from_value (*iter.current_value_p);
 
-    uint32_t index;
-    bool is_index = ecma_string_get_array_index (property_name_p, &index);
-    JERRY_ASSERT (is_index);
+    uint32_t index = ecma_string_get_array_index (property_name_p);
+    JERRY_ASSERT (index != ECMA_STRING_NOT_ARRAY_INDEX);
 
     if (index >= len)
     {
@@ -1309,9 +1307,8 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
   {
     ecma_string_t *property_name_p = ecma_get_string_from_value (*iter.current_value_p);
 
-    uint32_t index;
-    bool is_index = ecma_string_get_array_index (property_name_p, &index);
-    JERRY_ASSERT (is_index);
+    uint32_t index = ecma_string_get_array_index (property_name_p);
+    JERRY_ASSERT (index != ECMA_STRING_NOT_ARRAY_INDEX);
 
     if (index >= copied_num && index < len)
     {

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -301,9 +301,9 @@ ecma_op_array_object_define_own_property (ecma_object_t *object_p, /**< the arra
     return ecma_op_array_object_set_length (object_p, property_desc_p->value, flags);
   }
 
-  uint32_t index;
+  uint32_t index = ecma_string_get_array_index (property_name_p);
 
-  if (!ecma_string_get_array_index (property_name_p, &index))
+  if (index == ECMA_STRING_NOT_ARRAY_INDEX)
   {
     return ecma_op_general_object_define_own_property (object_p, property_name_p, property_desc_p, is_throw);
   }

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -255,9 +255,9 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *object_p, /**< the 
     return ret_value;
   }
 
-  uint32_t index;
+  uint32_t index = ecma_string_get_array_index (property_name_p);
 
-  if (!ecma_string_get_array_index (property_name_p, &index))
+  if (index == ECMA_STRING_NOT_ARRAY_INDEX)
   {
     return ret_value;
   }
@@ -338,9 +338,9 @@ ecma_op_arguments_object_delete (ecma_object_t *object_p, /**< the object */
 
   if (ecma_is_value_true (ret_value))
   {
-    uint32_t index;
+    uint32_t index = ecma_string_get_array_index (property_name_p);
 
-    if (ecma_string_get_array_index (property_name_p, &index))
+    if (index != ECMA_STRING_NOT_ARRAY_INDEX)
     {
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
 

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -104,9 +104,9 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
           return ECMA_PROPERTY_TYPE_VIRTUAL;
         }
 
-        uint32_t index;
+        uint32_t index = ecma_string_get_array_index (property_name_p);
 
-        if (ecma_string_get_array_index (property_name_p, &index))
+        if (index != ECMA_STRING_NOT_ARRAY_INDEX)
         {
           ecma_value_t prim_value_p = ext_object_p->u.class_prop.value;
           ecma_string_t *prim_value_str_p = ecma_get_string_from_value (prim_value_p);
@@ -173,9 +173,9 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
   else if (type == ECMA_OBJECT_TYPE_ARGUMENTS
            && property_ref_p != NULL)
   {
-    uint32_t index;
+    uint32_t index = ecma_string_get_array_index (property_name_p);
 
-    if (ecma_string_get_array_index (property_name_p, &index))
+    if (index != ECMA_STRING_NOT_ARRAY_INDEX)
     {
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
 
@@ -316,9 +316,9 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
 
   if (unlikely (type == ECMA_OBJECT_TYPE_ARGUMENTS))
   {
-    uint32_t index;
+    uint32_t index = ecma_string_get_array_index (property_name_p);
 
-    if (ecma_string_get_array_index (property_name_p, &index))
+    if (index != ECMA_STRING_NOT_ARRAY_INDEX)
     {
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
 
@@ -363,9 +363,9 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
           return ecma_make_uint32_value (length);
         }
 
-        uint32_t index;
+        uint32_t index = ecma_string_get_array_index (property_name_p);
 
-        if (ecma_string_get_array_index (property_name_p, &index))
+        if (index != ECMA_STRING_NOT_ARRAY_INDEX)
         {
           ecma_value_t prim_value_p = ext_object_p->u.class_prop.value;
 
@@ -578,9 +578,9 @@ ecma_op_object_put (ecma_object_t *object_p, /**< the object */
 
   if (type == ECMA_OBJECT_TYPE_ARGUMENTS)
   {
-    uint32_t index;
+    uint32_t index = ecma_string_get_array_index (property_name_p);
 
-    if (ecma_string_get_array_index (property_name_p, &index))
+    if (index != ECMA_STRING_NOT_ARRAY_INDEX)
     {
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
 
@@ -616,9 +616,9 @@ ecma_op_object_put (ecma_object_t *object_p, /**< the object */
 
       if (ext_object_p->u.class_prop.class_id == LIT_MAGIC_STRING_STRING_UL)
       {
-        uint32_t index;
+        uint32_t index = ecma_string_get_array_index (property_name_p);
 
-        if (ecma_string_get_array_index (property_name_p, &index))
+        if (index != ECMA_STRING_NOT_ARRAY_INDEX)
         {
           ecma_value_t prim_value_p = ext_object_p->u.class_prop.value;
           ecma_string_t *prim_value_str_p = ecma_get_string_from_value (prim_value_p);
@@ -717,10 +717,10 @@ ecma_op_object_put (ecma_object_t *object_p, /**< the object */
                                              is_throw); /* Failure handling */
       }
 
-      uint32_t index;
+      uint32_t index = ecma_string_get_array_index (property_name_p);
 
       if (type == ECMA_OBJECT_TYPE_ARRAY
-          && ecma_string_get_array_index (property_name_p, &index))
+          && index != ECMA_STRING_NOT_ARRAY_INDEX)
       {
         /* Since the length of an array is a non-configurable named data
          * property, the property_p must be a non-NULL pointer for all arrays. */
@@ -1272,11 +1272,11 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
     {
       ecma_string_t *name_p = ecma_get_string_from_value (*iter.current_value_p);
 
-      uint32_t index;
+      uint32_t index = ecma_string_get_array_index (name_p);
 
-      if (ecma_string_get_array_index (name_p, &index))
+      if (index != ECMA_STRING_NOT_ARRAY_INDEX)
       {
-        /* name_p is a valid array index */
+        /* The name is a valid array index. */
         array_index_named_properties_count++;
       }
       else if (!is_array_indices_only)
@@ -1299,9 +1299,9 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
     {
       ecma_string_t *name_p = ecma_get_string_from_value (*iter.current_value_p);
 
-      uint32_t index;
+      uint32_t index = ecma_string_get_array_index (name_p);
 
-      if (ecma_string_get_array_index (name_p, &index))
+      if (index != ECMA_STRING_NOT_ARRAY_INDEX)
       {
         JERRY_ASSERT (array_index_name_pos < array_index_named_properties_count);
 


### PR DESCRIPTION
Large performance gain (20% on nsieve-bits):

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 0.935 -> 0.900 : +3.740% | 
3d-raytrace.js | 1.106 -> 1.078 : +2.514% | 
access-binary-trees.js | 0.568 -> 0.562 : +1.045% | 
access-fannkuch.js | 2.364 -> 2.221 : +6.053% | 
access-nbody.js | 1.077 -> 1.067 : +0.886% | 
bitops-3bit-bits-in-byte.js | 0.583 -> 0.584 : -0.306% | 
bitops-bits-in-byte.js | 0.868 -> 0.870 : -0.241% | 
bitops-bitwise-and.js | 1.061 -> 1.045 : +1.576% | 
bitops-nsieve-bits.js | 1.764 -> 1.410 : +20.046% | 
controlflow-recursive.js | 0.393 -> 0.394 : -0.349% | 
crypto-aes.js | 1.084 -> 0.992 : +8.545% | 
crypto-md5.js | 0.699 -> 0.674 : +3.556% | 
crypto-sha1.js | 0.677 -> 0.656 : +3.079% | 
date-format-tofte.js | 0.834 -> 0.790 : +5.335% | 
date-format-xparb.js | 0.422 -> 0.411 : +2.538% | 
math-cordic.js | 1.343 -> 1.316 : +2.054% | 
math-partial-sums.js | 0.743 -> 0.726 : +2.279% | 
math-spectral-norm.js | 0.591 -> 0.575 : +2.607% | 
string-base64.js | 1.755 -> 1.704 : +2.902% | 
string-fasta.js | 1.343 -> 1.245 : +7.342% | 
Geometric mean: | +3.870% | 

Binary size nearly unchanged (152644->152612)