### PR TITLE
Add --jerry-debugger flag to arguments

### DIFF
--- a/jerry-core/ecma/base/ecma-alloc.c
+++ b/jerry-core/ecma/base/ecma-alloc.c
@@ -29,6 +29,9 @@ JERRY_STATIC_ASSERT (((sizeof (ecma_property_value_t) - 1) & sizeof (ecma_proper
 JERRY_STATIC_ASSERT (sizeof (ecma_string_t) == sizeof (uint64_t),
                      size_of_ecma_string_t_must_be_less_than_or_equal_to_8_bytes);
 
+JERRY_STATIC_ASSERT (sizeof (ecma_extended_object_t) - sizeof (ecma_object_t) <= sizeof (uint64_t),
+                     size_of_ecma_extended_object_part_must_be_less_than_or_equal_to_8_bytes);
+
 /** \addtogroup ecma ECMA
  * @{
  *

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -199,12 +199,6 @@ typedef enum
 {
   ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE, /**< native handle associated with an object */
   ECMA_INTERNAL_PROPERTY_FREE_CALLBACK, /**< object's native free callback */
-
-  /** Bound function internal properties **/
-  ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION,
-  ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_THIS,
-  ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS,
-
   ECMA_INTERNAL_PROPERTY_INSTANTIATED_MASK_32_63, /**< Bit-mask of non-instantiated
                                                    *   built-in's properties (bits 32-63) */
 
@@ -611,6 +605,15 @@ typedef struct
       ecma_value_t lex_env_cp; /**< lexical environment */
       uint32_t length; /**< length of names */
     } arguments;
+
+    /*
+     * Description of bound function object.
+     */
+    struct
+    {
+      ecma_value_t target_function; /**< target function */
+      ecma_length_t args_length; /**< length of arguments */
+    } bound_function;
 
     ecma_external_pointer_t external_function; /**< external function */
   } u;

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -771,8 +771,6 @@ ecma_free_internal_property (ecma_property_t *property_p) /**< the property */
 {
   JERRY_ASSERT (property_p != NULL && ECMA_PROPERTY_GET_TYPE (*property_p) == ECMA_PROPERTY_TYPE_INTERNAL);
 
-  uint32_t property_value = ECMA_PROPERTY_VALUE_PTR (property_p)->value;
-
   switch (ECMA_PROPERTY_GET_INTERNAL_PROPERTY_TYPE (property_p))
   {
     case ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE: /* an external pointer */
@@ -784,30 +782,11 @@ ecma_free_internal_property (ecma_property_t *property_p) /**< the property */
     }
 
     case ECMA_INTERNAL_PROPERTY_INSTANTIATED_MASK_32_63: /* an integer (bit-mask) */
-    case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_TARGET_FUNCTION:
     {
       break;
     }
 
-    case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_THIS:
-    {
-      ecma_free_value_if_not_object (property_value);
-      break;
-    }
-
-    case ECMA_INTERNAL_PROPERTY_BOUND_FUNCTION_BOUND_ARGS:
-    {
-      if (property_value != ECMA_NULL_POINTER)
-      {
-        ecma_free_values_collection (ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_header_t, property_value),
-                                     false);
-      }
-
-      break;
-    }
-
-    case ECMA_INTERNAL_PROPERTY__COUNT: /* not a real internal property type,
-                                         * but number of the real internal property types */
+    default:
     {
       JERRY_UNREACHABLE ();
       break;

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -120,6 +120,7 @@ print_help (char *name)
                       "  --parse-only\n"
                       "  --show-opcodes\n"
                       "  --show-regexp-opcodes\n"
+                      "  --jerry-debugger\n"
                       "  --save-snapshot-for-global FILE\n"
                       "  --save-snapshot-for-eval FILE\n"
                       "  --exec-snapshot FILE\n"
@@ -393,6 +394,11 @@ main (int argc,
     else if (!strcmp ("--show-regexp-opcodes", argv[i]))
     {
       flags |= JERRY_INIT_SHOW_REGEXP_OPCODES;
+      jerry_port_default_set_log_level (JERRY_LOG_LEVEL_DEBUG);
+    }
+    else if (!strcmp ("--jerry-debugger", argv[i]))
+    {
+      flags = JERRY_INIT_DEBUGGER;
       jerry_port_default_set_log_level (JERRY_LOG_LEVEL_DEBUG);
     }
     else if (!strcmp ("--save-snapshot-for-global", argv[i])


### PR DESCRIPTION
The easiest way to switch on/off the JERRY_INIT_FLAG is to add for arguments list the `--jerry-debugger` option.  