### PR TITLE
Warning fix for deprecated _BSD_SOURCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,9 +126,9 @@ if(ENABLE_LTO)
   endif()
 endif()
 
-# Define _BSD_SOURCE if we use default port and compiler default libc
+# Define _BSD_SOURCE and _DEFAULT_SOURCE if we use default port and compiler default libc
 if(${PORT_DIR} STREQUAL "${CMAKE_SOURCE_DIR}/targets/default" AND NOT JERRY_LIBC)
-  set(DEFINES_JERRY ${DEFINES_JERRY} _BSD_SOURCE)
+  set(DEFINES_JERRY ${DEFINES_JERRY} _BSD_SOURCE _DEFAULT_SOURCE)
 endif()
 
 # Compiler / Linker flags


### PR DESCRIPTION
Since glibc 2.20, the _BSD_SOURCE macro is deprecated.
It now has the same effect as defining _DEFAULT_SOURCE, but generates a
compile-time warning (unless _DEFAULT_SOURCE is also defined). To allow
code that requires _BSD_SOURCE in glibc 2.19 and earlier and _DEFAULT_SOURCE
in glibc 2.20 and later to compile without warnings, define both _BSD_SOURCE and _DEFAULT_SOURCE.
This warning received with glibc 2.24.