### PR TITLE
 Property hashmap allocation strategy based on gc pattern

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -664,6 +664,15 @@ ecma_free_unused_memory (jmem_free_unused_memory_severity_t severity) /**< sever
 {
   if (severity == JMEM_FREE_UNUSED_MEMORY_SEVERITY_LOW)
   {
+
+ #ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
+    if (JERRY_CONTEXT (ecma_prop_hashmap_alloc_state) > ECMA_PROP_HASHMAP_ALLOC_ON)
+    {
+      --JERRY_CONTEXT (ecma_prop_hashmap_alloc_state);
+    }
+    JERRY_CONTEXT (ecma_prop_hashmap_alloc_last_is_hs_gc) = false;
+#endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
+
     /*
      * If there is enough newly allocated objects since last GC, probably it is worthwhile to start GC now.
      * Otherwise, probability to free sufficient space is considered to be low.
@@ -678,6 +687,18 @@ ecma_free_unused_memory (jmem_free_unused_memory_severity_t severity) /**< sever
   else
   {
     JERRY_ASSERT (severity == JMEM_FREE_UNUSED_MEMORY_SEVERITY_HIGH);
+
+#ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
+    if (JERRY_CONTEXT (ecma_prop_hashmap_alloc_last_is_hs_gc))
+    {
+      JERRY_CONTEXT (ecma_prop_hashmap_alloc_state) = ECMA_PROP_HASHMAP_ALLOC_MAX;
+    }
+    else if (JERRY_CONTEXT (ecma_prop_hashmap_alloc_state) < ECMA_PROP_HASHMAP_ALLOC_MAX)
+    {
+      ++JERRY_CONTEXT (ecma_prop_hashmap_alloc_state);
+      JERRY_CONTEXT (ecma_prop_hashmap_alloc_last_is_hs_gc) = true;
+    }
+#endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 
     /* Freeing as much memory as we currently can */
     ecma_gc_run (severity);

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -1002,6 +1002,22 @@ typedef enum
   ECMA_GC_COLOR__COUNT /**< number of colors */
 } ecma_gc_color_t;
 
+#ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
+
+/**
+ * The lowest state of the ecma_prop_hashmap_alloc_state counter.
+ * If ecma_prop_hashmap_alloc_state other other than this value, it is
+ * disabled.
+ */
+#define ECMA_PROP_HASHMAP_ALLOC_ON 0
+
+/**
+ * The highest state of the ecma_prop_hashmap_alloc_state counter.
+ */
+#define ECMA_PROP_HASHMAP_ALLOC_MAX 4
+
+#endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
+
 /**
  * Number of values in a literal storage item
  */

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -21,6 +21,7 @@
 #include "ecma-lex-env.h"
 #include "ecma-literal-storage.h"
 #include "jmem-allocator.h"
+#include "jcontext.h"
 
 /** \addtogroup ecma ECMA
  * @{
@@ -39,6 +40,12 @@ ecma_init (void)
   ecma_init_global_lex_env ();
 
   jmem_register_free_unused_memory_callback (ecma_free_unused_memory);
+
+#ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
+  JERRY_CONTEXT (ecma_prop_hashmap_alloc_state) = ECMA_PROP_HASHMAP_ALLOC_ON;
+  JERRY_CONTEXT (ecma_prop_hashmap_alloc_last_is_hs_gc) = false;
+#endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
+
 } /* ecma_init */
 
 /**

--- a/jerry-core/ecma/base/ecma-property-hashmap.c
+++ b/jerry-core/ecma/base/ecma-property-hashmap.c
@@ -18,6 +18,7 @@
 #include "ecma-helpers.h"
 #include "ecma-property-hashmap.h"
 #include "jrt-libc-includes.h"
+#include "jcontext.h"
 
 /** \addtogroup ecma ECMA
  * @{
@@ -77,6 +78,11 @@ ecma_property_hashmap_create (ecma_object_t *object_p) /**< object */
 #ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
   JERRY_ASSERT (ecma_get_property_list (object_p) != NULL);
   JERRY_ASSERT (ECMA_PROPERTY_IS_PROPERTY_PAIR (ecma_get_property_list (object_p)));
+
+  if (JERRY_CONTEXT (ecma_prop_hashmap_alloc_state) != ECMA_PROP_HASHMAP_ALLOC_ON)
+  {
+    return;
+  }
 
   uint32_t named_property_count = 0;
 

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -72,6 +72,13 @@ typedef struct
   uint8_t ecma_gc_visited_flip_flag; /**< current state of an object's visited flag */
   uint8_t is_direct_eval_form_call; /**< direct call from eval */
   uint8_t jerry_api_available; /**< API availability flag */
+
+#ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
+  uint8_t ecma_prop_hashmap_alloc_state; /**< property hashmap allocation state: 0-4,
+                                          *   if !0 property hashmap allocation is disabled */
+  bool ecma_prop_hashmap_alloc_last_is_hs_gc; /**< true, if and only if the last gc action was a high severity gc */
+#endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
+
 #ifndef CONFIG_DISABLE_REGEXP_BUILTIN
   uint8_t re_cache_idx; /**< evicted item index when regex cache is full (round-robin) */
 #endif /* !CONFIG_DISABLE_REGEXP_BUILTIN */


### PR DESCRIPTION
The algorithm is the following:
* introduced a counter variable, which value is in [0-4]
* if its value is 0, property hashmap allocation is enabled
* JMEM_FREE_UNUSED_MEMORY_SEVERITY_LOW -> decrease the counter
* JMEM_FREE_UNUSED_MEMORY_SEVERITY_HIGH -> increase the counter
* if JMEM_FREE_UNUSED_MEMORY_SEVERITY_HIGH happens twice in a row increase the counter to 4

According to the measurements this algorithm provides better runtime results in low memory conditions.

JerryScript-DCO-1.0-Signed-off-by: István Kádár ikadar@inf.u-szeged.hu