### PR TITLE
Add API functions to create string from a valid UTF-8 string.

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -164,6 +164,7 @@ extern void ecma_free_value_if_not_object (ecma_value_t);
 
 /* ecma-helpers-string.c */
 extern ecma_string_t *ecma_new_ecma_string_from_utf8 (const lit_utf8_byte_t *, lit_utf8_size_t);
+extern ecma_string_t *ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8_byte_t *, lit_utf8_size_t);
 extern ecma_string_t *ecma_new_ecma_string_from_code_unit (ecma_char_t);
 extern ecma_string_t *ecma_new_ecma_string_from_uint32 (uint32_t);
 extern ecma_string_t *ecma_new_ecma_string_from_number (ecma_number_t);

--- a/jerry-core/jerry-api.h
+++ b/jerry-core/jerry-api.h
@@ -248,6 +248,8 @@ jerry_value_t jerry_create_number_infinity (bool);
 jerry_value_t jerry_create_number_nan (void);
 jerry_value_t jerry_create_null (void);
 jerry_value_t jerry_create_object (void);
+jerry_value_t jerry_create_string_from_utf8 (const jerry_char_t *);
+jerry_value_t jerry_create_string_sz_from_utf8 (const jerry_char_t *, jerry_size_t);
 jerry_value_t jerry_create_string (const jerry_char_t *);
 jerry_value_t jerry_create_string_sz (const jerry_char_t *, jerry_size_t);
 jerry_value_t jerry_create_undefined (void);

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -914,6 +914,40 @@ jerry_create_object (void)
 } /* jerry_create_object */
 
 /**
+ * Create string from a valid UTF8 string
+ *
+ * Note:
+ *      returned value must be freed with jerry_release_value when it is no longer needed.
+ *
+ * @return value of the created string
+ */
+jerry_value_t
+jerry_create_string_from_utf8 (const jerry_char_t *str_p) /**< pointer to string */
+{
+  return jerry_create_string_sz_from_utf8 (str_p, lit_zt_utf8_string_size ((lit_utf8_byte_t *) str_p));
+} /* jerry_create_string_from_utf8 */
+
+/**
+ * Create string from a valid UTF8 string
+ *
+ * Note:
+ *      returned value must be freed with jerry_release_value when it is no longer needed.
+ *
+ * @return value of the created string
+ */
+jerry_value_t
+jerry_create_string_sz_from_utf8 (const jerry_char_t *str_p, /**< pointer to string */
+                                  jerry_size_t str_size) /**< string size */
+{
+  jerry_assert_api_available ();
+
+  ecma_string_t *ecma_str_p = ecma_new_ecma_string_from_utf8_converted_to_cesu8 ((lit_utf8_byte_t *) str_p,
+                                                                                 (lit_utf8_size_t) str_size);
+
+  return ecma_make_string_value (ecma_str_p);
+} /* jerry_create_string_sz_from_utf8 */
+
+/**
  * Create string from a valid CESU8 string
  *
  * Note:


### PR DESCRIPTION
I think this patch needs to be followed by another, which contains symbol (functions names, types, ...) renames.  Because CESU-8 is a variant of UTF-8, the names was left utf8 and mentioned the CESU-8 only in comments after #616, but I think this is very confusing right now. For example the 'ecma_new_ecma_string_from_utf8' function check that the string is a cesu-8 encoded string at the first step, so it doesn't accept an utf-8 encoded string which contains 4 bytes long characters, and throw an assert.