### PR TITLE
target: zephyr: Allow parallel build of Zephyr

### DIFF
--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -106,7 +106,7 @@ zephyr: jerry
 ifdef V
 	@echo "- ZEPHYR -------------------------------------------------------"
 endif
-	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG)
+	+make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG)
 	@echo "Finished"
 	@file $(OUTPUT)/zephyr.strip
 	@size $(OUTPUT)/zephyr.strip


### PR DESCRIPTION
If we are building JerryScript from some other makefile that passes
down a -j option to make we should respect that when we build Zephyr.

JerryScript-DCO-1.0-Signed-off-by: Kumar Gala <kumar.gala@linaro.org>