### PR TITLE
Simplify ecma_property_types_t.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -197,6 +197,12 @@ typedef uintptr_t ecma_external_pointer_t;
  */
 typedef enum
 {
+  ECMA_SPECIAL_PROPERTY_DELETED, /**< deleted property */
+
+  /* Note: when new special types are added
+   * ECMA_PROPERTY_IS_PROPERTY_PAIR must be updated as well. */
+  ECMA_SPECIAL_PROPERTY_HASHMAP, /**< hashmap property */
+
   ECMA_INTERNAL_PROPERTY_NATIVE_HANDLE, /**< native handle associated with an object */
   ECMA_INTERNAL_PROPERTY_FREE_CALLBACK, /**< object's native free callback */
   ECMA_INTERNAL_PROPERTY_INSTANTIATED_MASK_32_63, /**< Bit-mask of non-instantiated
@@ -249,32 +255,44 @@ typedef enum
  */
 typedef enum
 {
-  ECMA_PROPERTY_TYPE_DELETED, /**< deleted property */
-  ECMA_PROPERTY_TYPE_INTERNAL, /**< internal property */
+  ECMA_PROPERTY_TYPE_SPECIAL, /**< internal property */
   ECMA_PROPERTY_TYPE_NAMEDDATA, /**< property is named data */
   ECMA_PROPERTY_TYPE_NAMEDACCESSOR, /**< property is named accessor */
+  ECMA_PROPERTY_TYPE_VIRTUAL, /**< property is virtual */
 
-  ECMA_PROPERTY_TYPE_PROPERTY_PAIR__MAX = ECMA_PROPERTY_TYPE_NAMEDACCESSOR, /**< highest value for
-                                                                             *   property pair types. */
-
-  ECMA_PROPERTY_TYPE_HASHMAP, /**< hash map for fast property access */
-
-  ECMA_PROPERTY_TYPE__MAX = ECMA_PROPERTY_TYPE_HASHMAP, /**< highest value for property types. */
-
-  /* Property type aliases. */
-  ECMA_PROPERTY_TYPE_NOT_FOUND = ECMA_PROPERTY_TYPE_DELETED, /**< property is not found */
-  ECMA_PROPERTY_TYPE_VIRTUAL = ECMA_PROPERTY_TYPE_HASHMAP, /**< property is virtual */
+  ECMA_PROPERTY_TYPE__MAX = ECMA_PROPERTY_TYPE_VIRTUAL, /**< highest value for property types. */
 } ecma_property_types_t;
 
 /**
  * Property type mask.
  */
-#define ECMA_PROPERTY_TYPE_MASK 0x7
+#define ECMA_PROPERTY_TYPE_MASK 0x3
 
 /**
  * Property flags base shift.
  */
-#define ECMA_PROPERTY_FLAG_SHIFT 3
+#define ECMA_PROPERTY_FLAG_SHIFT 2
+
+/**
+ * Define special property type.
+ */
+#define ECMA_SPECIAL_PROPERTY_VALUE(type) \
+  ((uint8_t) (ECMA_PROPERTY_TYPE_SPECIAL | ((type) << ECMA_PROPERTY_FLAG_SHIFT)))
+
+/**
+ * Type of deleted property.
+ */
+#define ECMA_PROPERTY_TYPE_DELETED ECMA_SPECIAL_PROPERTY_VALUE (ECMA_SPECIAL_PROPERTY_DELETED)
+
+/**
+ * Type of hash-map property.
+ */
+#define ECMA_PROPERTY_TYPE_HASHMAP ECMA_SPECIAL_PROPERTY_VALUE (ECMA_SPECIAL_PROPERTY_HASHMAP)
+
+/**
+ * Type of property not found.
+ */
+#define ECMA_PROPERTY_TYPE_NOT_FOUND ECMA_PROPERTY_TYPE_DELETED
 
 /**
  * Property flag list (for ECMA_PROPERTY_TYPE_NAMEDDATA
@@ -397,7 +415,8 @@ typedef struct
  * Returns true if the property pointer is a property pair.
  */
 #define ECMA_PROPERTY_IS_PROPERTY_PAIR(property_header_p) \
-  (ECMA_PROPERTY_GET_TYPE ((property_header_p)->types[0]) <= ECMA_PROPERTY_TYPE_PROPERTY_PAIR__MAX)
+  (ECMA_PROPERTY_GET_TYPE ((property_header_p)->types[0]) != ECMA_PROPERTY_TYPE_VIRTUAL \
+   && (property_header_p)->types[0] != ECMA_PROPERTY_TYPE_HASHMAP)
 
 /**
  * Returns the internal property type

--- a/jerry-core/ecma/base/ecma-property-hashmap.c
+++ b/jerry-core/ecma/base/ecma-property-hashmap.c
@@ -126,6 +126,7 @@ ecma_property_hashmap_create (ecma_object_t *object_p) /**< object */
   memset (hashmap_p, 0, total_size);
 
   hashmap_p->header.types[0] = ECMA_PROPERTY_TYPE_HASHMAP;
+  hashmap_p->header.types[1] = ECMA_PROPERTY_TYPE_DELETED;
   hashmap_p->header.next_property_cp = object_p->property_list_or_bound_object_cp;
   hashmap_p->max_property_count = max_property_count;
   hashmap_p->null_count = max_property_count - named_property_count;
@@ -230,8 +231,7 @@ ecma_property_hashmap_free (ecma_object_t *object_p) /**< object */
   /* Property hash must be exists and must be the first property. */
   ecma_property_header_t *property_p = ecma_get_property_list (object_p);
 
-  JERRY_ASSERT (property_p != NULL
-                && ECMA_PROPERTY_GET_TYPE (property_p->types[0]) == ECMA_PROPERTY_TYPE_HASHMAP);
+  JERRY_ASSERT (property_p != NULL && property_p->types[0] == ECMA_PROPERTY_TYPE_HASHMAP);
 
   ecma_property_hashmap_t *hashmap_p = (ecma_property_hashmap_t *) property_p;
 
@@ -257,7 +257,7 @@ ecma_property_hashmap_insert (ecma_object_t *object_p, /**< object */
   ecma_property_hashmap_t *hashmap_p = ECMA_GET_NON_NULL_POINTER (ecma_property_hashmap_t,
                                                                   object_p->property_list_or_bound_object_cp);
 
-  JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (hashmap_p->header.types[0]) == ECMA_PROPERTY_TYPE_HASHMAP);
+  JERRY_ASSERT (hashmap_p->header.types[0] == ECMA_PROPERTY_TYPE_HASHMAP);
 
   /* The NULLs are reduced below 1/8 of the hashmap. */
   if (hashmap_p->null_count < (hashmap_p->max_property_count >> 3))
@@ -340,7 +340,7 @@ ecma_property_hashmap_delete (ecma_object_t *object_p, /**< object */
   ecma_property_hashmap_t *hashmap_p = ECMA_GET_NON_NULL_POINTER (ecma_property_hashmap_t,
                                                                   object_p->property_list_or_bound_object_cp);
 
-  JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (hashmap_p->header.types[0]) == ECMA_PROPERTY_TYPE_HASHMAP);
+  JERRY_ASSERT (hashmap_p->header.types[0] == ECMA_PROPERTY_TYPE_HASHMAP);
 
   uint32_t entry_index = name_p->hash;
   uint32_t step = ecma_property_hashmap_steps[entry_index & (ECMA_PROPERTY_HASHMAP_NUMBER_OF_STEPS - 1)];

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -268,7 +268,7 @@ ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
 /**
  * Special type for ecma_op_general_object_define_own_property.
  */
-#define ECMA_PROPERTY_TYPE_GENERIC ECMA_PROPERTY_TYPE_DELETED
+#define ECMA_PROPERTY_TYPE_GENERIC ECMA_PROPERTY_TYPE_SPECIAL
 
 /**
  * [[DefineOwnProperty]] ecma general object's operation

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1189,8 +1189,7 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
 
     ecma_property_header_t *prop_iter_p = ecma_get_property_list (prototype_chain_iter_p);
 
-    if (prop_iter_p != NULL
-        && ECMA_PROPERTY_GET_TYPE (prop_iter_p->types[0]) == ECMA_PROPERTY_TYPE_HASHMAP)
+    if (prop_iter_p != NULL && prop_iter_p->types[0] == ECMA_PROPERTY_TYPE_HASHMAP)
     {
       prop_iter_p = ECMA_GET_POINTER (ecma_property_header_t,
                                       prop_iter_p->next_property_cp);


### PR DESCRIPTION
This patch is mostly a cleanup. It has no effect on performance (little noise), and memory. Binary size is reduced a bit (50 bytes).