### PR TITLE
Fix fopen call on non-existing files.

### DIFF
--- a/jerry-libc/target/posix/jerry-libc-target.c
+++ b/jerry-libc/target/posix/jerry-libc-target.c
@@ -178,7 +178,7 @@ fopen (const char *path, /**< file path */
 
   long int ret = syscall_3 (SYSCALL_NO (open), (long int) path, flags, access);
 
-  return (void *) (uintptr_t) (ret);
+  return ((ret < 0) ? NULL : (void *) (uintptr_t) (ret));
 } /* fopen */
 
 /**


### PR DESCRIPTION
The main implementation of unix platform hangs, if the engine was
built with jerry-libc. Open system call returns with a negative
error code if cannot open the file, but fopen must return NULL
when error happens.

Fixes #1437.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com